### PR TITLE
The data collection scripts in scripts/ are broken (wrong path to utils, missing dependencies)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,10 @@ Open data about Swedish political parties. Static public site, Swedish copy.
 - Styling: Tailwind 3 + Bootstrap 5 tables via sass. `src/styles/base.scss` is
   the single CSS entry; it pulls in `app.scss` and `lato.scss` so Tailwind's
   `@layer` blocks share one file with the `@tailwind` directives.
-- Data collection scripts live in `scripts/` and run offline
-  (`node scripts/collect.js`); results are committed to `data/`.
+- Data collection scripts live in `scripts/` and are run manually, outside the
+  site build (`npm run collect`, i.e. `node scripts/collect.js`); `collect.js`
+  fetches from `data.val.se`. Results are committed to `data/`. Paths resolve
+  from the repo root, so the scripts run from any directory.
 
 ## Deploy
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Tillgängliggöra data om alla Sveriges politiska partier på ett öppet och tra
 
 Baserad på XML-filen som går att ladda ner på val.se:<br />https://www.val.se/for-partier/partibeteckning/registrerade-partibeteckningar.html
 
-Kompletterad med partier som registrerat deltagande i val till landstingsfullmäktige och kommunfullmäktige 2018. Har lagt till attribut `uuid` och `filnamn` för enklare hantering i kod och datastrukturer. Se `toFileName` i `./utils.js`.
+Kompletterad med partier som registrerat deltagande i val till landstingsfullmäktige och kommunfullmäktige 2018. Har lagt till attribut `uuid` och `filnamn` för enklare hantering i kod och datastrukturer. Se `toFileName` i `scripts/utils.js`.
 
 ### parti/\<filnamn\>.json
 
@@ -52,6 +52,22 @@ Läs mer på: https://www.val.se/for-partier/anmal-deltagande.html
 ### val/\<year\>/kandidatlistor/\<parti.filnamn\>.json
 
 Kandidatlistor per parti i alla val för angivna året. För tillfället endast ett utkast.
+
+
+## Köra skripten
+
+Skripten i `scripts/` samlar in data och körs manuellt, utanför sajtbygget. Resultatet committas till `data/`.
+
+Krav: Node 24 och `npm ci`. Skripten kan köras från vilken katalog som helst — alla sökvägar till `data/` utgår från repots rot.
+
+### npm run collect
+
+Fyller i `partier` för de kommuner som saknar det i `data/val/<år>/partideltagande/kommun.json`, hämtat från `data.val.se`. Som mest 40 kommuner per körning — kör om tills `Starting at index` är lika med antalet kommuner i filen.
+
+### node scripts/parti.js
+
+Bygger om `data/parti/index.json` från partifilerna.
+
 
 ## Bidra
 

--- a/agent-docs/issue/18-datainsamlingsskripten-trasiga/index.md
+++ b/agent-docs/issue/18-datainsamlingsskripten-trasiga/index.md
@@ -1,0 +1,35 @@
+# Issue #18: Datainsamlingsskripten i scripts/ är trasiga (fel sökväg till utils, saknade beroenden)
+
+**Based on:** main
+
+## Summary
+
+`node scripts/collect.js` fails immediately: the scripts `require('./utils.js')` but the file is at `src/utils.js`, the file needs `lodash` and `uuid` which are not in `package.json`, and data paths mix `process.cwd()` and `__dirname`. Plan: `git mv src/utils.js scripts/utils.js`, replace `_.deburr`/`_.pick`/`uuid` with `String.prototype.normalize`, destructuring and `crypto.randomUUID()` (no new dependencies), resolve all committed data paths from a repo-root constant, add `npm run collect`, and document the scripts in `README.md`/`CLAUDE.md`. Deliberately minimal — #19 replaces `collect.js`/`helpers.js`/`parti.js` with a CSV import.
+
+## Triage Status
+
+| Field | Value |
+|-------|-------|
+| **Ready to work** | Yes |
+| **Risk** | Low |
+| **Safe for junior** | Yes |
+
+## Plan Review
+
+**Status:** Reviewed
+**Reviewed:** 2026-08-23
+**Feedback:** Codex review caught that `Buffer` is in fact used by `loadXML` (do not drop it), that the ad-hoc XML/HTML parsers should be left alone to keep scope minimal, that the cwd-independence test needs absolute paths and `git diff --exit-code` on the two rewritten data files, and that the smoke test proves startup only (no network). Also added #25 (README rewrite) as a related issue, the #18 → #24 → #19 sequencing, and pushed slug-collision checks for new names to #19.
+
+## Related Files
+
+- [plan.md](plan.md) - Full implementation plan
+- [progress.md](progress.md) - Implementation progress (if exists)
+- [research.md](research.md) - Research findings (if exists)
+
+## Related Issues
+
+- #19 - Update party data for the 2022 and 2026 elections; depends on this issue and will remove most of `scripts/` afterwards
+- #24 - Validate `data/` in CI; proposes a pure-Node `scripts/validate.js` in the same no-dependencies spirit; should land before #19
+- #25 - README update to current state; overlaps on the `./utils.js` reference and local-running docs
+- #20 - kommun.json has 208 of 290 kommuner (closed, superseded by #19)
+- #29 - collect.js error handling (closed, superseded by #19)

--- a/agent-docs/issue/18-datainsamlingsskripten-trasiga/plan.md
+++ b/agent-docs/issue/18-datainsamlingsskripten-trasiga/plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: Datainsamlingsskripten i scripts/ är trasiga (fel sökväg till utils, saknade beroenden)
+
+## Summary
+
+`node scripts/collect.js` (and `scripts/parti.js`) cannot start: `scripts/collect.js` and `scripts/helpers.js` `require('./utils.js')` but the file lives in `src/utils.js`; `src/utils.js` and `scripts/parti.js` require `lodash` and `uuid`, which are not in `package.json`; and data paths are resolved inconsistently (`process.cwd()` in some places, `__dirname` in others). Fix: move `src/utils.js` to `scripts/utils.js` (nothing in the site imports it), drop the `lodash`/`uuid` usages in favour of `String.prototype.normalize` and `crypto.randomUUID()` (no new dependencies), resolve every data path against the repository root, add an `npm run collect` script, and document how to run the scripts in `README.md`. Scope is deliberately "make it start again" — #19 will replace `collect.js`/`helpers.js`/`parti.js` with a CSV import, so no rewrite of the collection logic here.
+
+## Triage Info
+
+> Decision-support metadata for this issue.
+
+| Field | Value |
+|-------|-------|
+| **Blocked by** | None |
+| **Blocks** | #19 Uppdatera partidata för valen 2022 och 2026 ("Beror på #18"). The issue comment also lists #20 and #29, but both were closed 2026-08-22 as NOT_PLANNED, superseded by #19. |
+| **Related issues** | #19 (will delete `collect.js`/`helpers.js` and replace `parti.js` once the CSV import works — keep this fix minimal), #24 (CI data validation; proposes `scripts/validate.js` "ren Node, inga nya beroenden" — same no-deps direction as this plan), #25 (README rewrite — also fixes the `./utils.js` reference and documents local running; coordinate wording so the two PRs do not fight over the same README lines), #20 and #29 (closed, superseded by #19) |
+| **Scope** | 7 files across `scripts/`, `src/` (file removal), `package.json`, `README.md`, `CLAUDE.md` |
+| **Risk** | Low |
+| **Complexity** | Low |
+| **Safe for junior** | Yes |
+| **Conflict risk** | Low–Medium — the other plans in `agent-docs/issue/` (#15 merged, #16 `src/pages/**` + `src/types.ts`, #27 `src/pages/index.tsx`) touch no file in this plan. `README.md` is shared with the unplanned #25 (full README rewrite) and `CLAUDE.md`/`scripts/` with #19; keep the README addition small so #25 can absorb it. |
+
+### Triage Notes
+No explicit blockers; the only comment on the issue ("Blockerar #19, #20 och #29") describes what this issue blocks, not what blocks it. There is no `agent-docs/github/info.json` or `project.json`, so no project-board fields were queried and branch alignment was skipped (no `release` field); current branch is `main`. Verified locally on 2026-08-22 (Node v24.14.1): `node scripts/collect.js` fails with `Cannot find module './utils.js'`; `package-lock.json` contains neither `lodash` nor `uuid`; `npx eslint scripts src/utils.js` passes (eslint-config-next lints plain `.js` files too, so the moved file stays linted). Sequencing: #18 → #24 → #19 — #19 builds on runnable scripts (and removes most of them afterwards), and the comment on #24 asks for data validation to be in place before #19 rewrites large amounts of data. Neither affects #18 itself.
+
+## Analysis
+
+- **Who uses `src/utils.js`.** Only `scripts/collect.js` (`loadJSONFile`) and `scripts/helpers.js` (`loadJSONFile`, `loadXML`). `rg utils src` finds no import from the site; `tsconfig.json` has `allowJs` but `include` is `**/*.ts`/`**/*.tsx`, so the file is not type-checked either. Moving it to `scripts/utils.js` makes the existing `require('./utils.js')` lines correct without editing them. `README.md` currently points at "`toFileName` i `./utils.js`" — update that reference.
+- **`lodash` usages.** `_.deburr` in `toFileName` (utils) and `_.pick` in `parti.js`. `_.deburr` can be replaced by `name.normalize('NFD').replace(/[\u0300-\u036f]/g, '')` (write the range with `\u` escapes, not literal combining characters). Checked against the dataset: for all 333 entries in `data/parti/index.json` the NFD version yields the same `filnamn` as today except 8 entries whose `filnamn` were hand-adjusted anyway (`framstegspartiet-1223/1224/1226` disambiguated by partikod, and five with a trailing `-` from an older version of the function, e.g. `igov-direct-`); none of the 333 `beteckning` values contain characters that lodash deburrs but NFD does not (ø, æ, ß, đ, þ, œ). `_.pick(party, ['uuid','beteckning','filnamn'])` becomes object destructuring.
+- **`uuid` usage.** `newUuid()` in utils wraps `uuidV4()`; `crypto.randomUUID()` (Node ≥ 14.17, the repo requires `node >= 24`) produces the same v4 format. `newUuid` is not called by any script today but is the helper #19 will use for new parties, so keep it.
+- **Path resolution.** `loadJSONFile(...segments)` uses `path.resolve(...)` which is cwd-relative; `_getRiksdagPartyMap` builds `path.resolve('data', 'val', year, 'partideltagande/riksdag.json')` (cwd-relative); `collect.js` uses `path.resolve('data', 'val', …)` (cwd-relative) and `parti.js` uses `path.join('data', 'parti', 'index.json')` (cwd-relative); `parseULFile`/`parseKommunXMLFile` use `path.resolve(__dirname, filePathname || 'ul.html')` (scripts-dir-relative, for ad-hoc downloaded files that do not exist in the repo). Introduce one `ROOT = path.resolve(__dirname, '..')` in `scripts/utils.js` and a `dataPath(...segments)` helper so every committed data file resolves from the repo root regardless of cwd; make `loadJSONFile` go through it. The two file parsers for ad-hoc inputs (`parseULFile`, `parseKommunXMLFile`) are not called by any script and only matter for manual use; leave their `__dirname`-relative resolution untouched to keep this change limited to committed data files (#19 deletes them).
+- **Behaviour of the scripts on the current data (smoke-test baseline).** `collect.js` skips every kommun that already has `partier`; all 208 entries in `data/val/2018/partideltagande/kommun.json` have it, so a run logs `Starting at index: 208`, makes no HTTP requests, and after one 2 s tick rewrites the file. `JSON.stringify(data, null, 2)` is byte-identical to the committed file (no trailing newline — verified), so `git status` stays clean. `parti.js` rewrites `data/parti/index.json` from itself with a trailing newline — also verified byte-identical. Both scripts are therefore safe to run as "does it start and is it idempotent" checks — but note the smoke test makes no network request, so it proves startup and path resolution, not that collection from the legacy `data.val.se` XML endpoint still works (that endpoint, and the error handling around it, are #19's concern). They should not be "fixed" further: incomplete kommun coverage (#20) and error handling (#29) are closed in favour of #19.
+- **`npm run collect`.** `package.json` has no script for the collectors. Add `"collect": "node scripts/collect.js"`. `parti.js` is a one-off index rebuild that #19 replaces; it does not need its own npm script (document `node scripts/parti.js` in the README instead).
+- **Docs.** `CLAUDE.md` says the scripts "run offline (`node scripts/collect.js`)". After this change it is true again; adjust to mention `npm run collect` and note that `collect.js` does fetch from `data.val.se` ("offline" here means outside the site build, not "without network"). `README.md` gets a short "Köra skripten" section (Swedish, like the rest of the file).
+- **Lint/CI.** CI runs `npm run lint && npm run typecheck && npm run build`. `eslint .` already lints `scripts/*.js` and `src/utils.js` cleanly; after the move nothing changes for lint. No TS, no Next impact. `crypto` and `node:` built-ins are fine under the Next ESLint config (no `import/no-nodejs-modules` rule).
+
+## Implementation Steps
+
+### Phase 1: Move utils and drop the missing dependencies
+1. Move `src/utils.js` to `scripts/utils.js` with `git mv` so history follows the file.
+   - Files to move: `src/utils.js` → `scripts/utils.js`
+2. Remove the `lodash` and `uuid` requires in `scripts/utils.js`.
+   - `toFileName`: replace `_.deburr(name)` with `name.normalize('NFD').replace(/[\u0300-\u036f]/g, '')`; keep the rest of the chain unchanged.
+   - `newUuid`: `return crypto.randomUUID();` with `const crypto = require('crypto');` (or `node:crypto`).
+   - Keep the `Buffer` require — it is used by `Buffer.concat(chunks)` in `loadXML`.
+   - Files to modify: `scripts/utils.js`
+3. Remove `lodash` from `scripts/parti.js`.
+   - `parties.map(({ uuid, beteckning, filnamn }) => ({ uuid, beteckning, filnamn }))`; delete the `lodash` require.
+   - Files to modify: `scripts/parti.js`
+
+### Phase 2: Resolve data paths from the repository root
+4. Add a root-anchored path helper in `scripts/utils.js`.
+   - `const ROOT = path.resolve(__dirname, '..');` and `function dataPath (...segments) { return path.join(ROOT, 'data', ...segments); }`; export `dataPath` (and `ROOT` if useful).
+   - Contract: `loadJSONFile(...segments)` resolves `path.join(ROOT, ...segments)` — segments are relative to the repository root, so existing callers that pass `'data', 'parti', 'index.json'` keep working unchanged. `dataPath(...segments)` is the convenience for the `data/` subtree and is what the scripts use for write paths.
+   - Files to modify: `scripts/utils.js`
+5. Use the helper everywhere a committed data file is read or written.
+   - `scripts/helpers.js`: `_getRiksdagPartyMap` → `loadJSONFile('data', 'val', String(year), 'partideltagande', 'riksdag.json')`. Leave `parseULFile`/`parseKommunXMLFile` as they are.
+   - `scripts/collect.js`: `kommunJsonFile = dataPath('val', year, 'partideltagande', 'kommun.json')`, read with `JSON.parse(fs.readFileSync(kommunJsonFile, 'utf8'))`; keep the existing write. Remove the now-unused `path` require.
+   - `scripts/parti.js`: write to `dataPath('parti', 'index.json')`; remove the now-unused `path` require.
+   - Files to modify: `scripts/helpers.js`, `scripts/collect.js`, `scripts/parti.js`
+
+### Phase 3: npm script and documentation
+6. Add `"collect": "node scripts/collect.js"` under `scripts` in `package.json`. No dependency changes.
+   - Files to modify: `package.json`
+7. Document the scripts in `README.md` (Swedish).
+   - New section "Köra skripten" after "Tillgänglig data": requirements (Node 24, `npm ci`), `npm run collect` — what it does (fills in `partier` for kommuner in `data/val/<år>/partideltagande/kommun.json` from `data.val.se`, max 40 kommuner per run, re-run until `Starting at index` equals the number of kommuner), that it can be run from any directory, and `node scripts/parti.js` (rebuilds `data/parti/index.json` from the party files). Mention that results are committed to `data/`.
+   - Fix the reference "`toFileName` i `./utils.js`" → `scripts/utils.js`.
+   - Files to modify: `README.md`
+8. Update the "Stack" bullet in `CLAUDE.md` to `npm run collect` / `node scripts/collect.js`, and say the collectors fetch from `data.val.se` and are run manually, outside the site build.
+   - Files to modify: `CLAUDE.md`
+
+### Phase 4: Verify
+9. Confirm `data/val/2018/partideltagande/kommun.json` and `data/parti/index.json` are clean before testing. From the repo root: `npm run collect` → expect `Starting at index: 208`, then `Done, writing file …kommun.json` after ~2 s; `git diff --exit-code -- data/val/2018/partideltagande/kommun.json` must pass (byte-identical rewrite).
+10. From another directory, with absolute paths: `cd /tmp && node /abs/path/to/partidata/scripts/collect.js` → same output (proves cwd-independence); `node /abs/path/to/partidata/scripts/parti.js` → `git diff --exit-code -- data/parti/index.json` passes.
+11. `node -e "const u=require('./scripts/utils.js'); console.log(u.toFileName('Östra vägen (C)'), u.newUuid())"` → `ostra-vagen-c` and a v4 uuid. Optionally, as a one-off check (not committed): map every `beteckning` in `data/parti/index.json` through `toFileName` and confirm only the 8 known hand-adjusted entries differ from `filnamn`.
+12. `npm run lint && npm run typecheck && npm run build` (the CI `Integrate` job). `ls src/utils.js` must fail; `grep -rn "lodash\|require('uuid')" scripts src` must find nothing.
+13. Open a PR against `main` (branch + PR flow, squash-merged). End the body with `Closes #18`. No deploy tag is needed — nothing in `out/` changes.
+
+## Files Summary
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/utils.js` → `scripts/utils.js` | Move + Modify | Live next to its only consumers; replace `lodash.deburr` with NFD normalisation and `uuid` with `crypto.randomUUID()`; add `ROOT`/`dataPath` and root-anchored `loadJSONFile` |
+| `scripts/helpers.js` | Modify | Root-anchored `riksdag.json` path; ad-hoc file parsers take an explicit path |
+| `scripts/collect.js` | Modify | Root-anchored `kommun.json` path |
+| `scripts/parti.js` | Modify | Drop `lodash.pick`; root-anchored output path |
+| `package.json` | Modify | Add `collect` npm script |
+| `README.md` | Modify | "Köra skripten" section; fix `utils.js` reference |
+| `CLAUDE.md` | Modify | Accurate description of how the scripts run |
+
+## Codebase Areas
+
+List the primary directories/areas this plan touches (for conflict detection):
+- `scripts/` (all files)
+- `src/` (removal of `utils.js` only)
+- repo root (`package.json`, `README.md`, `CLAUDE.md`)
+
+## Design Decisions
+
+> Non-trivial choices made during planning. Feedback welcome; otherwise implementation proceeds with these.
+
+### 1. Remove the `lodash`/`uuid` usages instead of adding them as devDependencies
+**Options:** A) Add `lodash` and `uuid` to `devDependencies`; B) replace with `String.prototype.normalize` + `crypto.randomUUID()`.
+**Decision:** B
+**Rationale:** The issue offers both (user decision, issue #18: "eller ersätt med … och slipp beroendena"). B matches the direction of #19 and #24 ("ren Node, inga nya beroenden") and avoids adding two packages to a lockfile for three call sites. Verified on the dataset that NFD normalisation produces the same `filnamn` as `_.deburr` for every current party name (see Analysis). Residual difference: lodash also transliterates ø/æ/ß/đ/þ/œ, which NFD does not — no current name contains them; a future name with one of them would get a `-` for that character, which could in principle collide with another party. Collision handling is already #19's problem (it imports ~416 new 2022/2026 names and already plans partikod-based disambiguation, cf. `framstegspartiet-1223`), so #19 must assert non-empty, unique `filnamn` over the new names before writing party directories; this issue only has to keep the 333 existing slugs stable. Agent judgment on accepting that edge.
+
+### 2. Keep the fix minimal — no rewrite of `collect.js`
+**Options:** A) While touching the scripts, also fix error handling (#29), fetch the missing 82 kommuner (#20), or convert to `async`/`fetch`; B) only make the scripts start and resolve paths correctly.
+**Decision:** B
+**Rationale:** #20 and #29 were closed as NOT_PLANNED on 2026-08-22, superseded by #19, which will delete `collect.js`/`helpers.js` and the XML parser (user decision, issue #19 plan step 4 and the closing comments). Investing in code that is scheduled for removal would be wasted; the value of this issue is that #19 can start from runnable, correctly-pathed helpers (`loadJSONFile`, `toFileName`, `newUuid`).
+
+### 3. Move `utils.js` into `scripts/` rather than fixing the `require` paths
+**Options:** A) Change the two requires to `require('../src/utils.js')`; B) `git mv src/utils.js scripts/utils.js`.
+**Decision:** B
+**Rationale:** Suggested in the issue (user decision). The file is Node-only CommonJS with `https`/`fs` — it has no business under `src/`, which is the Next app. Moving keeps `src/` pure TS and leaves the existing `require('./utils.js')` lines untouched.
+
+### 4. Anchor paths on `path.resolve(__dirname, '..')`, not on `process.cwd()`
+**Options:** A) Standardise on cwd-relative paths and document "run from repo root"; B) standardise on a repo-root constant derived from `__dirname`.
+**Decision:** B
+**Rationale:** The issue names the cwd/`__dirname` mix as the problem. B makes `node scripts/collect.js`, `npm run collect` and an absolute invocation from elsewhere all behave the same, and is what #19's new `import-val.js` can reuse. Inputs supplied by the caller (`parseULFile(file)`) remain cwd-relative, as is conventional for CLI arguments. Agent judgment.
+
+### 5. Only `collect` gets an npm script
+**Options:** A) Add `collect` and `parti:index` (or similar) scripts; B) add only `collect` and document `node scripts/parti.js` in the README.
+**Decision:** B
+**Rationale:** The issue asks for an npm script `collect` (user decision). `parti.js` is a one-off index rebuild that #19 replaces; an npm alias would have to be removed again shortly. Agent judgment — trivial to add if preferred.
+
+## Verification Checklist
+
+- [ ] `node scripts/collect.js` from the repo root starts, logs `Starting at index: 208`, writes the file, and leaves `git status --porcelain` empty
+- [ ] The same command run from a different working directory (absolute path to the script) behaves identically
+- [ ] `node scripts/parti.js` runs and leaves `git status` clean
+- [ ] `npm run collect` exists and runs `scripts/collect.js`
+- [ ] `src/utils.js` no longer exists; `scripts/utils.js` exports `toFileName`, `newUuid`, `loadXML`, `loadJSONFile`, `dataPath`
+- [ ] `grep -rn "lodash\|require('uuid')" scripts src` finds nothing; `package.json` has no new dependencies
+- [ ] `scripts/helpers.js` `parseULFile`/`parseKommunXMLFile` unchanged; no `path` require left unused in `collect.js`/`parti.js`; `Buffer` require kept in `utils.js`
+- [ ] `toFileName('Östra vägen (C)') === 'ostra-vagen-c'`; `newUuid()` matches `/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/`
+- [ ] `README.md` has a "Köra skripten" section and no longer references `./utils.js`; `CLAUDE.md` describes `npm run collect`
+- [ ] `npm run lint && npm run typecheck && npm run build` green
+- [ ] PR body ends with `Closes #18`

--- a/agent-docs/issue/18-datainsamlingsskripten-trasiga/progress.md
+++ b/agent-docs/issue/18-datainsamlingsskripten-trasiga/progress.md
@@ -1,0 +1,42 @@
+# Implementation Progress: Issue #18
+
+**Started:** 2026-08-23
+**Last updated:** 2026-08-23
+**Completed:** 2026-08-23
+**Status:** Completed
+
+## Completed Steps
+
+- [x] Phase 1, Step 1: `git mv src/utils.js scripts/utils.js`
+- [x] Phase 1, Step 2: Drop `lodash`/`uuid` in `scripts/utils.js` (NFD normalisation, `crypto.randomUUID()`)
+- [x] Phase 1, Step 3: Drop `lodash` in `scripts/parti.js` (destructuring instead of `_.pick`)
+- [x] Phase 2, Step 4: Add `ROOT`/`dataPath` and root-anchored `loadJSONFile` in `scripts/utils.js`
+- [x] Phase 2, Step 5: Use the helper in `scripts/helpers.js`, `scripts/collect.js`, `scripts/parti.js`
+- [x] Phase 3, Step 6: Add `"collect"` npm script in `package.json`
+- [x] Phase 3, Step 7: `README.md` — "Köra skripten" section, fix `./utils.js` reference
+- [x] Phase 3, Step 8: `CLAUDE.md` — accurate description of how the scripts run
+- [x] Phase 4, Steps 9–12: Verification
+
+## Verification Checklist
+
+- [x] `npm run collect` from the repo root logs `Starting at index: 208`, writes the file, and `git diff --exit-code -- data/val/2018/partideltagande/kommun.json` passes
+- [x] Same run from another working directory (absolute path to the script) behaves identically
+- [x] `node scripts/parti.js` from another directory leaves `data/parti/index.json` byte-identical
+- [x] `npm run collect` exists and runs `scripts/collect.js`
+- [x] `src/utils.js` is gone; `scripts/utils.js` exports `toFileName`, `newUuid`, `loadXML`, `loadJSONFile`, `dataPath` (and `ROOT`)
+- [x] `grep -rn "lodash\|require('uuid')" scripts src` finds nothing; no new dependencies
+- [x] `parseULFile`/`parseKommunXMLFile` unchanged; no unused `path` require in `collect.js`/`parti.js`; `Buffer` require kept in `utils.js`
+- [x] `toFileName('Östra vägen (C)') === 'ostra-vagen-c'`; `newUuid()` matches the v4 pattern
+- [x] `README.md` has "Köra skripten" and no longer references `./utils.js`; `CLAUDE.md` describes `npm run collect`
+- [x] `npm run precommit` (lint + typecheck + build) green
+- [ ] PR body ends with `Closes #18` — not done: `/work-issue` was invoked without `--commit`/`--PR`, so the work stays on the feature branch
+
+## Notes
+
+Branch `issue/18-datainsamlingsskripten-trasiga` created from `main`. Changes are uncommitted on that branch.
+
+Slug check over all 333 entries in `data/parti/index.json`: NFD normalisation reproduces the committed `filnamn` for 325 entries; the 8 differences are exactly the hand-adjusted ones the plan predicted — `framstegspartiet-1223/1224/1226` (disambiguated by partikod), and `igov-direct-`, `ip-idrottspartiet-radda-stadshagens-ip-`, `kommunens-rost-`, `oppna-goteborg-` (trailing `-` from an older version of the function) plus `langen-amp-co` (from an `&amp;` entity). No `beteckning` contains a character that `_.deburr` transliterates but NFD does not (ø æ ß đ þ œ), so no slug changes for the current dataset.
+
+`scripts/helpers.js` keeps its `fs` and `path` requires — both are still used by `parseULFile`/`parseKommunXMLFile`, which the plan leaves untouched.
+
+The smoke test makes no HTTP request (all 208 kommuner already have `partier`), so it proves startup and path resolution only, not that collection from `data.val.se` still works — that is #19's concern.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dev": "next dev",
     "build": "next build",
     "lint": "eslint .",
+    "collect": "node scripts/collect.js",
     "typecheck": "tsc --noEmit",
     "precommit": "npm run lint && npm run typecheck && npm run build"
   },

--- a/scripts/collect.js
+++ b/scripts/collect.js
@@ -1,20 +1,19 @@
-const path = require('path');
 const fs = require('fs');
 
-const { loadJSONFile } = require('./utils.js');
+const { dataPath } = require('./utils.js');
 const { getNonRiksdagPartiesFromKommunXmlUrl } = require('./helpers.js');
 
 /**
  * Script for collecting data from XML files at data.val.se
  * and updating party participation per municipality (kommun).
  * Run:
- * > node scripts/collect.js
+ * > npm run collect
  */
 
 const year = '2018';
 
-const kommunJsonFile = path.resolve('data', 'val', year, 'partideltagande', 'kommun.json');
-const kommunDeltagande = loadJSONFile(kommunJsonFile);
+const kommunJsonFile = dataPath('val', year, 'partideltagande', 'kommun.json');
+const kommunDeltagande = JSON.parse(fs.readFileSync(kommunJsonFile, 'utf8'));
 
 const fetchLimit = 40;
 let numFetched = 0;

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -143,10 +143,7 @@ function getNonRiksdagPartiesFromKommunXmlUrl (year, url) {
  * _getRiksdagPartyMap
  */
 function _getRiksdagPartyMap (year) {
-  const riksdagParties = JSON.parse(
-    fs.readFileSync(path.resolve('data', 'val', String(year), 'partideltagande/riksdag.json'))
-      .toString('utf8')
-  );
+  const riksdagParties = loadJSONFile('data', 'val', String(year), 'partideltagande', 'riksdag.json');
   return riksdagParties.reduce((acc, p) => {
     acc[p.beteckning] = p;
     return acc;

--- a/scripts/parti.js
+++ b/scripts/parti.js
@@ -1,10 +1,9 @@
-const _ = require('lodash');
-const path = require('path');
 const fs = require('fs');
 
+const { dataPath } = require('./utils.js');
 const { parties } = require('./helpers.js');
 
-const newParties = parties.map(party => _.pick(party, ['uuid', 'beteckning', 'filnamn']));
+const newParties = parties.map(({ uuid, beteckning, filnamn }) => ({ uuid, beteckning, filnamn }));
 
 // Write index file
-fs.writeFileSync(path.join('data', 'parti', 'index.json'), JSON.stringify(newParties, null, 2) + '\n');
+fs.writeFileSync(dataPath('parti', 'index.json'), JSON.stringify(newParties, null, 2) + '\n');

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,9 +1,26 @@
 const fs = require('fs');
 const path = require('path');
-const _ = require('lodash');
-const { v4: uuidV4 } = require('uuid');
+const crypto = require('crypto');
 const https = require('https');
 const { Buffer } = require('buffer');
+
+/**
+ * ROOT
+ * Repository root, so paths resolve the same regardless of
+ * the working directory the script is started from.
+ * @type {String}
+ */
+const ROOT = path.resolve(__dirname, '..');
+
+/**
+ * dataPath
+ * Absolute path to a file in the committed data/ tree.
+ * @param  {...String} segments Path segments below data/
+ * @return {String}
+ */
+function dataPath (...segments) {
+  return path.join(ROOT, 'data', ...segments);
+}
 
 /**
  * toFileName
@@ -13,7 +30,9 @@ const { Buffer } = require('buffer');
  * @return {String}
  */
 function toFileName (name) {
-  return _.deburr(name)
+  return name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
     .toLowerCase()
     .replace(' - ', '-')
     .replace(/[)(]/g, '')
@@ -26,7 +45,7 @@ function toFileName (name) {
  * @return {String} uuid
  */
 function newUuid () {
-  return uuidV4();
+  return crypto.randomUUID();
 }
 
 /**
@@ -59,12 +78,12 @@ function loadXML (url, callback) {
 
 /**
  * loadJSONFile
- * @param  {...} resolveArgs
+ * @param  {...String} segments Path segments relative to the repository root
  * @return {Object}
  */
-function loadJSONFile (...resolveArgs) {
+function loadJSONFile (...segments) {
   return JSON.parse(
-    fs.readFileSync(path.resolve(...resolveArgs))
+    fs.readFileSync(path.join(ROOT, ...segments))
       .toString('utf8')
   );
 }
@@ -72,6 +91,8 @@ function loadJSONFile (...resolveArgs) {
 /**
  * Exports
  */
+exports.ROOT = ROOT;
+exports.dataPath = dataPath;
 exports.toFileName = toFileName;
 exports.newUuid = newUuid;
 exports.loadXML = loadXML;

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -23,6 +23,36 @@ function dataPath (...segments) {
 }
 
 /**
+ * DEBURR_LETTERS
+ * Latin letters without a canonical decomposition — NFD normalisation leaves
+ * them intact, so they are transliterated explicitly. The mappings match
+ * lodash's deburr table, which the committed `filnamn` values are generated
+ * with.
+ * @type {Object}
+ */
+const DEBURR_LETTERS = {
+  '\u00d0': 'D', '\u00f0': 'd', // D-with-stroke (eth)
+  '\u00d8': 'O', '\u00f8': 'o', // O-with-stroke
+  '\u00c6': 'Ae', '\u00e6': 'ae', // ae ligature
+  '\u00de': 'Th', '\u00fe': 'th', // thorn
+  '\u00df': 'ss', // sharp s
+  '\u0110': 'D', '\u0111': 'd', // D-with-stroke
+  '\u0126': 'H', '\u0127': 'h', // H-with-stroke
+  '\u0131': 'i', // dotless i
+  '\u0138': 'k', // kra
+  '\u013f': 'L', '\u0140': 'l', // L-with-middle-dot
+  '\u0141': 'L', '\u0142': 'l', // L-with-stroke
+  '\u014a': 'N', '\u014b': 'n', // eng
+  '\u0166': 'T', '\u0167': 't', // T-with-stroke
+  '\u0132': 'IJ', '\u0133': 'ij', // ij ligature
+  '\u0152': 'Oe', '\u0153': 'oe', // oe ligature
+  '\u0149': '\u0027n', // n preceded by apostrophe
+  '\u017f': 's' // long s
+};
+
+const DEBURR_PATTERN = new RegExp('[' + Object.keys(DEBURR_LETTERS).join('') + ']', 'g');
+
+/**
  * toFileName
  * Turns name with latin chars into file name,
  * e.g. "Östra vägen (C)" => "ostra-vagen-c"
@@ -33,6 +63,7 @@ function toFileName (name) {
   return name
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
+    .replace(DEBURR_PATTERN, ch => DEBURR_LETTERS[ch])
     .toLowerCase()
     .replace(' - ', '-')
     .replace(/[)(]/g, '')


### PR DESCRIPTION
Makes `node scripts/collect.js` and `node scripts/parti.js` actually start:

- `src/utils.js` moves to `scripts/utils.js`, where its only two consumers live.
- No new dependencies: `_.deburr` is replaced by `String.prototype.normalize('NFD')` plus removal of combining characters, `uuid` by `crypto.randomUUID()`, `_.pick` by destructuring. All 333 existing `filnamn` verified unchanged.
- Paths are anchored at the repository root (`ROOT`/`dataPath`) so the scripts can be run from any directory.
- `npm run collect` added; the README gets a section on running the scripts and CLAUDE.md is updated.

No error handling or data completion here — `collect.js` and the XML parser are replaced in #19. No deploy needed (`out/` is unaffected).

Closes #18
