### PR TITLE
Ensure titles on exported party pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "node scripts/validate-export.js",
     "lint": "eslint .",
     "import-val": "node scripts/import-val.js",
     "typecheck": "tsc --noEmit",

--- a/scripts/validate-export.js
+++ b/scripts/validate-export.js
@@ -1,0 +1,35 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function findHtmlFiles (directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const entryPath = path.join(directory, entry.name);
+    return entry.isDirectory() ? findHtmlFiles(entryPath) : entryPath.endsWith('.html') ? [entryPath] : [];
+  });
+}
+
+function validatePartyTitles (outDirectory) {
+  const partyDirectory = path.join(outDirectory, 'parti');
+  const files = findHtmlFiles(partyDirectory);
+  if (files.length === 0) {
+    throw new Error(`Inga exporterade partisidor hittades i ${partyDirectory}`);
+  }
+  const invalid = files.filter(file => {
+    const html = fs.readFileSync(file, 'utf8');
+    const title = html.match(/<title\b[^>]*>(.*?)<\/title>/s)?.[1].trim();
+    return !title;
+  });
+
+  if (invalid.length > 0) {
+    const relativeFiles = invalid.map(file => path.relative(outDirectory, file));
+    throw new Error(`Tom eller saknad <title> i:\n${relativeFiles.join('\n')}`);
+  }
+
+  console.log(`Kontrollerade <title> på ${files.length} partisidor.`);
+}
+
+if (require.main === module) {
+  validatePartyTitles(path.resolve(process.argv[2] || 'out'));
+}
+
+exports.validatePartyTitles = validatePartyTitles;

--- a/scripts/validate-export.test.js
+++ b/scripts/validate-export.test.js
@@ -1,0 +1,34 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { validatePartyTitles } = require('./validate-export.js');
+
+function writePartyPage (directory, slug, title) {
+  const partyDirectory = path.join(directory, 'parti', slug);
+  fs.mkdirSync(partyDirectory, { recursive: true });
+  fs.writeFileSync(path.join(partyDirectory, 'index.html'), `<html><head>${title}</head></html>`);
+}
+
+test('validatePartyTitles accepts exported party pages with titles', t => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'partidata-export-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  writePartyPage(directory, 'testpartiet', '<title data-next-head="">Testpartiet - Partidata 🇸🇪</title>');
+
+  assert.doesNotThrow(() => validatePartyTitles(directory));
+});
+
+test('validatePartyTitles rejects empty or missing titles', t => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'partidata-export-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  writePartyPage(directory, 'tom-title', '<title></title>');
+  writePartyPage(directory, 'saknad-title', '');
+
+  assert.throws(
+    () => validatePartyTitles(directory),
+    error => error.message.includes('parti/tom-title/index.html') &&
+      error.message.includes('parti/saknad-title/index.html')
+  );
+});

--- a/src/pages/parti/[filnamn].tsx
+++ b/src/pages/parti/[filnamn].tsx
@@ -36,7 +36,7 @@ function PartyPage ({ beteckning, forkortning, kod, valmyndigheten_registrerings
     <div>
       <main className="container">
         <Head>
-          <title>{beteckning} - Partidata 🇸🇪</title>
+          <title>{`${beteckning} - Partidata 🇸🇪`}</title>
           <meta name="description" content={`Öppen data om det politiska partiet “${beteckning}”`} />
           <link rel="icon" href="/favicon.ico" />
         </Head>


### PR DESCRIPTION
Closes #41

## Summary

- passes the party page title to Next Head as a single interpolated string
- validates after every build that every exported party page has a non-empty title
- tests both valid and empty or missing titles

## Verification

- npm run precommit
- 700 exported party pages checked
- 42 tests pass
