### PR TITLE
Validate data consistency in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,6 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run typecheck
+      - run: npm run validate:data
       - run: npm test
       - run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ Open data about Swedish political parties. Static public site, Swedish copy.
 ## Workflow
 
 - Branch + PR flow — never commit directly to `main`. PRs are squash-merged.
-- CI (`Integrate`) must be green: `npm run lint && npm run typecheck && npm test
-  && npm run build`.
+- CI (`Integrate`) must be green: `npm run lint && npm run typecheck &&
+  npm run validate:data && npm test && npm run build`.
 - Deploys happen on `v*` tags, not on merge: tag `main` and push the tag
   (see `deploy/README.md`). Merging is not releasing.
 
@@ -27,7 +27,8 @@ Open data about Swedish political parties. Static public site, Swedish copy.
   `data/val/<år>/partideltagande/` and reconciles `data/parti/`;
   `node scripts/parti.js` rebuilds the registry from `data/` alone. Results are
   committed to `data/`. Paths resolve from the repo root, so the scripts run
-  from any directory. `npm test` runs the `node:test` suite in `scripts/`.
+  from any directory. `npm run validate:data` checks the committed data tree;
+  `npm test` runs the `node:test` suite in `scripts/`.
 
 ## Deploy
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Körningen är idempotent: samma indata ger samma filer, oavsett i vilken ordnin
 
 Bygger om partifilerna och `data/parti/index.json` från det som redan finns i `data/`, utan att hämta något.
 
+### npm run validate:data
+
+Kontrollerar att partiregistret, partifilerna, valårens partireferenser samt region- och kommundatan är konsistenta. Kontrollen körs också i CI före tester och bygge.
+
 ### npm test
 
 Kör `node:test`-sviten för importen och partiregistret.

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "build": "next build",
     "lint": "eslint .",
     "import-val": "node scripts/import-val.js",
+    "validate:data": "node scripts/validate.js",
     "typecheck": "tsc --noEmit",
     "test": "node --test",
-    "precommit": "npm run lint && npm run typecheck && npm run build && npm test"
+    "precommit": "npm run lint && npm run typecheck && npm run validate:data && npm run build && npm test"
   },
   "dependencies": {
     "bootstrap": "^5.3.8",

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -1,0 +1,256 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { ROOT, toFileName } = require('./utils.js');
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function readJson (file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    throw new Error(`Kan inte läsa ${file}: ${error.message}`);
+  }
+}
+
+function requireArray (value, context) {
+  assert.ok(Array.isArray(value), `${context} ska vara en array`);
+  return value;
+}
+
+function requireString (value, context) {
+  assert.equal(typeof value, 'string', `${context} ska vara en sträng`);
+  assert.notEqual(value, '', `${context} får inte vara tom`);
+}
+
+function requireUuid (value, context) {
+  requireString(value, context);
+  assert.match(value, UUID_PATTERN, `${context} ska vara ett UUID`);
+}
+
+function requireUnique (items, key, context) {
+  const seen = new Set();
+  for (const item of items) {
+    const value = item[key];
+    assert.ok(!seen.has(value), `${context} innehåller dubbelt ${key}: ${value}`);
+    seen.add(value);
+  }
+}
+
+function validatePartyRegistry (dataDirectory) {
+  const partyDirectory = path.join(dataDirectory, 'parti');
+  const index = requireArray(readJson(path.join(partyDirectory, 'index.json')), 'parti/index.json');
+  requireUnique(index, 'uuid', 'parti/index.json');
+  requireUnique(index, 'filnamn', 'parti/index.json');
+
+  const sorted = index.map(party => party.filnamn).toSorted();
+  assert.deepEqual(index.map(party => party.filnamn), sorted, 'parti/index.json ska vara sorterad på filnamn');
+
+  const directories = fs.readdirSync(partyDirectory, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .toSorted();
+  assert.deepEqual(directories, sorted, 'Partikatalogerna ska motsvara posterna i parti/index.json');
+
+  const partiesByUuid = new Map();
+  const partySlugs = new Set();
+  const routableSlugs = new Set();
+  for (const entry of index) {
+    const context = `parti/index.json (${entry.filnamn || 'okänt filnamn'})`;
+    requireUuid(entry.uuid, `${context}.uuid`);
+    requireString(entry.beteckning, `${context}.beteckning`);
+    requireString(entry.filnamn, `${context}.filnamn`);
+    const slugs = [entry.filnamn, ...(entry.tidigare_filnamn || [])];
+    for (const slug of slugs) {
+      requireString(slug, `${context}.filnamn`);
+      assert.match(slug, /^[a-z0-9][a-z0-9-]*$/, `${context}: ${slug} är inte en säker slug`);
+      assert.ok(!routableSlugs.has(slug), `${context}: sluggen ${slug} används av flera partisidor`);
+      routableSlugs.add(slug);
+    }
+
+    const file = path.join(partyDirectory, entry.filnamn, 'index.json');
+    assert.ok(fs.existsSync(file), `${path.relative(dataDirectory, file)} saknas`);
+    const party = readJson(file);
+    requireUuid(party.uuid, `${entry.filnamn}.uuid`);
+    requireString(party.beteckning, `${entry.filnamn}.beteckning`);
+    requireString(party.filnamn, `${entry.filnamn}.filnamn`);
+    requireString(party.kod, `${entry.filnamn}.kod`);
+    assert.equal(party.filnamn, entry.filnamn, `${entry.filnamn}: filnamn ska matcha katalogen`);
+
+    for (const [key, value] of Object.entries(entry)) {
+      assert.deepEqual(value, party[key], `${entry.filnamn}: ${key} skiljer sig mellan index och partifil`);
+    }
+
+    const baseSlug = toFileName(party.beteckning);
+    const legacyHtmlSlug = toFileName(party.beteckning.replaceAll('&', '&amp;'));
+    assert.ok(
+      party.filnamn === baseSlug ||
+      party.filnamn === `${baseSlug}-${party.kod}` ||
+      party.filnamn === `${baseSlug}-` ||
+      party.filnamn === legacyHtmlSlug,
+      `${entry.filnamn}: filnamn utgår inte från beteckningen ${JSON.stringify(party.beteckning)}`
+    );
+    partiesByUuid.set(party.uuid, party);
+    partySlugs.add(party.filnamn);
+  }
+
+  return { index, partiesByUuid, partySlugs };
+}
+
+function validateRegions (dataDirectory) {
+  const regions = requireArray(readJson(path.join(dataDirectory, 'regioner', 'index.json')), 'regioner/index.json');
+  requireUnique(regions, 'kod', 'regioner/index.json');
+  requireUnique(regions, 'uuid', 'regioner/index.json');
+
+  const regionsByCode = new Map();
+  const municipalities = [];
+  for (const region of regions) {
+    requireString(region.kod, 'region.kod');
+    requireString(region.namn, `region ${region.kod}.namn`);
+    requireUuid(region.uuid, `region ${region.kod}.uuid`);
+    regionsByCode.set(region.kod, region);
+    for (const municipality of requireArray(region.kommuner, `region ${region.kod}.kommuner`)) {
+      requireString(municipality.kod, `kommun i region ${region.kod}.kod`);
+      requireString(municipality.namn, `kommun ${municipality.kod}.namn`);
+      requireUuid(municipality.uuid, `kommun ${municipality.kod}.uuid`);
+      municipalities.push(municipality);
+    }
+  }
+  requireUnique(municipalities, 'kod', 'regioner/index.json kommuner');
+  requireUnique(municipalities, 'uuid', 'regioner/index.json kommuner');
+
+  return {
+    regions,
+    regionsByCode,
+    municipalities,
+    municipalitiesByCode: new Map(municipalities.map(municipality => [municipality.kod, municipality]))
+  };
+}
+
+function validatePartyList (records, partiesByUuid, context) {
+  requireArray(records, context);
+  requireUnique(records, 'uuid', context);
+  for (const record of records) {
+    assert.notEqual(record.uuid, 'NOT FOUND', `${context} innehåller NOT FOUND`);
+    requireUuid(record.uuid, `${context}.uuid`);
+    requireString(record.kod, `${context}.kod`);
+    requireString(record.beteckning, `${context}.beteckning`);
+    assert.ok(partiesByUuid.has(record.uuid), `${context} hänvisar till okänt parti-UUID ${record.uuid}`);
+  }
+}
+
+function validateAreaList (areas, referenceByCode, partiesByUuid, context, complete = false) {
+  requireArray(areas, context);
+  requireUnique(areas, 'kod', context);
+  for (const area of areas) {
+    const reference = referenceByCode.get(area.kod);
+    assert.ok(reference, `${context} innehåller okänd områdeskod ${area.kod}`);
+    assert.equal(area.uuid, reference.uuid, `${context} ${area.kod} har fel UUID`);
+    assert.equal(area.namn, reference.namn, `${context} ${area.kod} har fel namn`);
+    validatePartyList(area.partier, partiesByUuid, `${context} ${area.kod}.partier`);
+  }
+  if (complete) {
+    assert.deepEqual(
+      areas.map(area => area.kod).toSorted(),
+      [...referenceByCode.keys()].toSorted(),
+      `${context} ska innehålla samtliga områden`
+    );
+  }
+}
+
+function validateCandidateLists (yearDirectory, partySlugs) {
+  const directory = path.join(yearDirectory, 'kandidatlistor');
+  if (!fs.existsSync(directory)) return 0;
+
+  const files = fs.readdirSync(directory).filter(file => file.endsWith('.json'));
+  for (const file of files) {
+    const candidateList = readJson(path.join(directory, file));
+    requireString(candidateList.filnamn, `${file}.filnamn`);
+    assert.equal(file, `${candidateList.filnamn}.json`, `${file}: filnamn-fältet ska matcha filen`);
+    assert.ok(partySlugs.has(candidateList.filnamn), `${file} hänvisar till ett okänt parti`);
+  }
+  return files.length;
+}
+
+function validateElectionYears (dataDirectory, parties, geography) {
+  const electionDirectory = path.join(dataDirectory, 'val');
+  const years = fs.readdirSync(electionDirectory, { withFileTypes: true })
+    .filter(entry => entry.isDirectory() && /^\d{4}$/.test(entry.name));
+  let referenceCount = 0;
+  let candidateListCount = 0;
+
+  for (const year of years) {
+    const yearDirectory = path.join(electionDirectory, year.name);
+    const participationDirectory = path.join(yearDirectory, 'partideltagande');
+    const partierFile = path.join(participationDirectory, 'partier.json');
+    const riksdagFile = path.join(participationDirectory, 'riksdag.json');
+    const regionFile = ['region.json', 'landsting.json']
+      .map(file => path.join(participationDirectory, file))
+      .find(file => fs.existsSync(file));
+    const municipalityFile = path.join(participationDirectory, 'kommun.json');
+
+    if (fs.existsSync(partierFile)) {
+      const records = readJson(partierFile);
+      validatePartyList(records, parties.partiesByUuid, `${year.name}/partier.json`);
+      referenceCount += records.length;
+    }
+    if (fs.existsSync(riksdagFile)) {
+      const records = readJson(riksdagFile);
+      validatePartyList(records, parties.partiesByUuid, `${year.name}/riksdag.json`);
+      referenceCount += records.length;
+    }
+    if (regionFile) {
+      const areas = readJson(regionFile);
+      validateAreaList(areas, geography.regionsByCode, parties.partiesByUuid, `${year.name}/${path.basename(regionFile)}`);
+      referenceCount += areas.reduce((sum, area) => sum + area.partier.length, 0);
+    }
+    if (fs.existsSync(municipalityFile)) {
+      const areas = readJson(municipalityFile);
+      validateAreaList(
+        areas,
+        geography.municipalitiesByCode,
+        parties.partiesByUuid,
+        `${year.name}/kommun.json`,
+        fs.existsSync(partierFile)
+      );
+      referenceCount += areas.reduce((sum, area) => sum + area.partier.length, 0);
+    }
+    candidateListCount += validateCandidateLists(yearDirectory, parties.partySlugs);
+  }
+
+  return { years: years.length, referenceCount, candidateListCount };
+}
+
+function validateData (dataDirectory = path.join(ROOT, 'data')) {
+  const parties = validatePartyRegistry(dataDirectory);
+  const geography = validateRegions(dataDirectory);
+  requireUnique(
+    [
+      ...parties.index.map(({ uuid }) => ({ uuid })),
+      ...geography.regions.map(({ uuid }) => ({ uuid })),
+      ...geography.municipalities.map(({ uuid }) => ({ uuid }))
+    ],
+    'uuid',
+    'partier, regioner och kommuner'
+  );
+  const elections = validateElectionYears(dataDirectory, parties, geography);
+
+  return {
+    parties: parties.index.length,
+    regions: geography.regions.length,
+    municipalities: geography.municipalities.length,
+    ...elections
+  };
+}
+
+if (require.main === module) {
+  const result = validateData(process.argv[2] ? path.resolve(process.argv[2]) : undefined);
+  console.log(
+    `Validerade ${result.parties} partier, ${result.regions} regioner, ` +
+    `${result.municipalities} kommuner och ${result.referenceCount} partireferenser ` +
+    `över ${result.years} valår samt ${result.candidateListCount} kandidatlistor.`
+  );
+}
+
+exports.validateData = validateData;

--- a/scripts/validate.test.js
+++ b/scripts/validate.test.js
@@ -1,0 +1,103 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { validateData } = require('./validate.js');
+
+const PARTY = {
+  uuid: '11111111-1111-4111-8111-111111111111',
+  kod: '9001',
+  beteckning: 'Testpartiet',
+  filnamn: 'testpartiet'
+};
+const REGION = {
+  kod: '01',
+  namn: 'Testlän',
+  uuid: '22222222-2222-4222-8222-222222222222'
+};
+const MUNICIPALITIES = [
+  { kod: '0101', namn: 'Testköping', uuid: '33333333-3333-4333-8333-333333333333' },
+  { kod: '0102', namn: 'Provstad', uuid: '44444444-4444-4444-8444-444444444444' }
+];
+
+function writeJson (root, relativePath, value) {
+  const file = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(value));
+}
+
+function makeData () {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'partidata-validation-'));
+  writeJson(root, 'parti/index.json', [{
+    uuid: PARTY.uuid,
+    beteckning: PARTY.beteckning,
+    filnamn: PARTY.filnamn
+  }]);
+  writeJson(root, 'parti/testpartiet/index.json', PARTY);
+  writeJson(root, 'regioner/index.json', [{ ...REGION, kommuner: MUNICIPALITIES }]);
+  writeJson(root, 'val/2026/partideltagande/partier.json', [PARTY]);
+  writeJson(root, 'val/2026/partideltagande/riksdag.json', [PARTY]);
+  writeJson(root, 'val/2026/partideltagande/region.json', [{ ...REGION, partier: [PARTY] }]);
+  writeJson(root, 'val/2026/partideltagande/kommun.json', MUNICIPALITIES.map(municipality => ({
+    ...municipality,
+    partier: [PARTY]
+  })));
+  return root;
+}
+
+test('validateData accepts a consistent data tree', t => {
+  const root = makeData();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  assert.deepEqual(validateData(root), {
+    parties: 1,
+    regions: 1,
+    municipalities: 2,
+    years: 1,
+    referenceCount: 5,
+    candidateListCount: 0
+  });
+});
+
+test('validateData rejects inconsistencies with useful errors', async t => {
+  await t.test('missing party files', t => {
+    const root = makeData();
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    fs.rmSync(path.join(root, 'parti/testpartiet'), { recursive: true });
+    assert.throws(() => validateData(root), /Partikatalogerna ska motsvara/);
+  });
+
+  await t.test('duplicate UUIDs across entity types', t => {
+    const root = makeData();
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    const regions = readJson(root, 'regioner/index.json');
+    regions[0].uuid = PARTY.uuid;
+    writeJson(root, 'regioner/index.json', regions);
+    const electionRegions = readJson(root, 'val/2026/partideltagande/region.json');
+    electionRegions[0].uuid = PARTY.uuid;
+    writeJson(root, 'val/2026/partideltagande/region.json', electionRegions);
+    assert.throws(() => validateData(root), /partier, regioner och kommuner innehåller dubbelt uuid/);
+  });
+
+  await t.test('unknown party references', t => {
+    const root = makeData();
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    const records = readJson(root, 'val/2026/partideltagande/riksdag.json');
+    records[0].uuid = '55555555-5555-4555-8555-555555555555';
+    writeJson(root, 'val/2026/partideltagande/riksdag.json', records);
+    assert.throws(() => validateData(root), /okänt parti-UUID/);
+  });
+
+  await t.test('incomplete municipality files for imported years', t => {
+    const root = makeData();
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    writeJson(root, 'val/2026/partideltagande/kommun.json', [{ ...MUNICIPALITIES[0], partier: [] }]);
+    assert.throws(() => validateData(root), /ska innehålla samtliga områden/);
+  });
+});
+
+function readJson (root, relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(root, relativePath), 'utf8'));
+}


### PR DESCRIPTION
Closes #24

## Summary

- adds a standalone validation of the whole data directory
- checks the party index, party files, file names, UUIDs and historical slugs
- checks party references and region and municipality links for every election year
- checks the candidate lists' party references
- runs the validation in CI and precommit before the build
- documents the command and tests the common error types

## Verification

- npm run lint
- npm run typecheck
- npm run validate:data
- npm test: 46 tests pass
- npm run build -- --webpack

The ordinary local Turbopack run was blocked by the execution environment when the CSS loader tried to bind a local port. The webpack build passes; GitHub CI runs the ordinary npm run build.
