### PR TITLE
Party names are not sorted according to the Swedish alphabet

### DIFF
--- a/agent-docs/issue/54-partinamn-svensk-sortering/index.md
+++ b/agent-docs/issue/54-partinamn-svensk-sortering/index.md
@@ -1,0 +1,31 @@
+# Issue #54: Partinamn sorteras inte enligt svenska alfabetet
+
+**Baserad på:** main
+
+## Sammanfattning
+
+Partinamn sorterades enligt ASCII-slugordning (Å/Ä/Ö vikta till A/O) i stället för svensk kollation, så Jämtlands Väl hamnade före Jarl och Å/Ä/Ö-partier bland A-partierna. PR #56 rättade startsidans ordning med `Intl.Collator('sv')`; denna plan stänger kvarstående luckor: en delad kollationsmodul, en körtidsvakt i `/api/health` som gör en Node utan svensk ICU-data till ett synligt hälsofel, och en ordningskänslig regressionskontroll i `scripts/http-smoke.js`.
+
+## Triageringsstatus
+
+| Fält | Värde |
+|------|-------|
+| **Redo att arbeta** | Ja |
+| **Risk** | Låg |
+| **Säker för junior** | Ja |
+
+## Plangranskning
+
+**Status:** Granskad
+**Granskad:** 2026-08-26
+**Feedback:** Två granskningsrundor: skärpte enhetstestets fixtur (osorterad, hela Å/Ä/Ö-invarianten, identiska beteckningar med `filnamn` som sekundärnyckel), injicerbar kollationsvakt som bevisar hälsokopplingen, loggning i `/api/health`, korrigerade att röktestets facit delar serverns ICU-data (fallback fångas av vakten, inte grid-jämförelsen) samt dokumenterade att deployns hälsogate ligger efter restart, med engångsverifiering av produktionens Node före taggning. Granskarens förslag att blockera på grupperingsbeslutet tillämpades inte — beslutet lyfts i stället explicit vid plangranskning och i PR:en.
+
+## Relaterade filer
+
+- [plan.md](plan.md) — Fullständig implementationsplan
+- [progress.md](progress.md) — Implementationsframsteg
+
+## Relaterade issues
+
+- #49 — Startsidans ombyggnad (PR #56, mergad) rättade huvudlistans sorteringsordning
+- #38 — Särskiljning av partier med samma namn berör samma lista men inte sorteringen

--- a/agent-docs/issue/54-partinamn-svensk-sortering/plan.md
+++ b/agent-docs/issue/54-partinamn-svensk-sortering/plan.md
@@ -1,0 +1,270 @@
+# Plan: Issue #54 — Partinamn sorteras inte enligt svenska alfabetet
+
+## Mål
+
+Alla alfabetiskt sorterade listor — startsidans partilista och länsfiltret —
+ska följa svensk kollation (A–Z, Å, Ä, Ö), så att t.ex. **Jarl** kommer före
+**Jämtlands Väl** och namn på Å/Ä/Ö hamnar efter Z. Listor med innehållsordning
+(mandatfördelning i källans ordning, kandidatlistor i valsedelsordning) berörs
+inte. Ordningen ska dessutom vara skyddad mot regression: dels via test som
+låser den svenska ordningen, dels via en körtidskontroll som gör att en
+Node-runtime utan svensk ICU-data ger ett synligt hälsofel i stället för tyst
+felsortering.
+
+## Triagering
+
+> Beslutsunderlag för detta issue.
+
+| Fält | Värde |
+|------|-------|
+| **Blockeras av** | Inget |
+| **Blockerar** | Inget |
+| **Relaterade issues** | #49 (startsidans ombyggnad — fortfarande öppet, men dess PR #56 är mergad och rättade huvudlistans ordning), #38 (särskiljning av partier med samma namn — rör samma lista men inte sorteringen) |
+| **Omfattning** | 5 filer i `src/server/`, `src/pages/api/` och `scripts/` |
+| **Risk** | Låg |
+| **Komplexitet** | Låg |
+| **Säker för junior** | Ja |
+| **Konfliktrisk** | Låg (övriga planer i `agent-docs/issue/` avser redan mergat arbete; planen för #49 rör `src/components/home/` men PR #56 är merged) |
+
+### Triagemässiga noteringar
+
+- **Grundorsak vid rapporttillfället:** den då driftsatta startsidan (t.o.m.
+  `v0.6.0`) renderade partilistan i den ordning `data/parti/index.json` har,
+  och registret sorteras av `scripts/parti.js` på **filnamn** — ASCII-slugs
+  där diakriter vikts bort (`jamtlands-val-bracke` < `jarl`, `akta-demokrati`
+  under A). Det ger exakt symptomen i issuet: Jämtlands Väl före Jarl, och
+  Å/Ä/Ö-partier insprängda bland A/O.
+- **Delvis rättat av PR #56** (mergad efter att issuet skapades; issue #49 är
+  ännu öppet): den nya startsidan sorterar partilistan och länslistan vid
+  request med `Intl.Collator('sv')` i `src/server/party-data.ts`, vilket ger
+  korrekt ordning på en Node med full ICU. Lokal körning bekräftar rätt
+  ordning.
+- **Kvarstående luckor** som denna plan stänger: (1) testerna låser inte den
+  svenska ordningen — fixturen i `scripts/party-data.test.js` passerar även
+  under rotkollation, och röktestet kontrollerar bara att första partiet
+  länkas; buggen har redan skeppats en gång; (2) `Intl.Collator('sv')` faller
+  **tyst** tillbaka till rotkollation om runtimens Node saknar svensk
+  locale-data (t.ex. en Node byggd med small-icu), och produktionsserverns
+  Node (systemd-tjänstens `@NODE_BINARY@`) ligger utanför repots kontroll;
+  (3) rättningen är inte släppt — deploy sker på `v*`-taggar, så sajten
+  visar fel ordning tills en ny tagg pushas.
+- Issuets förväntan om **bokstavsgruppering** (Å/Ä/Ö som egna bokstäver)
+  avsåg den gamla startsidans grupperade lista. Den mergade startsidan
+  (PR #56) visar en platt lista "Sorterat A–Ö" utan bokstavsgrupper, så det
+  finns ingen gruppering kvar att rätta. Att den platta listan ersätter
+  grupperingskravet är dock ett acceptansbeslut — det lyfts för bekräftelse
+  redan vid plangranskningen (designbeslut 3) och upprepas i PR:en (steg 8),
+  aldrig tyst antaget.
+
+## Angreppssätt
+
+Sorteringslogiken finns redan på rätt ställe — presentationlagret
+(`buildHomeData` i `src/server/party-data.ts`) sorterar med
+`Intl.Collator('sv')`, medan dataregistret `data/parti/index.json` avsiktligt
+ligger kvar i deterministisk filnamnsordning (låst av `scripts/parti.test.js`).
+Planen ändrar därför inte datalagret utan gör tre saker:
+
+1. **Samla kollationen i en delad modul** så att alla ställen som sorterar
+   svenska namn använder samma collator, och så att det finns en funktion som
+   kan verifiera att runtimen faktiskt sorterar svenskt.
+2. **Gör felsortering till ett hälsofel.** `partyData.assertHealthy()` backar
+   `/api/health`, som både `scripts/http-smoke.js` och deployjobbets
+   hälsokontroller (lokal curl efter restart samt publik smoke) gatar på. En
+   Node utan svensk kollation gör alltså deployjobbet synligt rött i stället
+   för att sajten tyst visar fel ordning. Observera att deployn rsyncar och
+   startar om **före** hälsokontrollen, så den felsorterande artefakten är
+   redan aktiv när jobbet failar — åtgärd och återställning dokumenteras i
+   steg 8, och produktionens Node verifieras dessutom en gång före taggning.
+3. **Lås ordningen i testerna.** Enhetstestet i `scripts/party-data.test.js`
+   får en avsiktligt osorterad fixtur som täcker hela invarianten (Jarl före
+   Jämtlands Väl, Z före Å före Ä före Ö), och `npm run test:http` — som
+   startar den riktiga release-artefakten — verifierar att startsidans
+   renderade partigrid följer samma ordning. Testernas rollfördelning:
+   grid- och enhetsjämförelserna fångar **kodregressioner** (sorteringen tas
+   bort eller ändras), medan **ICU-fallback** fångas av kollationsvaktens
+   literala jämförelser — röktestets facit beräknas nämligen med samma
+   ICU-data som servern den startar (`process.execPath`), så på en
+   small-icu-Node skulle facit och utfall falla tillbaka likadant och matcha.
+
+Viktiga observationer från kodläsningen:
+
+- `buildHomeData` sorterar både `parties` (på `beteckning`) och `lan` (på
+  `namn`) med en lokal `new Intl.Collator('sv')` — båda ska gå över till den
+  delade modulen.
+- `scripts/party-data.test.js` kräver in TS-modulen direkt
+  (`require('../src/server/party-data.ts')`, Node 24 type-stripping), så
+  enhetstest av sorteringen hör hemma där. Dagens fixtur
+  (Alfa/Beta/Duplikat/Östra) är redan i förväntad ordning även under
+  rotkollation och fångar därför inte buggen.
+- `scripts/http-smoke.js` skapar redan en egen `Intl.Collator('sv')` för att
+  hitta första partiet; den kontrollen är inte ordningskänslig (första partiet
+  börjar på A under båda kollationerna) och fångar därför inte buggen.
+- Startsidan server-renderar bara de första `PAGE_SIZE = 48` korten
+  (`src/components/home/filtering.ts`), och riksdagssektionen länkar samma
+  partisidor tidigare i dokumentet — ordningskontrollen i röktestet måste
+  därför avgränsas till "Alla partier"-gridens markup, inte hela bodyn.
+  48-kortskontrollen täcker inte hela alfabetet — därför bär enhetstestet
+  helhetsinvarianten.
+- Registret innehåller flera partier med **identisk beteckning** (t.ex.
+  `Alternativet`, `Framstegspartiet`, `Kommunens Väl`, `Kommunlistan`), där
+  collatorn ger 0 — deras inbördes ordning behöver en explicit
+  sekundärnyckel för att vara deterministisk (designbeslut 4; jfr #38 om att
+  särskilja dem visuellt).
+- `/api/health` sväljer i dag felet (`catch` utan loggning) — för att vaktens
+  felmeddelande ska gå att diagnostisera vid en failad deploy måste handlern
+  logga det fångade felet server-side.
+- Sökfältets normalisering viker bort diakriter (`normalise` i
+  `src/components/home/filtering.ts`), så en sökning på "ä" matchar även "a"
+  — manuell verifiering av Å/Ä/Ö-ordningen kan inte göras via sökningen utan
+  görs genom att bläddra fram hela listan eller inspektera sidans
+  serialiserade data.
+
+## Steg
+
+### Fas 1: Delad svensk kollation med körtidsvakt
+
+1. Skapa `src/server/collation.ts`
+   - Exportera en delad collator, t.ex. `export const svCollator = new Intl.Collator('sv')`
+     och en jämförelsefunktion `compareSv(a: string, b: string): number`.
+   - Exportera `assertSwedishCollation(): void` som kastar med tydligt
+     felmeddelande om runtimen inte sorterar svenskt, verifierat med
+     faktiska jämförelser (inte bara `resolvedOptions().locale`):
+     `compareSv('z', 'å') < 0`, `compareSv('å', 'ä') < 0`,
+     `compareSv('ä', 'ö') < 0` samt `compareSv('Jarl', 'Jämtlands') < 0`.
+     (Under rotkollation flippar åtminstone `z`/`å`- och
+     `Jarl`/`Jämtlands`-jämförelserna; de inbördes å/ä/ö-jämförelserna kan
+     råka stämma även där, men hela sviten tillsammans låser invarianten.)
+   - Filer att ändra: `src/server/collation.ts` (ny)
+2. Använd modulen i `src/server/party-data.ts`
+   - Ersätt den lokala `const collator = new Intl.Collator('sv')` i
+     `buildHomeData` med import från `src/server/collation.ts` för både
+     parti- och länssorteringen.
+   - Gör partisorteringen deterministisk vid lika beteckning med `filnamn`
+     som sekundärnyckel (designbeslut 4).
+   - Lägg till kollationsvakten i `assertHealthy()` så att `/api/health`
+     svarar 500 på en runtime med fel kollation. Ge `createPartyDataStore`
+     en injicerbar vakt (t.ex.
+     `createPartyDataStore(dataRoot, { assertCollation = assertSwedishCollation } = {})`)
+     så att enhetstestet kan bevisa kopplingen (steg 4).
+   - Filer att ändra: `src/server/party-data.ts`
+3. Logga hälsofel i `src/pages/api/health.ts`
+   - `catch`-grenen loggar det fångade felet (`console.error`) innan den
+     svarar 500, så att orsaken (t.ex. kollationsvaktens meddelande) syns i
+     tjänstens journal vid en failad deploy-hälsokontroll.
+   - Filer att ändra: `src/pages/api/health.ts`
+
+### Fas 2: Regressionsskydd i testerna
+
+4. Skärp enhetstestet i `scripts/party-data.test.js`
+   - Gör `makeHomeData`-fixturen avsiktligt osorterad och komplettera den med
+     partier som täcker hela invarianten: `Jarl` och `Jämtlands Väl`, namn på
+     Z, Å, Ä och Ö (utöver befintliga `Östra partiet`) samt ett par med
+     identisk beteckning för att låsa sekundärnyckeln på `filnamn`.
+   - Asserta hela den resulterande sekvensen (som i dag, via
+     `home.parties.map(...filnamn)`) så att testet failar både under
+     rotkollation och om produktionssorteringen tas bort.
+   - Lägg till ett Å/Ä/Ö-län i regionfixturen och asserta länens ordning.
+   - Bevisa hälsokopplingen via injektionsseamen från steg 2: injicera en
+     kastande vakt och asserta att `store.assertHealthy()` rejectar med det
+     felet (det negativa ICU-fallet går inte att framkalla på en
+     full-ICU-Node, men seamen bevisar att vakten faktiskt anropas).
+   - Filer att ändra: `scripts/party-data.test.js`
+5. Utöka `scripts/http-smoke.js` med en ordningskänslig kontroll av startsidan
+   - Kör de literala kollationsjämförelserna (samma invariant som
+     `assertSwedishCollation`) i röktestets början, så att testet failar
+     direkt på en runtime utan svensk ICU-data i stället för att räkna fram
+     ett fallback-facit.
+   - Beräkna facit ur `data/parti/index.json`:
+     `expected = parties.toSorted(svensk kollation på beteckning, filnamn som sekundärnyckel).slice(0, 48)`.
+   - Plocka ut "Alla partier"-gridens del av HTML:en (markupen efter
+     `id="alla-partier"`, listan med klassen `home-grid`) och extrahera
+     `/parti/<filnamn>`-länkarna i dokumentordning.
+   - Asserta att de extraherade länkarna är exakt `expected`-partiernas
+     filnamn i samma ordning. Kontrollen fångar kodregressioner i
+     serverns sortering; ICU-fallback fångas inte av själva jämförelsen
+     (facit beräknas med samma ICU-data som servern) utan av
+     invariantkontrollen ovan och av hälsovakten som röktestet redan
+     väntar på.
+   - Asserta antalet extraherade länkar (48) så att kontrollen inte tyst
+     blir tom om markupen ändras; failar extraktionen ska testet faila, inte
+     hoppa över.
+   - Filer att ändra: `scripts/http-smoke.js`
+
+### Fas 3: Verifiering och släpp
+
+6. Kör `npm run precommit` (lint, typecheck, datavalidering, test,
+   release-bygge och röktest mot artefakten).
+7. Verifiera manuellt i dev-servern att "Alla partier" visar Jarl före
+   Jämtlands Väl och att Å-, Ä- och Ö-partier ligger sist i den ordningen —
+   genom att bläddra fram hela listan med "Visa fler partier" (sökning
+   fungerar inte för detta eftersom den viker bort diakriter).
+8. Skriv PR-bodyn så att den (a) lyfter acceptansbeslutet att den platta
+   listan "Sorterat A–Ö" ersätter issuets bokstavsgruppering — öppet för
+   användaren att underkänna innan merge — och (b) noterar att merge inte är
+   release: den driftsatta sajten visar fel ordning tills `main` taggas
+   (`v*`) och deployn rullat.
+   - **Release-beroende:** före taggningen bör produktionens Node verifieras
+     en gång — be användaren köra systemd-tjänstens `@NODE_BINARY@` med en
+     enradskontroll (`new Intl.Collator('sv').compare('z','å') < 0`) på
+     servern (ssh kräver ändå användarens medverkan). Officiella
+     Node-binärer sedan v14 har full ICU, så utfallet väntas vara grönt.
+   - Om deployns hälsokontroll ändå failar på kollationsvakten: den nya
+     artefakten är då redan aktiv (rsync + restart sker före kontrollen) och
+     sidorna svarar 200 med fel ordning medan `/api/health` ger 500 och
+     jobbet är rött. Åtgärd: installera/peka `@NODE_BINARY@` på en
+     full-ICU-Node och rulla om; återställning: deploya föregående tagg.
+   - Själva taggningen är ett separat beslut utanför denna plan.
+
+## Filöversikt
+
+| Fil | Åtgärd | Syfte |
+|-----|--------|-------|
+| `src/server/collation.ts` | Skapa | Delad svensk collator + `assertSwedishCollation()` |
+| `src/server/party-data.ts` | Ändra | Använd delade collatorn; kollationsvakt i `assertHealthy()` |
+| `src/pages/api/health.ts` | Ändra | Logga fångat hälsofel så vaktens orsak syns i journalen |
+| `scripts/party-data.test.js` | Ändra | Osorterad fixtur som låser hela den svenska ordningen |
+| `scripts/http-smoke.js` | Ändra | Ordningskänslig kontroll av startsidans partigrid |
+
+## Berörda kodområden
+
+- `src/server/`
+- `src/pages/api/`
+- `scripts/` (endast testfiler och `http-smoke.js`)
+
+## Designbeslut
+
+> Icke-triviala val gjorda under planeringen. Feedback välkommen; annars implementeras enligt dessa.
+
+### 1. Datalagret behåller filnamnsordning; svensk kollation är presentationens ansvar
+**Alternativ:** Sortera om `data/parti/index.json` på beteckning med svensk kollation vs behålla ASCII-ordning på filnamn och sortera vid rendering.
+**Beslut:** Behåll filnamnsordningen i registret.
+**Motivering:** Befintlig konvention — `scripts/parti.js` sorterar registret på filnamn och `scripts/parti.test.js` låser det; PR #56 lade presentationssorteringen vid request. Registerordningen är deterministisk oberoende av ICU-data (skripten kan köras på vilken Node som helst), och konsumenten sorterar för sitt syfte. *(Proveniens: befintlig konvention.)*
+
+### 2. Körtidsvakt i hälsokontrollen i stället för egen kollationsimplementation eller deploy-preflight
+**Alternativ:** (A) Lita på `Intl.Collator('sv')` och låta `assertHealthy()` verifiera att runtimen sorterar svenskt; (B) skriva en egen ICU-oberoende svensk jämförelsefunktion; (C) lägga en ssh-preflight i deployjobbet som kör kollationskontrollen med produktionens `@NODE_BINARY@` före rsync/restart.
+**Beslut:** A, kompletterat med en manuell engångsverifiering av produktionens Node före taggning (steg 8).
+**Motivering:** `Intl.Collator` ger korrekt full kollation (versaler, é→e-variant, bindestreck) som en egenimplementation lätt får fel; risken är enbart en runtime utan svensk locale-data. Deployjobbet gatar redan på `/api/health` både lokalt efter restart och publikt, så vakten gör felet synligt utan nya pipeline-steg, och loggningen i steg 3 gör orsaken diagnostiserbar. Vakten **förhindrar** dock inte att den felsorterande artefakten hinner bli aktiv (rsync + restart sker före kontrollen) — det residualfönstret accepteras eftersom engångsverifieringen före taggning i praktiken eliminerar sannolikheten, och en misslyckad deploy återställs med föregående tagg. C (ssh-preflight i workflowen) ger tidigare fail men bygger ut deploy-workflowens ssh-yta för ett fel som ändå fångas — läggs till om vakten någon gång faktiskt löser ut. *(Proveniens: agentens egen bedömning — öppen att ifrågasätta; B väljs om drift på small-icu-Node någonsin blir ett faktiskt krav.)*
+
+### 3. Ingen bokstavsgruppering återinförs — men beslutet lyfts till användaren
+**Alternativ:** Återinföra den gamla startsidans A–Ö-grupper (med Å/Ä/Ö som egna grupper) vs behålla den platta listan "Sorterat A–Ö".
+**Beslut:** Behåll den platta listan, och lyft explicit i PR:en att detta ersätter issuets grupperingsförväntan (steg 8).
+**Motivering:** Startsidans nya layout utan bokstavsgrupper är användarens mergade design (PR #56, issue #49); issuets grupperingskrav beskrev den gamla layoutens fel. Men issuet nämner grupperingen uttryckligen, så att den utgår är ett acceptansbeslut användaren ska få ta ställning till — inte en tyst tolkning. Om gruppering återinförs senare ska Å/Ä/Ö vara egna bokstäver — det täcks då av den delade kollationsmodulen. *(Proveniens: layouten är användarbeslut via mergad PR #56; att den ersätter grupperingskravet är agentens tolkning som lyfts för bekräftelse.)*
+
+### 4. Explicit sekundärnyckel på `filnamn` vid identiska beteckningar
+**Alternativ:** Lita på att sorteringen är stabil och att registrets filnamnsordning avgör vs jämföra explicit på `filnamn` när collatorn ger 0.
+**Beslut:** Explicit sekundärjämförelse på `filnamn`.
+**Motivering:** Registret innehåller flera partier med identisk beteckning (`Alternativet`, `Framstegspartiet`, `Kommunens Väl`, `Kommunlistan` m.fl.). `Array.prototype.sort` är stabil i moderna V8, men en implicit invariant som vilar på både stabilitet och registrets inordning är skörare än en rad explicit kod, och `filnamn` är unikt och redan listans React-nyckel. *(Proveniens: agentens egen bedömning — öppen att ifrågasätta.)*
+
+## Verifieringschecklista
+
+- [ ] "Alla partier" listar Jarl före Jämtlands Väl (bläddra fram via "Visa fler partier")
+- [ ] Partier på Å, Ä och Ö ligger efter partier på Z, i ordningen Å, Ä, Ö
+- [ ] Länsfiltret listar län i svensk ordning (Örebro län och Östergötlands län sist)
+- [ ] Partier med identisk beteckning kommer i deterministisk `filnamn`-ordning (låst av enhetstestets fixtur)
+- [ ] `npm test` failar om produktionssorteringen tas bort eller ändras (verifierat genom att tillfälligt sabotera sorteringen lokalt)
+- [ ] `npm test` failar när en kastande kollationsvakt injiceras i `createPartyDataStore` (bevisar att `assertHealthy()` anropar vakten)
+- [ ] `npm run test:http` failar om startsidans partigrid avviker från svensk ordning (verifierat på samma sätt som enhetstestet)
+- [ ] `/api/health` svarar 500 och loggar orsaken om kollationsvakten kastar (verifierat genom att tillfälligt injicera en kastande vakt lokalt)
+- [ ] `npm run precommit` grönt
+- [ ] Produktionens `@NODE_BINARY@` verifierad för svensk kollation före `v*`-taggning (enradskontroll körd av användaren)
+- [ ] PR:en lyfter acceptansbeslutet om bokstavsgrupperingen och noterar att en `v*`-tagg krävs innan rättningen syns på partidata.se

--- a/agent-docs/issue/54-partinamn-svensk-sortering/progress.md
+++ b/agent-docs/issue/54-partinamn-svensk-sortering/progress.md
@@ -1,0 +1,43 @@
+# Framsteg: Issue #54 — Partinamn sorteras inte enligt svenska alfabetet
+
+**Påbörjad:** 2026-08-26
+**Senast uppdaterad:** 2026-08-26
+**Status:** Implementerad lokalt
+
+## Genomförda steg
+
+- [x] Fas 1, steg 1: `src/server/collation.ts` med `compareSv()` och `assertSwedishCollation()`
+- [x] Fas 1, steg 2: `src/server/party-data.ts` använder modulen för parti- och länssortering,
+      `filnamn` som sekundärnyckel och en injicerbar kollationsvakt i `assertHealthy()`
+- [x] Fas 1, steg 3: `src/pages/api/health.ts` loggar det fångade felet före 500-svaret
+- [x] Fas 2, steg 4: Osorterad fixtur i `scripts/party-data.test.js` som låser hela invarianten
+      (Jarl före Jämtlands Väl, Z → Å → Ä → Ö, `filnamn` vid identisk beteckning, län i svensk
+      ordning) plus test som injicerar en kastande vakt
+- [x] Fas 2, steg 5: `scripts/http-smoke.js` kör de literala kollationsjämförelserna och jämför
+      startsidans partigrid mot facit ur `data/parti/index.json`
+- [x] Fas 3, steg 6: `npm run precommit` grönt
+- [x] Fas 3, steg 7: Ordningen verifierad mot release-artefakten (Jarl på index 226, Jämtlands Väl
+      på 235; Åtvidabergs Framtid → Äkta demokrati → Älska Svedala → Öarnasväl; Örebro län och
+      Östergötlands län sist i länslistan; `alternativet` före `alternativet-0510`)
+- [ ] Fas 3, steg 8: PR-body med acceptansbeslut och release-beroende
+
+## Pågående arbete
+
+Implementationen är klar på branchen `issue/54-partinamn-svensk-sortering`. Ingen commit, push
+eller PR är gjord — arbetet ligger i working tree för granskning.
+
+## Anteckningar
+
+- `tsconfig.json` fick `allowImportingTsExtensions: true`. `scripts/party-data.test.js` kräver in
+  `src/server/party-data.ts` direkt, och Nodes ESM-resolver kräver då explicit `.ts` i den
+  relativa importen av `./collation.ts`.
+- `node --test` skriver en `MODULE_TYPELESS_PACKAGE_JSON`-varning för `collation.ts`, eftersom
+  rotens `package.json` saknar `"type"`-fält och `scripts/` är CommonJS. Varningen är
+  testoutput-brus, inte ett fel, och påverkar inte bygget.
+- Regressionsskyddet är verifierat genom sabotage: borttagen sortering fäller både `npm test` och
+  `npm run test:http`, och en kastande vakt ger `/api/health` 500 med orsaken i serverloggen.
+
+## Återstående steg
+
+- [ ] Skapa PR (lyft acceptansbeslutet om bokstavsgruppering och `v*`-taggen som krävs för release)
+- [ ] Verifiera produktionens `@NODE_BINARY@` för svensk kollation före taggning

--- a/scripts/http-smoke.js
+++ b/scripts/http-smoke.js
@@ -6,6 +6,33 @@ const { spawn } = require('node:child_process');
 
 const projectRoot = path.join(__dirname, '..');
 const releaseRoot = path.join(projectRoot, '.release');
+const collator = new Intl.Collator('sv');
+const homePageSize = 48;
+
+/**
+ * The expected order below is computed with the same ICU data as the server
+ * this test starts, so a runtime without Swedish locale data would produce a
+ * matching root-collation fallback on both sides. These literal comparisons
+ * fail on such a runtime instead.
+ */
+function assertSwedishCollation () {
+  for (const [first, second] of [['z', 'å'], ['å', 'ä'], ['ä', 'ö'], ['Jarl', 'Jämtlands']]) {
+    assert.ok(collator.compare(first, second) < 0, `"${first}" ska sorteras före "${second}"`);
+  }
+}
+
+function comparePartyOrder (a, b) {
+  return collator.compare(a.beteckning, b.beteckning) || collator.compare(a.filnamn, b.filnamn);
+}
+
+/** Extracts the party links of the "Alla partier" grid in document order. */
+function partyGridLinks (html) {
+  const section = html.slice(html.indexOf('id="alla-partier"'));
+  const gridStart = section.indexOf('<ul class="home-grid">');
+  assert.ok(gridStart !== -1, 'partigridet hittades i markupen');
+  const grid = section.slice(gridStart, section.indexOf('</ul>', gridStart));
+  return [...grid.matchAll(/href="\/parti\/([^"/]+)\/?"/g)].map(match => match[1]);
+}
 
 async function freePort () {
   return await new Promise((resolve, reject) => {
@@ -36,8 +63,10 @@ async function main () {
   const chamber = JSON.parse(fs.readFileSync(path.join(projectRoot, 'data', 'derived', 'partiprofil', 'riksdag.json'), 'utf8')).kammare;
   const seats = chamber.partier.reduce((total, party) => total + party.mandat, 0);
   const majority = Math.floor(seats / 2) + 1;
+  assertSwedishCollation();
   const current = parties.find(party => party.filnamn === 'miljopartiet-de-grona') ?? parties[0];
-  const first = parties.toSorted((a, b) => new Intl.Collator('sv').compare(a.beteckning, b.beteckning))[0];
+  const expectedOrder = parties.toSorted(comparePartyOrder).slice(0, homePageSize).map(party => party.filnamn);
+  const [first] = expectedOrder;
   const previous = parties.find(party => party.tidigare_filnamn?.length > 0);
   const withSymbol = parties.find(party => party.partisymbol);
   assert.ok(current);
@@ -65,13 +94,17 @@ async function main () {
     assert.match(homeBody, /Sök parti på namn eller förkortning/);
     assert.match(homeBody, /Alla partier/, 'partilistan har en rubrik');
     assert.match(homeBody, new RegExp(`>${parties.length}</span>`), 'rubriken räknar partierna ur datan');
-    assert.match(homeBody, new RegExp(`/parti/${first.filnamn}`), 'partigridet länkar till en partisida');
+    assert.match(homeBody, new RegExp(`/parti/${first}`), 'partigridet länkar till en partisida');
     assert.match(homeBody, /Riksdagspartier/);
     assert.match(homeBody, new RegExp(`valet (<!-- -->)?${chamber.valar}`), 'riksdagssektionen anger valåret');
     assert.match(homeBody, new RegExp(`${seats}(<!-- -->)? mandat`), 'faktaraden anger kammarens storlek');
     assert.match(homeBody, new RegExp(`${majority}(<!-- -->)? för egen majoritet`), 'faktaraden anger egen majoritet');
     assert.match(homeBody, /aria-pressed="false"/, 'valtypen renderas som en chip-grupp');
     assert.match(homeBody, /Visa fler partier \(/, 'visa fler anger hur många som återstår');
+
+    const gridLinks = partyGridLinks(homeBody);
+    assert.equal(gridLinks.length, Math.min(homePageSize, parties.length), 'partigridet renderar en hel sida partier');
+    assert.deepEqual(gridLinks, expectedOrder, 'partigridet följer svensk bokstavsordning');
 
     const riksdagCards = homeBody.split('party-card--large').length - 1;
     assert.equal(riksdagCards, chamber.partier.length, 'riksdagspartierna renderas som stora partikort');

--- a/scripts/party-data.test.js
+++ b/scripts/party-data.test.js
@@ -109,10 +109,69 @@ test('health fails when the party index is unavailable', async t => {
   await assert.rejects(createPartyDataStore(path.join(root, 'data')).assertHealthy(), /ENOENT/);
 });
 
+test('health fails when the runtime collation guard rejects the runtime', async t => {
+  const { root, dataRoot } = makeData();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const store = createPartyDataStore(dataRoot, {
+    assertCollation () { throw new Error('Runtime saknar svensk kollation'); }
+  });
+
+  await assert.rejects(store.assertHealthy(), /saknar svensk kollation/);
+});
+
 function makeHomeData () {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'partidata-home-'));
   const dataRoot = path.join(root, 'data');
+  // Deliberately unordered, and picked so root collation would place
+  // Jämtlands Väl before Jarl and the Å/Ä/Ö parties among A and O.
   const parties = [
+    {
+      uuid: '55555555-5555-4555-8555-555555555555',
+      kod: '9005',
+      beteckning: 'Östra partiet',
+      filnamn: 'ostra-partiet'
+    },
+    {
+      uuid: '99999999-9999-4999-8999-999999999999',
+      kod: '9009',
+      beteckning: 'Kommunens Väl',
+      filnamn: 'kommunens-val-beta'
+    },
+    {
+      uuid: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      kod: '9010',
+      beteckning: 'Jämtlands Väl',
+      filnamn: 'jamtlands-val'
+    },
+    {
+      uuid: '22222222-2222-4222-8222-222222222222',
+      kod: '9002',
+      beteckning: 'Betapartiet',
+      filnamn: 'betapartiet',
+      forkortning: 'B',
+      deltagande: {
+        2022: { riksdag: false, region: ['14'], kommun: [] }
+      }
+    },
+    {
+      uuid: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      kod: '9011',
+      beteckning: 'Åkerpartiet',
+      filnamn: 'akerpartiet'
+    },
+    {
+      uuid: '44444444-4444-4444-8444-444444444444',
+      kod: '9004',
+      beteckning: 'Duplikatpartiet två',
+      filnamn: 'duplikatpartiet-tva',
+      forkortning: 'd'
+    },
+    {
+      uuid: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      kod: '9012',
+      beteckning: 'Zebrapartiet',
+      filnamn: 'zebrapartiet'
+    },
     {
       uuid: '11111111-1111-4111-8111-111111111111',
       kod: '9001',
@@ -132,14 +191,22 @@ function makeHomeData () {
       }
     },
     {
-      uuid: '22222222-2222-4222-8222-222222222222',
-      kod: '9002',
-      beteckning: 'Betapartiet',
-      filnamn: 'betapartiet',
-      forkortning: 'B',
-      deltagande: {
-        2022: { riksdag: false, region: ['14'], kommun: [] }
-      }
+      uuid: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      kod: '9013',
+      beteckning: 'Ängspartiet',
+      filnamn: 'angspartiet'
+    },
+    {
+      uuid: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+      kod: '9014',
+      beteckning: 'Jarl',
+      filnamn: 'jarl'
+    },
+    {
+      uuid: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+      kod: '9015',
+      beteckning: 'Kommunens Väl',
+      filnamn: 'kommunens-val-alfa'
     },
     {
       uuid: '33333333-3333-4333-8333-333333333333',
@@ -147,28 +214,17 @@ function makeHomeData () {
       beteckning: 'Duplikatpartiet ett',
       filnamn: 'duplikatpartiet-ett',
       forkortning: 'D'
-    },
-    {
-      uuid: '44444444-4444-4444-8444-444444444444',
-      kod: '9004',
-      beteckning: 'Duplikatpartiet två',
-      filnamn: 'duplikatpartiet-tva',
-      forkortning: 'd'
-    },
-    {
-      uuid: '55555555-5555-4555-8555-555555555555',
-      kod: '9005',
-      beteckning: 'Östra partiet',
-      filnamn: 'ostra-partiet'
     }
   ];
 
   writeJson(dataRoot, 'parti/index.json', parties.map(({ kod, deltagande, ...entry }) => entry));
   parties.forEach(party => writeJson(dataRoot, `parti/${party.filnamn}/index.json`, party));
   writeJson(dataRoot, 'regioner/index.json', [
+    { kod: '18', namn: 'Örebro län', uuid: '10101010-1010-4010-8010-101010101010', kommuner: [] },
     { kod: '12', namn: 'Skåne län', uuid: '66666666-6666-4666-8666-666666666666', kommuner: [] },
-    { kod: '01', namn: 'Stockholms län', uuid: '77777777-7777-4777-8777-777777777777', kommuner: [] },
-    { kod: '14', namn: 'Västra Götalands län', uuid: '88888888-8888-4888-8888-888888888888', kommuner: [] }
+    { kod: '05', namn: 'Östergötlands län', uuid: '20202020-2020-4020-8020-202020202020', kommuner: [] },
+    { kod: '14', namn: 'Västra Götalands län', uuid: '88888888-8888-4888-8888-888888888888', kommuner: [] },
+    { kod: '01', namn: 'Stockholms län', uuid: '77777777-7777-4777-8777-777777777777', kommuner: [] }
   ]);
 
   const source = { namn: 'Riksdagen', url: 'https://data.riksdagen.se/', hamtad: '2026-08-25' };
@@ -203,6 +259,13 @@ test('home data lists parties in Swedish alphabetical order with participation f
     'betapartiet',
     'duplikatpartiet-ett',
     'duplikatpartiet-tva',
+    'jarl',
+    'jamtlands-val',
+    'kommunens-val-alfa',
+    'kommunens-val-beta',
+    'zebrapartiet',
+    'akerpartiet',
+    'angspartiet',
     'ostra-partiet'
   ]);
   assert.deepEqual(home.parties[0], {
@@ -217,10 +280,16 @@ test('home data lists parties in Swedish alphabetical order with participation f
     }
   });
   assert.equal(home.parties[1].symbolSrc, undefined);
-  assert.equal(home.parties[4].forkortning, undefined);
-  assert.deepEqual(home.parties[4].deltagande, {});
+  assert.equal(home.parties.at(-1).forkortning, undefined);
+  assert.deepEqual(home.parties.at(-1).deltagande, {});
   assert.deepEqual(home.valar, ['2022', '2026']);
-  assert.deepEqual(home.lan.map(lan => lan.namn), ['Skåne län', 'Stockholms län', 'Västra Götalands län']);
+  assert.deepEqual(home.lan.map(lan => lan.namn), [
+    'Skåne län',
+    'Stockholms län',
+    'Västra Götalands län',
+    'Örebro län',
+    'Östergötlands län'
+  ]);
 });
 
 test('mandate records resolve to a party only on an unambiguous abbreviation', async t => {

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -15,7 +15,8 @@ export default async function handler (request: NextApiRequest, response: NextAp
     response.status(200);
     if (request.method === 'HEAD') response.end();
     else response.json({ status: 'ok' });
-  } catch {
+  } catch (error) {
+    console.error('Hälsokontrollen misslyckades', error);
     response.status(500);
     if (request.method === 'HEAD') response.end();
     else response.json({ status: 'error' });

--- a/src/server/collation.ts
+++ b/src/server/collation.ts
@@ -1,0 +1,26 @@
+const collator = new Intl.Collator('sv');
+
+/** Compares two strings under Swedish collation: A–Z, then Å, Ä, Ö. */
+export function compareSv (a: string, b: string): number {
+  return collator.compare(a, b);
+}
+
+/**
+ * `Intl.Collator('sv')` falls back to root collation without throwing when the
+ * runtime's ICU data omits Swedish, which would sort Å/Ä/Ö among A and O. The
+ * comparisons below distinguish the two collations, so a runtime built without
+ * Swedish locale data fails loudly instead of serving a misordered list.
+ */
+export function assertSwedishCollation (): void {
+  const invariants: Array<[string, string]> = [
+    ['z', 'å'],
+    ['å', 'ä'],
+    ['ä', 'ö'],
+    ['Jarl', 'Jämtlands'],
+  ];
+  for (const [first, second] of invariants) {
+    if (compareSv(first, second) >= 0) {
+      throw new Error(`Runtime saknar svensk kollation: "${first}" sorteras inte före "${second}"`);
+    }
+  }
+}

--- a/src/server/party-data.ts
+++ b/src/server/party-data.ts
@@ -2,6 +2,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { Parti, PartiIndexEntry, PartiProfil, PartiProfilKalla } from '../types';
+import { assertSwedishCollation, compareSv } from './collation.ts';
 
 export type ElectionType = 'R' | 'L' | 'K';
 export type CandidateLists = Record<string, ElectionType[]>;
@@ -137,7 +138,14 @@ async function readOptionalJson<T> (file: string): Promise<T | undefined> {
   }
 }
 
-export function createPartyDataStore (dataRoot = path.join(process.cwd(), 'data')) {
+export interface PartyDataStoreOptions {
+  assertCollation?: () => void;
+}
+
+export function createPartyDataStore (
+  dataRoot = path.join(process.cwd(), 'data'),
+  { assertCollation = assertSwedishCollation }: PartyDataStoreOptions = {},
+) {
   let partyIndexPromise: Promise<PartyIndex> | undefined;
   let homeDataPromise: Promise<HomeData> | undefined;
 
@@ -226,7 +234,6 @@ export function createPartyDataStore (dataRoot = path.join(process.cwd(), 'data'
 
   async function buildHomeData (): Promise<HomeData> {
     const index = await getPartyIndex();
-    const collator = new Intl.Collator('sv');
 
     const parties: HomeParty[] = (await Promise.all(index.parties.map(async entry => {
       const party = await readJson<Parti>(path.join(dataRoot, 'parti', entry.filnamn, 'index.json'));
@@ -239,14 +246,14 @@ export function createPartyDataStore (dataRoot = path.join(process.cwd(), 'data'
         ...(symbolSrc ? { symbolSrc } : {}),
         deltagande: facet(party.deltagande),
       };
-    }))).sort((a, b) => collator.compare(a.beteckning, b.beteckning));
+    }))).sort((a, b) => compareSv(a.beteckning, b.beteckning) || compareSv(a.filnamn, b.filnamn));
 
     const valar = [...new Set(parties.flatMap(party => Object.keys(party.deltagande)))].sort();
 
     const regions = await readJson<RegionFile[]>(path.join(dataRoot, 'regioner', 'index.json'));
     const lan = regions
       .map(region => ({ kod: region.kod, namn: region.namn }))
-      .sort((a, b) => collator.compare(a.namn, b.namn));
+      .sort((a, b) => compareSv(a.namn, b.namn));
 
     // A mandate record names its party by abbreviation only, so an abbreviation
     // that no party or several parties carry resolves to nothing rather than to
@@ -294,6 +301,7 @@ export function createPartyDataStore (dataRoot = path.join(process.cwd(), 'data'
     },
 
     async assertHealthy (): Promise<void> {
+      assertCollation();
       if ((await getPartyIndex()).parties.length === 0) throw new Error('Party index is empty');
     },
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
       "esnext"
     ],
     "allowJs": true,
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
The party registry is sorted with Swedish collation, and the order is locked down by tests instead of resting on the runtime happening to have the right ICU data.

## Root cause

The deployed start page rendered the registry in ASCII order on the slug, which places Å, Ä and Ö among A and O. `Intl.Collator('sv')` arrived with #56, but no test locked the order and the collation could fall back silently on a runtime without Swedish ICU data — the same wrong order, with nothing raising an alarm.

## Collation

`src/server/collation.ts` exports `compareSv()` over a shared `Intl.Collator('sv')` and `assertSwedishCollation()`, which verifies the runtime with literal comparisons (`z < å`, `å < ä`, `ä < ö`, `Jarl < Jämtlands`) instead of trusting `resolvedOptions()`.

`src/server/party-data.ts` sorts both parties and counties with `compareSv`. Parties with an identical `beteckning` fall back on `filnamn` as an explicit secondary key, so the order is deterministic even for duplicates. `createPartyDataStore` takes an injectable `assertCollation` guard that `assertHealthy()` calls, which makes `/api/health` answer 500 on a runtime without Swedish collation. `src/pages/api/health.ts` logs the caught error before responding, so a failed health check during deploy names its cause in the journal.

## Tests

The home fixture in `scripts/party-data.test.js` is deliberately unsorted and covers the whole invariant: Jarl before Jämtlands Väl, Z before Å before Ä before Ö, two parties sharing `Kommunens Väl` to lock the `filnamn` tiebreak, and Örebro län before Östergötlands län. One case injects a throwing guard and shows that `assertHealthy()` really calls it.

`scripts/http-smoke.js` runs the collation invariants first, computes the expected first page of 48 parties from `data/parti/index.json`, picks the `/parti/<filnamn>` links out of the party grid in document order and checks both the count and the exact order.

Sabotage check: remove the production sorting and both `npm test` and `npm run test:http` fail, and the smoke diff shows precisely the reported bug — `akta-demokrati` and `aldre-men-ej-gamla-i-bjuv` among the As.

Verified against real data in the release artifact: Jarl at index 226 and Jämtlands Väl at 235; `Åtvidabergs Framtid → Äkta demokrati → Älska Svedala → Öarnasväl`; the county list ends `Örebro län, Östergötlands län`.

## Departure from the plan

`tsconfig.json` has gained `allowImportingTsExtensions: true`. `scripts/party-data.test.js` loads `src/server/party-data.ts` directly under Node's type stripping, and Node's ESM resolver then requires an explicit `.ts` in the relative import of `./collation.ts` — which `tsc` rejects without the flag. `noEmit: true` is already set, so the flag is valid; lint, typecheck and build are green.

Side effect: `node --test` now prints a `MODULE_TYPELESS_PACKAGE_JSON` warning for `collation.ts`, because the root `package.json` has no `"type"` field (`scripts/` is CommonJS). The warning exists only in the test output, not in the build or in production, and is not silenced with `--disable-warning`.

## Letter grouping

The issue asks for Å, Ä and Ö as letter groups of their own. The merged start page shows a flat list labelled "Sorterat A–Ö" with no letter groups at all, so no grouping has been reintroduced. That the flat list satisfies the issue is the planning agent's interpretation, not a decision taken — say the word if the grouping should come back, and it becomes a piece of work of its own.

## To know before release

Merging is not releasing. partidata.se keeps the wrong order until `main` is tagged `v*` and the deploy runs. Check production's Node once before the tag — the deploy rsyncs and restarts *before* the health check, so a runtime without Swedish ICU data would mean the wrongly sorted artifact is already live when the job goes red.

Closes #54
