### PR TITLE
Finish sitemap, language and canonical (#22)

### DIFF
--- a/scripts/http-smoke.js
+++ b/scripts/http-smoke.js
@@ -91,6 +91,7 @@ async function main () {
     assert.equal(home.status, 200);
     const homeBody = await home.text();
     assert.match(homeBody, /<title[^>]*>Partidata<\/title>/);
+    assert.match(homeBody, /<link rel="canonical" href="https:\/\/www\.partidata\.se\/"[^>]*>/);
     assert.match(homeBody, /Sök parti på namn eller förkortning/);
     assert.match(homeBody, /Alla partier/, 'partilistan har en rubrik');
     assert.match(homeBody, new RegExp(`>${parties.length}</span>`), 'rubriken räknar partierna ur datan');

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,6 +14,7 @@ const HomePage: NextPage<HomeData> = props => {
         <title>Partidata</title>
         <meta name="description" content="Öppen data om politiska partier i Sverige" />
         <link rel="icon" href="/img/partidata/mark.svg" type="image/svg+xml" />
+        <link rel="canonical" href="https://www.partidata.se/" />
       </Head>
 
       <Header />


### PR DESCRIPTION
## Summary

- adds a canonical URL to the start page
- verifies the canonical link in the HTTP smoke test
- the sitemap, `lang=sv` and canonical on party pages were already in place from the server-rendered deployment

Closes #22

## Verification

- `npm run precommit`
