### PR TITLE
Clarify the start page intro after the election result ranking

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,7 +24,7 @@ const HomePage: NextPage<HomeData> = props => {
           <p className="description">
             Partidata samlar uppgifter från Valmyndigheten om partibeteckningar,
             tidigare namn och anmält deltagande i riksdags-, region- och kommunval.
-            Ingen värdering, ingen rangordning — bara källhänvisad data.
+            Ingen partipolitisk värdering — bara källhänvisad data.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

- replaces the now misleading wording "ingen rangordning" with "ingen partipolitisk värdering"
- keeps the emphasis on sourced data

## Verification

- `npm run precommit`
