### PR TITLE
Normalise party symbols and rebuild the start page cards and filters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,12 @@ Open data about Swedish political parties. Swedish copy.
   `deltagande-partier.csv` from `data.val.se`, writes
   `data/val/<år>/partideltagande/` and reconciles `data/parti/`;
   `npm run import-partisymboler -- <år> [--file <zip>] [--legacy-dir <dir>]`
-  imports code-and-name-labelled PNG party symbols into each party directory
-  and records their provenance in `partisymbol`;
+  imports code-and-name-labelled PNG party symbols into each party directory,
+  records their provenance in `partisymbol` and measures each file into
+  `partisymbol.bild`/`partisymbol.bildyta` — the sheet the symbol was delivered
+  on and the box its drawing occupies, which is how the site shows every symbol
+  at the same optical size; `npm run measure-partisymboler` re-measures the
+  already committed symbols without re-importing them;
   `node scripts/parti.js` rebuilds the registry from `data/` alone. Results are
   committed to `data/`. Paths resolve from the repo root, so the scripts run
   from any directory. `npm run validate:data` checks the committed data tree;

--- a/README.md
+++ b/README.md
@@ -72,19 +72,43 @@ Fyra filer per valår, skrivna av `npm run import-val`:
 | `region.json` | En post per län som har anmälda partier, med länets partier |
 | `kommun.json` | Alla 290 kommuner, med kommunens partier (tom lista när inga finns) |
 
-Partiposterna i `riksdag.json`, `region.json` och `kommun.json` har ett `grunder`-fält med Valmyndighetens `DELTAGANDEGRUND` oförändrad. Ett parti kan ha flera anmälningar för samma valområde, med olika grund och olika datum, och då listas alla: de åtta riksdagspartierna har till exempel både `R` och `K` i riksdagsvalet 2026. `R` och `K` förekommer i stort sett bara för partier med registrerad partibeteckning. Vad bokstäverna står för framgår inte av filen — se Valmyndighetens beskrivning av anmälan om deltagande nedan.
+Partiposterna i `riksdag.json`, `region.json` och `kommun.json` har ett `grunder`-fält med Valmyndighetens `DELTAGANDEGRUND` oförändrad. Ett parti kan ha flera anmälningar för samma valområde, med olika grund och olika datum, och då listas alla: de åtta riksdagspartierna har till exempel både `R` och `K` i riksdagsvalet 2026. `R` och `K` förekommer i stort sett bara för partier med registrerad partibeteckning.
+
+Bokstäverna förklaras inte i filen. Valmyndigheten beskriver dem så här:
+
+| Grund | Valmyndighetens formulering |
+|-------|------------------------------|
+| `A` | Anmält deltagande |
+| `R` | Redan representerad, anses anmält deltagande |
+| `K` | Anmält kandidater och anses genom det anmält deltagande |
+
+Alla tre betyder att partiet deltar i valet i det valområdet; de skiljer sig bara i hur partiet kvalificerade sig. Källa: [Partier som deltar i val](https://www.val.se/stalla-upp-i-val/anmalda-och-registrerade-partier/partier-som-deltar-i-kommande-val).
+
+Valmyndigheten beskriver också en anmälans räckvidd:
 
 > Om ett parti anmäler deltagande i val till riksdagen gäller anmälan också för:
 > * val till region- och kommunfullmäktige i hela landet och,
 > * nästa kommande val till Europaparlamentet.
 
-Läs mer på: https://www.val.se/for-partier/anmal-deltagande.html
+Läs mer på: https://www.val.se/stalla-upp-i-val/anmala-parti-till-val/anmal-att-partiet-vill-delta-i-val
+
+Filen låter sig inte läsas som en tillämpning av den regeln, så räkna inte med den när du tolkar raderna. I 2026 års fil har 156 partier `A` i riksdagsvalet, varav 115 finns i alla 290 kommuner och 41 i mellan 0 och 287; samtidigt finns sju partier i alla 290 kommuner utan att ha `A` i riksdagsvalet. Vänsterpartiet (285 kommuner) och Miljöpartiet (278) saknas i enskilda kommuner helt och hållet. Filen skiljer alltså inte på en egen anmälan per valområde och en anmälan som gäller vidare.
 
 2018 års filer ligger kvar som de samlades in: `landsting.json` i stället för `region.json`, inget `partier.json`, 208 av 290 kommuner i `kommun.json`, och region- och kommunfilerna listar bara partier som inte finns i `riksdag.json`.
 
 ### val/\<år\>/kandidatlistor/\<parti.filnamn\>.json
 
-Kandidatlistor per parti i alla val för angivna året. För tillfället endast ett utkast.
+Kandidatlistor per parti i alla val för angivna året. För tillfället endast ett utkast. Fältet `val` anger valtypen med `R` för riksdag, `L` för landsting (region) och `K` för kommun.
+
+### Bokstavskoder i datan
+
+Tre kodsystem möts i `data/val/`, och `R` och `K` betyder olika saker i två av dem. Läs alltid koden mot filen den står i:
+
+| Var | Koder | Betyder |
+|-----|-------|---------|
+| `partideltagande/*.json` → `grunder` | `A` `R` `K` | anmält deltagande · redan representerad · anmält kandidater |
+| `kandidatlistor/*.json` → `val` | `R` `L` `K` | riksdag · landsting (region) · kommun |
+| Källans CSV → `VALTYP` | `RD` `RF` `KF` | riksdag · regionfullmäktige · kommunfullmäktige |
 
 ### val/\<år\>/valresultat/riksdag.json
 

--- a/data/parti/99-svarta-ballonger/index.json
+++ b/data/parti/99-svarta-ballonger/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1806"
+    "partikod": "1806",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 1,
+      "y": 5,
+      "bredd": 1025,
+      "hojd": 144
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/aktiv-samling-bodenalternativet/index.json
+++ b/data/parti/aktiv-samling-bodenalternativet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1373"
+    "partikod": "1373",
+    "bild": {
+      "bredd": 2138,
+      "hojd": 320
+    },
+    "bildyta": {
+      "x": 505,
+      "y": 15,
+      "bredd": 1102,
+      "hojd": 299
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/ale-demokraterna/index.json
+++ b/data/parti/ale-demokraterna/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/0139.png",
     "valar": 2019,
-    "partikod": "0139"
+    "partikod": "0139",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 209,
+      "y": 12,
+      "bredd": 608,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/alska-svedala/index.json
+++ b/data/parti/alska-svedala/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1379"
+    "partikod": "1379",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 296,
+      "y": 0,
+      "bredd": 433,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/alternativ-for-sverige/index.json
+++ b/data/parti/alternativ-for-sverige/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1325"
+    "partikod": "1325",
+    "bild": {
+      "bredd": 2139,
+      "hojd": 320
+    },
+    "bildyta": {
+      "x": 606,
+      "y": 26,
+      "bredd": 1012,
+      "hojd": 280
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/alternative-for-immigrants/index.json
+++ b/data/parti/alternative-for-immigrants/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1753"
+    "partikod": "1753",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 8,
+      "y": 1,
+      "bredd": 1010,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/alternativet/index.json
+++ b/data/parti/alternativet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1284"
+    "partikod": "1284",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 0,
+      "bredd": 1026,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/alvesta-alternativet/index.json
+++ b/data/parti/alvesta-alternativet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0124"
+    "partikod": "0124",
+    "bild": {
+      "bredd": 2138,
+      "hojd": 320
+    },
+    "bildyta": {
+      "x": 117,
+      "y": 58,
+      "bredd": 1925,
+      "hojd": 182
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/alvestademokraterna/index.json
+++ b/data/parti/alvestademokraterna/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1445"
+    "partikod": "1445",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 58,
+      "y": 1,
+      "bredd": 968,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/ambition-sverige/index.json
+++ b/data/parti/ambition-sverige/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1729"
+    "partikod": "1729",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 297,
+      "y": 0,
+      "bredd": 431,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/amoristerna/index.json
+++ b/data/parti/amoristerna/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1662"
+    "partikod": "1662",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 1,
+      "bredd": 1026,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/ansvar-i-samverkan/index.json
+++ b/data/parti/ansvar-i-samverkan/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1763"
+    "partikod": "1763",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 381,
+      "y": 2,
+      "bredd": 266,
+      "hojd": 149
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/anti-auktoritara-aktions-partiet/index.json
+++ b/data/parti/anti-auktoritara-aktions-partiet/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1817"
+    "partikod": "1817",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 457,
+      "y": 0,
+      "bredd": 115,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/arbetarepartiet-socialdemokraterna/index.json
+++ b/data/parti/arbetarepartiet-socialdemokraterna/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0002"
+    "partikod": "0002",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 639
+    },
+    "bildyta": {
+      "x": 83,
+      "y": 53,
+      "bredd": 4088,
+      "hojd": 540
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/arvikapartiet/index.json
+++ b/data/parti/arvikapartiet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1521"
+    "partikod": "1521",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 192,
+      "y": 0,
+      "bredd": 643,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/atvidabergs-framtid/index.json
+++ b/data/parti/atvidabergs-framtid/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1738"
+    "partikod": "1738",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 338,
+      "y": 0,
+      "bredd": 350,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/balstapartiet/index.json
+++ b/data/parti/balstapartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0184"
+    "partikod": "0184",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 140,
+      "y": 12,
+      "bredd": 747,
+      "hojd": 130
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/barapartiet/index.json
+++ b/data/parti/barapartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1310"
+    "partikod": "1310",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 29,
+      "y": 5,
+      "bredd": 967,
+      "hojd": 122
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/basta-alternativet/index.json
+++ b/data/parti/basta-alternativet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1366"
+    "partikod": "1366",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 167,
+      "y": 2,
+      "bredd": 693,
+      "hojd": 150
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/battre-vellinge/index.json
+++ b/data/parti/battre-vellinge/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1708"
+    "partikod": "1708",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 118,
+      "y": 4,
+      "bredd": 789,
+      "hojd": 146
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/bergshamrapartiet/index.json
+++ b/data/parti/bergshamrapartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1105.png",
     "valar": 2019,
-    "partikod": "1105"
+    "partikod": "1105",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 13,
+      "y": 20,
+      "bredd": 1000,
+      "hojd": 113
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/bergspartiet/index.json
+++ b/data/parti/bergspartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1597"
+    "partikod": "1597",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 639
+    },
+    "bildyta": {
+      "x": 1023,
+      "y": 9,
+      "bredd": 2191,
+      "hojd": 623
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/bjarepartiet/index.json
+++ b/data/parti/bjarepartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0163"
+    "partikod": "0163",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 0,
+      "bredd": 1026,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/borlangepartiet/index.json
+++ b/data/parti/borlangepartiet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1793"
+    "partikod": "1793",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 333,
+      "y": 0,
+      "bredd": 359,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/brobyggarpartiet/index.json
+++ b/data/parti/brobyggarpartiet/index.json
@@ -14,7 +14,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1497"
+    "partikod": "1497",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 1158,
+      "y": 6,
+      "bredd": 1997,
+      "hojd": 628
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/bygdepartiet/index.json
+++ b/data/parti/bygdepartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1053"
+    "partikod": "1053",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 176,
+      "y": 0,
+      "bredd": 592,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/centerpartiet/index.json
+++ b/data/parti/centerpartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0004"
+    "partikod": "0004",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 166,
+      "y": 8,
+      "bredd": 3826,
+      "hojd": 621
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/civis/index.json
+++ b/data/parti/civis/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1884"
+    "partikod": "1884",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 388,
+      "y": 1,
+      "bredd": 251,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/dalademokraterna/index.json
+++ b/data/parti/dalademokraterna/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1562"
+    "partikod": "1562",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 639
+    },
+    "bildyta": {
+      "x": 519,
+      "y": 93,
+      "bredd": 3194,
+      "hojd": 453
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/de-oberoende-i-torsby/index.json
+++ b/data/parti/de-oberoende-i-torsby/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1522"
+    "partikod": "1522",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 888,
+      "y": 24,
+      "bredd": 2513,
+      "hojd": 599
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/demokraterna/index.json
+++ b/data/parti/demokraterna/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1297"
+    "partikod": "1297",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 5,
+      "y": 1,
+      "bredd": 1016,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/demokratiresan/index.json
+++ b/data/parti/demokratiresan/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1490"
+    "partikod": "1490",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 221,
+      "y": 16,
+      "bredd": 582,
+      "hojd": 127
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/demokratisk-rattvisa/index.json
+++ b/data/parti/demokratisk-rattvisa/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1331.png",
     "valar": 2019,
-    "partikod": "1331"
+    "partikod": "1331",
+    "bild": {
+      "bredd": 243,
+      "hojd": 38
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 0,
+      "bredd": 243,
+      "hojd": 38
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/demokratiska-sekulara-socialister-arbetarpartiet/index.json
+++ b/data/parti/demokratiska-sekulara-socialister-arbetarpartiet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1180"
+    "partikod": "1180",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 4,
+      "y": 0,
+      "bredd": 1018,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/din-makt/index.json
+++ b/data/parti/din-makt/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1748"
+    "partikod": "1748",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 309,
+      "y": 0,
+      "bredd": 413,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/direktdemokraterna/index.json
+++ b/data/parti/direktdemokraterna/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1150"
+    "partikod": "1150",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 86,
+      "y": 7,
+      "bredd": 848,
+      "hojd": 133
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/djurens-parti/index.json
+++ b/data/parti/djurens-parti/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1136.png",
     "valar": 2019,
-    "partikod": "1136"
+    "partikod": "1136",
+    "bild": {
+      "bredd": 1027,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 148,
+      "y": 2,
+      "bredd": 716,
+      "hojd": 150
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/dorotea-kommunlista/index.json
+++ b/data/parti/dorotea-kommunlista/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0187"
+    "partikod": "0187",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 56,
+      "y": 10,
+      "bredd": 914,
+      "hojd": 133
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/drevvikenpartiet/index.json
+++ b/data/parti/drevvikenpartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0122"
+    "partikod": "0122",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 44,
+      "y": 12,
+      "bredd": 938,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/edetlistan/index.json
+++ b/data/parti/edetlistan/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1552"
+    "partikod": "1552",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 639
+    },
+    "bildyta": {
+      "x": 905,
+      "y": 79,
+      "bredd": 2550,
+      "hojd": 504
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/ekeropartiet/index.json
+++ b/data/parti/ekeropartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1481"
+    "partikod": "1481",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 140,
+      "y": 4,
+      "bredd": 731,
+      "hojd": 144
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/elbira-partiet/index.json
+++ b/data/parti/elbira-partiet/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1900"
+    "partikod": "1900",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 491,
+      "y": 0,
+      "bredd": 45,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/empartiet/index.json
+++ b/data/parti/empartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1333"
+    "partikod": "1333",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 257,
+      "y": 15,
+      "bredd": 512,
+      "hojd": 124
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/en-vis-avskaffar-asylratten/index.json
+++ b/data/parti/en-vis-avskaffar-asylratten/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1482"
+    "partikod": "1482",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 3,
+      "bredd": 1026,
+      "hojd": 148
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/enad-rost/index.json
+++ b/data/parti/enad-rost/index.json
@@ -17,7 +17,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0532"
+    "partikod": "0532",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 18,
+      "y": 0,
+      "bredd": 990,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/enade-sverige/index.json
+++ b/data/parti/enade-sverige/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1448"
+    "partikod": "1448",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 128,
+      "y": 0,
+      "bredd": 770,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/enhet/index.json
+++ b/data/parti/enhet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0189"
+    "partikod": "0189",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 272,
+      "y": 6,
+      "bredd": 324,
+      "hojd": 141
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/eskilstunaborna/index.json
+++ b/data/parti/eskilstunaborna/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1840"
+    "partikod": "1840",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 27,
+      "bredd": 1026,
+      "hojd": 100
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/familjens-frihet/index.json
+++ b/data/parti/familjens-frihet/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1606"
+    "partikod": "1606",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 905,
+      "y": 23,
+      "bredd": 2384,
+      "hojd": 591
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/feministerna-gullspang/index.json
+++ b/data/parti/feministerna-gullspang/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1815"
+    "partikod": "1815",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 436,
+      "y": 0,
+      "bredd": 154,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/feministerna-och-kommunisterna/index.json
+++ b/data/parti/feministerna-och-kommunisterna/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1822"
+    "partikod": "1822",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 10,
+      "y": 1,
+      "bredd": 1006,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/fokus/index.json
+++ b/data/parti/fokus/index.json
@@ -18,7 +18,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1344"
+    "partikod": "1344",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 250,
+      "y": 0,
+      "bredd": 526,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/folkets-rost/index.json
+++ b/data/parti/folkets-rost/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1265"
+    "partikod": "1265",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 1260,
+      "y": 21,
+      "bredd": 1609,
+      "hojd": 595
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/folkets-val/index.json
+++ b/data/parti/folkets-val/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0126"
+    "partikod": "0126",
+    "bild": {
+      "bredd": 1027,
+      "hojd": 154
+    },
+    "bildyta": {
+      "x": 17,
+      "y": 18,
+      "bredd": 995,
+      "hojd": 112
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/folkinitiativet-arjeplog/index.json
+++ b/data/parti/folkinitiativet-arjeplog/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1514"
+    "partikod": "1514",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 1668,
+      "y": 13,
+      "bredd": 806,
+      "hojd": 615
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/folklistan/index.json
+++ b/data/parti/folklistan/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1659"
+    "partikod": "1659",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 16,
+      "bredd": 1026,
+      "hojd": 121
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/folkradet/index.json
+++ b/data/parti/folkradet/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1830"
+    "partikod": "1830",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 56,
+      "y": 0,
+      "bredd": 921,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/folkviljan-orust/index.json
+++ b/data/parti/folkviljan-orust/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0204"
+    "partikod": "0204",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 206,
+      "y": 8,
+      "bredd": 520,
+      "hojd": 138
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/foretaget-sverige/index.json
+++ b/data/parti/foretaget-sverige/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1510"
+    "partikod": "1510",
+    "bild": {
+      "bredd": 4275,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 4,
+      "y": 33,
+      "bredd": 4251,
+      "hojd": 548
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/fornyalund/index.json
+++ b/data/parti/fornyalund/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1135"
+    "partikod": "1135",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 162,
+      "y": 1,
+      "bredd": 702,
+      "hojd": 150
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/fram-for-kommunen/index.json
+++ b/data/parti/fram-for-kommunen/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1771"
+    "partikod": "1771",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 1,
+      "bredd": 1026,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/framatanda-i-en-nytankande-landsbygd/index.json
+++ b/data/parti/framatanda-i-en-nytankande-landsbygd/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1915"
+    "partikod": "1915",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 179,
+      "y": 0,
+      "bredd": 668,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/framtid-i-ale/index.json
+++ b/data/parti/framtid-i-ale/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1158"
+    "partikod": "1158",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 147,
+      "y": 3,
+      "bredd": 728,
+      "hojd": 147
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/framtid-i-kalix/index.json
+++ b/data/parti/framtid-i-kalix/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1164"
+    "partikod": "1164",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 639
+    },
+    "bildyta": {
+      "x": 1558,
+      "y": 18,
+      "bredd": 817,
+      "hojd": 591
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/framtid-oland/index.json
+++ b/data/parti/framtid-oland/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1142"
+    "partikod": "1142",
+    "bild": {
+      "bredd": 1027,
+      "hojd": 154
+    },
+    "bildyta": {
+      "x": 232,
+      "y": 3,
+      "bredd": 563,
+      "hojd": 148
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/framtidens-vanster/index.json
+++ b/data/parti/framtidens-vanster/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1795"
+    "partikod": "1795",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 63,
+      "y": 0,
+      "bredd": 900,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/framtidspartiet-i-lekeberg/index.json
+++ b/data/parti/framtidspartiet-i-lekeberg/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0997"
+    "partikod": "0997",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 11,
+      "y": 93,
+      "bredd": 4248,
+      "hojd": 466
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/framtidstro/index.json
+++ b/data/parti/framtidstro/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1449"
+    "partikod": "1449",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 313,
+      "y": 0,
+      "bredd": 400,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/fred-och-demokrati/index.json
+++ b/data/parti/fred-och-demokrati/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1903"
+    "partikod": "1903",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 448,
+      "y": 0,
+      "bredd": 131,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/freds-och-frihetspartier/index.json
+++ b/data/parti/freds-och-frihetspartier/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1731"
+    "partikod": "1731",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 89,
+      "y": 0,
+      "bredd": 848,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/fria-demokraterna/index.json
+++ b/data/parti/fria-demokraterna/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1280.png",
     "valar": 2019,
-    "partikod": "1280"
+    "partikod": "1280",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 146,
+      "y": 0,
+      "bredd": 740,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/fria-liberaler-i-flens-kommun/index.json
+++ b/data/parti/fria-liberaler-i-flens-kommun/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1821"
+    "partikod": "1821",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 435,
+      "y": 0,
+      "bredd": 155,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/fria-stockholmare/index.json
+++ b/data/parti/fria-stockholmare/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1156.png",
     "valar": 2019,
-    "partikod": "1156"
+    "partikod": "1156",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 49,
+      "y": 1,
+      "bredd": 928,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/fria-wermland/index.json
+++ b/data/parti/fria-wermland/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1548"
+    "partikod": "1548",
+    "bild": {
+      "bredd": 4275,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 183,
+      "y": 34,
+      "bredd": 3891,
+      "hojd": 586
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/fridslaget/index.json
+++ b/data/parti/fridslaget/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1765"
+    "partikod": "1765",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 401,
+      "y": 4,
+      "bredd": 224,
+      "hojd": 145
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/futurum-sverige/index.json
+++ b/data/parti/futurum-sverige/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1363.png",
     "valar": 2019,
-    "partikod": "1363"
+    "partikod": "1363",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 308,
+      "y": 1,
+      "bredd": 410,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/globala-partiet/index.json
+++ b/data/parti/globala-partiet/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1653"
+    "partikod": "1653",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 228,
+      "y": 0,
+      "bredd": 570,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/gotenes-framtid/index.json
+++ b/data/parti/gotenes-framtid/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0094"
+    "partikod": "0094",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 242,
+      "y": 1,
+      "bredd": 542,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/granskning-jarfalla/index.json
+++ b/data/parti/granskning-jarfalla/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1567"
+    "partikod": "1567",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 205,
+      "y": 77,
+      "bredd": 3747,
+      "hojd": 462
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/habodemokraterna-1532/index.json
+++ b/data/parti/habodemokraterna-1532/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1532"
+    "partikod": "1532",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 11,
+      "bredd": 1026,
+      "hojd": 131
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/habodemokraterna/index.json
+++ b/data/parti/habodemokraterna/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1287"
+    "partikod": "1287",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 176,
+      "y": 0,
+      "bredd": 674,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/halleforspartiet/index.json
+++ b/data/parti/halleforspartiet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1860"
+    "partikod": "1860",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 167,
+      "y": 4,
+      "bredd": 693,
+      "hojd": 146
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/halmstadpartiet/index.json
+++ b/data/parti/halmstadpartiet/index.json
@@ -17,7 +17,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1563"
+    "partikod": "1563",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 167,
+      "y": 0,
+      "bredd": 692,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/haningepartiet/index.json
+++ b/data/parti/haningepartiet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1272.png",
     "valar": 2019,
-    "partikod": "1272"
+    "partikod": "1272",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 172,
+      "y": 0,
+      "bredd": 681,
+      "hojd": 137
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/hela-edas-lista/index.json
+++ b/data/parti/hela-edas-lista/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0160"
+    "partikod": "0160",
+    "bild": {
+      "bredd": 4275,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 300,
+      "y": 21,
+      "bredd": 3721,
+      "hojd": 588
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/helmjolksinitiativet/index.json
+++ b/data/parti/helmjolksinitiativet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1728"
+    "partikod": "1728",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 0,
+      "bredd": 1026,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/helsingborgspartiet/index.json
+++ b/data/parti/helsingborgspartiet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1789"
+    "partikod": "1789",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 30,
+      "bredd": 1026,
+      "hojd": 95
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/herrljunga-partiet/index.json
+++ b/data/parti/herrljunga-partiet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1797"
+    "partikod": "1797",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 3,
+      "y": 7,
+      "bredd": 1023,
+      "hojd": 139
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/horbys-framtid/index.json
+++ b/data/parti/horbys-framtid/index.json
@@ -17,7 +17,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1587"
+    "partikod": "1587",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 16,
+      "y": 0,
+      "bredd": 994,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/huddingepartiet/index.json
+++ b/data/parti/huddingepartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0028"
+    "partikod": "0028",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 25,
+      "y": 7,
+      "bredd": 975,
+      "hojd": 138
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/index.json
+++ b/data/parti/index.json
@@ -16,7 +16,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1806"
+      "partikod": "1806",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 1,
+        "y": 5,
+        "bredd": 1025,
+        "hojd": 144
+      }
     }
   },
   {
@@ -40,7 +50,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1373"
+      "partikod": "1373",
+      "bild": {
+        "bredd": 2138,
+        "hojd": 320
+      },
+      "bildyta": {
+        "x": 505,
+        "y": 15,
+        "bredd": 1102,
+        "hojd": 299
+      }
     }
   },
   {
@@ -60,7 +80,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/0139.png",
       "valar": 2019,
-      "partikod": "0139"
+      "partikod": "0139",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 209,
+        "y": 12,
+        "bredd": 608,
+        "hojd": 129
+      }
     }
   },
   {
@@ -91,7 +121,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1379"
+      "partikod": "1379",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 296,
+        "y": 0,
+        "bredd": 433,
+        "hojd": 153
+      }
     }
   },
   {
@@ -116,7 +156,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1325"
+      "partikod": "1325",
+      "bild": {
+        "bredd": 2139,
+        "hojd": 320
+      },
+      "bildyta": {
+        "x": 606,
+        "y": 26,
+        "bredd": 1012,
+        "hojd": 280
+      }
     }
   },
   {
@@ -134,7 +184,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1753"
+      "partikod": "1753",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 8,
+        "y": 1,
+        "bredd": 1010,
+        "hojd": 151
+      }
     }
   },
   {
@@ -148,7 +208,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1284"
+      "partikod": "1284",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 0,
+        "bredd": 1026,
+        "hojd": 153
+      }
     }
   },
   {
@@ -169,7 +239,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0124"
+      "partikod": "0124",
+      "bild": {
+        "bredd": 2138,
+        "hojd": 320
+      },
+      "bildyta": {
+        "x": 117,
+        "y": 58,
+        "bredd": 1925,
+        "hojd": 182
+      }
     }
   },
   {
@@ -183,7 +263,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1445"
+      "partikod": "1445",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 58,
+        "y": 1,
+        "bredd": 968,
+        "hojd": 151
+      }
     }
   },
   {
@@ -195,7 +285,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1729"
+      "partikod": "1729",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 297,
+        "y": 0,
+        "bredd": 431,
+        "hojd": 153
+      }
     }
   },
   {
@@ -208,7 +308,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1662"
+      "partikod": "1662",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 1,
+        "bredd": 1026,
+        "hojd": 152
+      }
     }
   },
   {
@@ -237,7 +347,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1763"
+      "partikod": "1763",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 381,
+        "y": 2,
+        "bredd": 266,
+        "hojd": 149
+      }
     }
   },
   {
@@ -255,7 +375,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1817"
+      "partikod": "1817",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 457,
+        "y": 0,
+        "bredd": 115,
+        "hojd": 152
+      }
     }
   },
   {
@@ -273,7 +403,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0002"
+      "partikod": "0002",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 639
+      },
+      "bildyta": {
+        "x": 83,
+        "y": 53,
+        "bredd": 4088,
+        "hojd": 540
+      }
     }
   },
   {
@@ -292,7 +432,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1521"
+      "partikod": "1521",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 192,
+        "y": 0,
+        "bredd": 643,
+        "hojd": 153
+      }
     }
   },
   {
@@ -335,7 +485,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1738"
+      "partikod": "1738",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 338,
+        "y": 0,
+        "bredd": 350,
+        "hojd": 153
+      }
     }
   },
   {
@@ -349,7 +509,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0184"
+      "partikod": "0184",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 140,
+        "y": 12,
+        "bredd": 747,
+        "hojd": 130
+      }
     }
   },
   {
@@ -363,7 +533,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1310"
+      "partikod": "1310",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 29,
+        "y": 5,
+        "bredd": 967,
+        "hojd": 122
+      }
     }
   },
   {
@@ -398,7 +578,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1366"
+      "partikod": "1366",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 167,
+        "y": 2,
+        "bredd": 693,
+        "hojd": 150
+      }
     }
   },
   {
@@ -416,7 +606,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1708"
+      "partikod": "1708",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 118,
+        "y": 4,
+        "bredd": 789,
+        "hojd": 146
+      }
     }
   },
   {
@@ -430,7 +630,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1105.png",
       "valar": 2019,
-      "partikod": "1105"
+      "partikod": "1105",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 13,
+        "y": 20,
+        "bredd": 1000,
+        "hojd": 113
+      }
     }
   },
   {
@@ -444,7 +654,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1597"
+      "partikod": "1597",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 639
+      },
+      "bildyta": {
+        "x": 1023,
+        "y": 9,
+        "bredd": 2191,
+        "hojd": 623
+      }
     }
   },
   {
@@ -469,7 +689,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0163"
+      "partikod": "0163",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 0,
+        "bredd": 1026,
+        "hojd": 153
+      }
     }
   },
   {
@@ -546,7 +776,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1793"
+      "partikod": "1793",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 333,
+        "y": 0,
+        "bredd": 359,
+        "hojd": 153
+      }
     }
   },
   {
@@ -566,7 +806,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1497"
+      "partikod": "1497",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 1158,
+        "y": 6,
+        "bredd": 1997,
+        "hojd": 628
+      }
     }
   },
   {
@@ -586,7 +836,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1053"
+      "partikod": "1053",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 176,
+        "y": 0,
+        "bredd": 592,
+        "hojd": 153
+      }
     }
   },
   {
@@ -599,7 +859,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0004"
+      "partikod": "0004",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 166,
+        "y": 8,
+        "bredd": 3826,
+        "hojd": 621
+      }
     }
   },
   {
@@ -611,7 +881,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1884"
+      "partikod": "1884",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 388,
+        "y": 1,
+        "bredd": 251,
+        "hojd": 152
+      }
     }
   },
   {
@@ -631,7 +911,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1562"
+      "partikod": "1562",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 639
+      },
+      "bildyta": {
+        "x": 519,
+        "y": 93,
+        "bredd": 3194,
+        "hojd": 453
+      }
     }
   },
   {
@@ -670,7 +960,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1522"
+      "partikod": "1522",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 888,
+        "y": 24,
+        "bredd": 2513,
+        "hojd": 599
+      }
     }
   },
   {
@@ -684,7 +984,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1297"
+      "partikod": "1297",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 5,
+        "y": 1,
+        "bredd": 1016,
+        "hojd": 151
+      }
     }
   },
   {
@@ -736,7 +1046,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1490"
+      "partikod": "1490",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 221,
+        "y": 16,
+        "bredd": 582,
+        "hojd": 127
+      }
     }
   },
   {
@@ -755,7 +1075,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1331.png",
       "valar": 2019,
-      "partikod": "1331"
+      "partikod": "1331",
+      "bild": {
+        "bredd": 243,
+        "hojd": 38
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 0,
+        "bredd": 243,
+        "hojd": 38
+      }
     }
   },
   {
@@ -774,7 +1104,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1180"
+      "partikod": "1180",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 4,
+        "y": 0,
+        "bredd": 1018,
+        "hojd": 153
+      }
     }
   },
   {
@@ -822,7 +1162,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1748"
+      "partikod": "1748",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 309,
+        "y": 0,
+        "bredd": 413,
+        "hojd": 153
+      }
     }
   },
   {
@@ -835,7 +1185,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1150"
+      "partikod": "1150",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 86,
+        "y": 7,
+        "bredd": 848,
+        "hojd": 133
+      }
     }
   },
   {
@@ -848,7 +1208,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1136.png",
       "valar": 2019,
-      "partikod": "1136"
+      "partikod": "1136",
+      "bild": {
+        "bredd": 1027,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 148,
+        "y": 2,
+        "bredd": 716,
+        "hojd": 150
+      }
     }
   },
   {
@@ -873,7 +1243,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0187"
+      "partikod": "0187",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 56,
+        "y": 10,
+        "bredd": 914,
+        "hojd": 133
+      }
     }
   },
   {
@@ -887,7 +1267,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0122"
+      "partikod": "0122",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 44,
+        "y": 12,
+        "bredd": 938,
+        "hojd": 129
+      }
     }
   },
   {
@@ -906,7 +1296,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1552"
+      "partikod": "1552",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 639
+      },
+      "bildyta": {
+        "x": 905,
+        "y": 79,
+        "bredd": 2550,
+        "hojd": 504
+      }
     }
   },
   {
@@ -920,7 +1320,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1481"
+      "partikod": "1481",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 140,
+        "y": 4,
+        "bredd": 731,
+        "hojd": 144
+      }
     }
   },
   {
@@ -937,7 +1347,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1900"
+      "partikod": "1900",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 491,
+        "y": 0,
+        "bredd": 45,
+        "hojd": 152
+      }
     }
   },
   {
@@ -951,7 +1371,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1333"
+      "partikod": "1333",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 257,
+        "y": 15,
+        "bredd": 512,
+        "hojd": 124
+      }
     }
   },
   {
@@ -969,7 +1399,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1482"
+      "partikod": "1482",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 3,
+        "bredd": 1026,
+        "hojd": 148
+      }
     }
   },
   {
@@ -990,7 +1430,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0532"
+      "partikod": "0532",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 18,
+        "y": 0,
+        "bredd": 990,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1002,7 +1452,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1448"
+      "partikod": "1448",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 128,
+        "y": 0,
+        "bredd": 770,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1022,7 +1482,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0189"
+      "partikod": "0189",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 272,
+        "y": 6,
+        "bredd": 324,
+        "hojd": 141
+      }
     }
   },
   {
@@ -1055,7 +1525,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1840"
+      "partikod": "1840",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 27,
+        "bredd": 1026,
+        "hojd": 100
+      }
     }
   },
   {
@@ -1122,7 +1602,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1606"
+      "partikod": "1606",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 905,
+        "y": 23,
+        "bredd": 2384,
+        "hojd": 591
+      }
     }
   },
   {
@@ -1151,7 +1641,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1815"
+      "partikod": "1815",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 436,
+        "y": 0,
+        "bredd": 154,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1164,7 +1664,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1822"
+      "partikod": "1822",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 10,
+        "y": 1,
+        "bredd": 1006,
+        "hojd": 151
+      }
     }
   },
   {
@@ -1205,7 +1715,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1344"
+      "partikod": "1344",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 250,
+        "y": 0,
+        "bredd": 526,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1236,7 +1756,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1265"
+      "partikod": "1265",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 1260,
+        "y": 21,
+        "bredd": 1609,
+        "hojd": 595
+      }
     }
   },
   {
@@ -1250,7 +1780,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0126"
+      "partikod": "0126",
+      "bild": {
+        "bredd": 1027,
+        "hojd": 154
+      },
+      "bildyta": {
+        "x": 17,
+        "y": 18,
+        "bredd": 995,
+        "hojd": 112
+      }
     }
   },
   {
@@ -1280,7 +1820,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1514"
+      "partikod": "1514",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 1668,
+        "y": 13,
+        "bredd": 806,
+        "hojd": 615
+      }
     }
   },
   {
@@ -1299,7 +1849,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1659"
+      "partikod": "1659",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 16,
+        "bredd": 1026,
+        "hojd": 121
+      }
     }
   },
   {
@@ -1316,7 +1876,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1830"
+      "partikod": "1830",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 56,
+        "y": 0,
+        "bredd": 921,
+        "hojd": 151
+      }
     }
   },
   {
@@ -1335,7 +1905,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0204"
+      "partikod": "0204",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 206,
+        "y": 8,
+        "bredd": 520,
+        "hojd": 138
+      }
     }
   },
   {
@@ -1357,7 +1937,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1510"
+      "partikod": "1510",
+      "bild": {
+        "bredd": 4275,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 4,
+        "y": 33,
+        "bredd": 4251,
+        "hojd": 548
+      }
     }
   },
   {
@@ -1377,7 +1967,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1135"
+      "partikod": "1135",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 162,
+        "y": 1,
+        "bredd": 702,
+        "hojd": 150
+      }
     }
   },
   {
@@ -1396,7 +1996,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1771"
+      "partikod": "1771",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 1,
+        "bredd": 1026,
+        "hojd": 151
+      }
     }
   },
   {
@@ -1409,7 +2019,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1915"
+      "partikod": "1915",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 179,
+        "y": 0,
+        "bredd": 668,
+        "hojd": 152
+      }
     }
   },
   {
@@ -1441,7 +2061,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1158"
+      "partikod": "1158",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 147,
+        "y": 3,
+        "bredd": 728,
+        "hojd": 147
+      }
     }
   },
   {
@@ -1462,7 +2092,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1164"
+      "partikod": "1164",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 639
+      },
+      "bildyta": {
+        "x": 1558,
+        "y": 18,
+        "bredd": 817,
+        "hojd": 591
+      }
     }
   },
   {
@@ -1489,7 +2129,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1142"
+      "partikod": "1142",
+      "bild": {
+        "bredd": 1027,
+        "hojd": 154
+      },
+      "bildyta": {
+        "x": 232,
+        "y": 3,
+        "bredd": 563,
+        "hojd": 148
+      }
     }
   },
   {
@@ -1515,7 +2165,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1795"
+      "partikod": "1795",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 63,
+        "y": 0,
+        "bredd": 900,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1529,7 +2189,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0997"
+      "partikod": "0997",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 11,
+        "y": 93,
+        "bredd": 4248,
+        "hojd": 466
+      }
     }
   },
   {
@@ -1547,7 +2217,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1449"
+      "partikod": "1449",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 313,
+        "y": 0,
+        "bredd": 400,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1559,7 +2239,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1903"
+      "partikod": "1903",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 448,
+        "y": 0,
+        "bredd": 131,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1571,7 +2261,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1731"
+      "partikod": "1731",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 89,
+        "y": 0,
+        "bredd": 848,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1590,7 +2290,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1280.png",
       "valar": 2019,
-      "partikod": "1280"
+      "partikod": "1280",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 146,
+        "y": 0,
+        "bredd": 740,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1603,7 +2313,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1821"
+      "partikod": "1821",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 435,
+        "y": 0,
+        "bredd": 155,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1622,7 +2342,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1156.png",
       "valar": 2019,
-      "partikod": "1156"
+      "partikod": "1156",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 49,
+        "y": 1,
+        "bredd": 928,
+        "hojd": 151
+      }
     }
   },
   {
@@ -1634,7 +2364,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1548"
+      "partikod": "1548",
+      "bild": {
+        "bredd": 4275,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 183,
+        "y": 34,
+        "bredd": 3891,
+        "hojd": 586
+      }
     }
   },
   {
@@ -1646,7 +2386,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1765"
+      "partikod": "1765",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 401,
+        "y": 4,
+        "bredd": 224,
+        "hojd": 145
+      }
     }
   },
   {
@@ -1675,7 +2425,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1363.png",
       "valar": 2019,
-      "partikod": "1363"
+      "partikod": "1363",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 308,
+        "y": 1,
+        "bredd": 410,
+        "hojd": 151
+      }
     }
   },
   {
@@ -1709,7 +2469,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1653"
+      "partikod": "1653",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 228,
+        "y": 0,
+        "bredd": 570,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1729,7 +2499,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0094"
+      "partikod": "0094",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 242,
+        "y": 1,
+        "bredd": 542,
+        "hojd": 151
+      }
     }
   },
   {
@@ -1754,7 +2534,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1567"
+      "partikod": "1567",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 205,
+        "y": 77,
+        "bredd": 3747,
+        "hojd": 462
+      }
     }
   },
   {
@@ -1789,7 +2579,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1287"
+      "partikod": "1287",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 176,
+        "y": 0,
+        "bredd": 674,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1802,7 +2602,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1532"
+      "partikod": "1532",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 11,
+        "bredd": 1026,
+        "hojd": 131
+      }
     }
   },
   {
@@ -1815,7 +2625,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1860"
+      "partikod": "1860",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 167,
+        "y": 4,
+        "bredd": 693,
+        "hojd": 146
+      }
     }
   },
   {
@@ -1832,7 +2652,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1563"
+      "partikod": "1563",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 167,
+        "y": 0,
+        "bredd": 692,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1850,7 +2680,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1272.png",
       "valar": 2019,
-      "partikod": "1272"
+      "partikod": "1272",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 172,
+        "y": 0,
+        "bredd": 681,
+        "hojd": 137
+      }
     }
   },
   {
@@ -1877,7 +2717,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0160"
+      "partikod": "0160",
+      "bild": {
+        "bredd": 4275,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 300,
+        "y": 21,
+        "bredd": 3721,
+        "hojd": 588
+      }
     }
   },
   {
@@ -1904,7 +2754,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1728"
+      "partikod": "1728",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 0,
+        "bredd": 1026,
+        "hojd": 152
+      }
     }
   },
   {
@@ -1917,7 +2777,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1789"
+      "partikod": "1789",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 30,
+        "bredd": 1026,
+        "hojd": 95
+      }
     }
   },
   {
@@ -1930,7 +2800,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1797"
+      "partikod": "1797",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 3,
+        "y": 7,
+        "bredd": 1023,
+        "hojd": 139
+      }
     }
   },
   {
@@ -1972,7 +2852,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1587"
+      "partikod": "1587",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 16,
+        "y": 0,
+        "bredd": 994,
+        "hojd": 153
+      }
     }
   },
   {
@@ -1986,7 +2876,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0028"
+      "partikod": "0028",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 25,
+        "y": 7,
+        "bredd": 975,
+        "hojd": 138
+      }
     }
   },
   {
@@ -2028,7 +2928,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1374.png",
       "valar": 2019,
-      "partikod": "1374"
+      "partikod": "1374",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 304,
+        "y": 1,
+        "bredd": 418,
+        "hojd": 151
+      }
     }
   },
   {
@@ -2041,7 +2951,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1865"
+      "partikod": "1865",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 447,
+        "y": 0,
+        "bredd": 131,
+        "hojd": 153
+      }
     }
   },
   {
@@ -2071,7 +2991,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1327"
+      "partikod": "1327",
+      "bild": {
+        "bredd": 240,
+        "hojd": 35
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 0,
+        "bredd": 240,
+        "hojd": 35
+      }
     }
   },
   {
@@ -2085,7 +3015,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1312"
+      "partikod": "1312",
+      "bild": {
+        "bredd": 1027,
+        "hojd": 154
+      },
+      "bildyta": {
+        "x": 36,
+        "y": 8,
+        "bredd": 956,
+        "hojd": 138
+      }
     }
   },
   {
@@ -2107,7 +3047,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1671"
+      "partikod": "1671",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 310,
+        "y": 0,
+        "bredd": 405,
+        "hojd": 153
+      }
     }
   },
   {
@@ -2159,7 +3109,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1825"
+      "partikod": "1825",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 106,
+        "y": 0,
+        "bredd": 814,
+        "hojd": 153
+      }
     }
   },
   {
@@ -2194,7 +3154,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1350"
+      "partikod": "1350",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 342,
+        "y": 0,
+        "bredd": 341,
+        "hojd": 153
+      }
     }
   },
   {
@@ -2213,7 +3183,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1764"
+      "partikod": "1764",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 303,
+        "y": 0,
+        "bredd": 420,
+        "hojd": 153
+      }
     }
   },
   {
@@ -2226,7 +3206,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0638"
+      "partikod": "0638",
+      "bild": {
+        "bredd": 1027,
+        "hojd": 154
+      },
+      "bildyta": {
+        "x": 9,
+        "y": 6,
+        "bredd": 951,
+        "hojd": 142
+      }
     }
   },
   {
@@ -2245,7 +3235,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1560"
+      "partikod": "1560",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 119,
+        "y": 0,
+        "bredd": 789,
+        "hojd": 152
+      }
     }
   },
   {
@@ -2258,7 +3258,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1505"
+      "partikod": "1505",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 557,
+        "y": 17,
+        "bredd": 3077,
+        "hojd": 604
+      }
     }
   },
   {
@@ -2279,7 +3289,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0303"
+      "partikod": "0303",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 246,
+        "y": 8,
+        "bredd": 453,
+        "hojd": 136
+      }
     }
   },
   {
@@ -2305,7 +3325,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1338.png",
       "valar": 2019,
-      "partikod": "1338"
+      "partikod": "1338",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 262,
+        "y": 1,
+        "bredd": 502,
+        "hojd": 151
+      }
     }
   },
   {
@@ -2349,7 +3379,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0502"
+      "partikod": "0502",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 247,
+        "y": 12,
+        "bredd": 532,
+        "hojd": 129
+      }
     }
   },
   {
@@ -2370,7 +3410,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/0526.png",
       "valar": 2019,
-      "partikod": "0526"
+      "partikod": "0526",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 82,
+        "y": 12,
+        "bredd": 863,
+        "hojd": 130
+      }
     }
   },
   {
@@ -2389,7 +3439,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0471"
+      "partikod": "0471",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 10,
+        "y": 1,
+        "bredd": 1008,
+        "hojd": 152
+      }
     }
   },
   {
@@ -2424,7 +3484,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0593"
+      "partikod": "0593",
+      "bild": {
+        "bredd": 1027,
+        "hojd": 154
+      },
+      "bildyta": {
+        "x": 167,
+        "y": 12,
+        "bredd": 693,
+        "hojd": 130
+      }
     }
   },
   {
@@ -2443,7 +3513,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1899"
+      "partikod": "1899",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 150,
+        "y": 0,
+        "bredd": 727,
+        "hojd": 152
+      }
     }
   },
   {
@@ -2457,7 +3537,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1258"
+      "partikod": "1258",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 108,
+        "y": 1,
+        "bredd": 810,
+        "hojd": 151
+      }
     }
   },
   {
@@ -2475,7 +3565,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0068"
+      "partikod": "0068",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 480,
+        "y": 18,
+        "bredd": 3258,
+        "hojd": 605
+      }
     }
   },
   {
@@ -2494,7 +3594,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1766"
+      "partikod": "1766",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 1,
+        "y": 4,
+        "bredd": 1025,
+        "hojd": 146
+      }
     }
   },
   {
@@ -2530,7 +3640,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1036"
+      "partikod": "1036",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 47,
+        "y": 12,
+        "bredd": 932,
+        "hojd": 129
+      }
     }
   },
   {
@@ -2542,7 +3662,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1781"
+      "partikod": "1781",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 237,
+        "y": 1,
+        "bredd": 549,
+        "hojd": 152
+      }
     }
   },
   {
@@ -2561,7 +3691,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1588"
+      "partikod": "1588",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 71,
+        "y": 1,
+        "bredd": 884,
+        "hojd": 152
+      }
     }
   },
   {
@@ -2581,7 +3721,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0418"
+      "partikod": "0418",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 201,
+        "y": 12,
+        "bredd": 625,
+        "hojd": 131
+      }
     }
   },
   {
@@ -2600,7 +3750,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1011"
+      "partikod": "1011",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 154
+      },
+      "bildyta": {
+        "x": 103,
+        "y": 12,
+        "bredd": 812,
+        "hojd": 130
+      }
     }
   },
   {
@@ -2631,7 +3791,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0003"
+      "partikod": "0003",
+      "bild": {
+        "bredd": 1004,
+        "hojd": 150
+      },
+      "bildyta": {
+        "x": 1,
+        "y": 0,
+        "bredd": 1002,
+        "hojd": 150
+      }
     }
   },
   {
@@ -2650,7 +3820,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1824"
+      "partikod": "1824",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 183,
+        "y": 1,
+        "bredd": 660,
+        "hojd": 151
+      }
     }
   },
   {
@@ -2675,7 +3855,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0019"
+      "partikod": "0019",
+      "bild": {
+        "bredd": 1024,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 1,
+        "bredd": 1024,
+        "hojd": 151
+      }
     }
   },
   {
@@ -2694,7 +3884,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1458"
+      "partikod": "1458",
+      "bild": {
+        "bredd": 4275,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 33,
+        "y": 36,
+        "bredd": 4211,
+        "hojd": 565
+      }
     }
   },
   {
@@ -2720,7 +3920,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1540"
+      "partikod": "1540",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 5,
+        "bredd": 1026,
+        "hojd": 143
+      }
     }
   },
   {
@@ -2734,7 +3944,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0535"
+      "partikod": "0535",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 140
+      },
+      "bildyta": {
+        "x": 13,
+        "y": 6,
+        "bredd": 938,
+        "hojd": 130
+      }
     }
   },
   {
@@ -2784,7 +4004,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1750"
+      "partikod": "1750",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 261,
+        "y": 0,
+        "bredd": 504,
+        "hojd": 153
+      }
     }
   },
   {
@@ -2803,7 +4033,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0248"
+      "partikod": "0248",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 639
+      },
+      "bildyta": {
+        "x": 414,
+        "y": 82,
+        "bredd": 3525,
+        "hojd": 488
+      }
     }
   },
   {
@@ -2815,7 +4055,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1775"
+      "partikod": "1775",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 306,
+        "y": 0,
+        "bredd": 414,
+        "hojd": 153
+      }
     }
   },
   {
@@ -2849,7 +4099,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0498"
+      "partikod": "0498",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 305,
+        "y": 0,
+        "bredd": 416,
+        "hojd": 153
+      }
     }
   },
   {
@@ -2870,7 +4130,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1459"
+      "partikod": "1459",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 1,
+        "y": 3,
+        "bredd": 1024,
+        "hojd": 147
+      }
     }
   },
   {
@@ -2934,7 +4204,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1575"
+      "partikod": "1575",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 101,
+        "y": 0,
+        "bredd": 825,
+        "hojd": 152
+      }
     }
   },
   {
@@ -2952,7 +4232,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1296"
+      "partikod": "1296",
+      "bild": {
+        "bredd": 1004,
+        "hojd": 150
+      },
+      "bildyta": {
+        "x": 71,
+        "y": 0,
+        "bredd": 862,
+        "hojd": 150
+      }
     }
   },
   {
@@ -2976,7 +4266,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0055"
+      "partikod": "0055",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 67,
+        "y": 4,
+        "bredd": 892,
+        "hojd": 144
+      }
     }
   },
   {
@@ -3016,7 +4316,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1568"
+      "partikod": "1568",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 639
+      },
+      "bildyta": {
+        "x": 948,
+        "y": 34,
+        "bredd": 2380,
+        "hojd": 572
+      }
     }
   },
   {
@@ -3029,7 +4339,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0001"
+      "partikod": "0001",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 100,
+        "y": 0,
+        "bredd": 826,
+        "hojd": 153
+      }
     }
   },
   {
@@ -3047,7 +4367,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1760"
+      "partikod": "1760",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 3,
+        "bredd": 1025,
+        "hojd": 149
+      }
     }
   },
   {
@@ -3084,7 +4414,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1861"
+      "partikod": "1861",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 153,
+        "y": 1,
+        "bredd": 723,
+        "hojd": 152
+      }
     }
   },
   {
@@ -3104,7 +4444,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0543"
+      "partikod": "0543",
+      "bild": {
+        "bredd": 2139,
+        "hojd": 320
+      },
+      "bildyta": {
+        "x": 104,
+        "y": 15,
+        "bredd": 1920,
+        "hojd": 291
+      }
     }
   },
   {
@@ -3116,7 +4466,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1877"
+      "partikod": "1877",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 62,
+        "y": 4,
+        "bredd": 887,
+        "hojd": 148
+      }
     }
   },
   {
@@ -3143,7 +4503,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1281"
+      "partikod": "1281",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 303,
+        "y": 4,
+        "bredd": 425,
+        "hojd": 145
+      }
     }
   },
   {
@@ -3180,7 +4550,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1340.png",
       "valar": 2019,
-      "partikod": "1340"
+      "partikod": "1340",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 33,
+        "y": 1,
+        "bredd": 960,
+        "hojd": 151
+      }
     }
   },
   {
@@ -3208,7 +4588,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0985"
+      "partikod": "0985",
+      "bild": {
+        "bredd": 1027,
+        "hojd": 154
+      },
+      "bildyta": {
+        "x": 72,
+        "y": 13,
+        "bredd": 883,
+        "hojd": 129
+      }
     }
   },
   {
@@ -3241,7 +4631,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1446"
+      "partikod": "1446",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 43,
+        "y": 75,
+        "bredd": 4182,
+        "hojd": 487
+      }
     }
   },
   {
@@ -3258,7 +4658,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1313.png",
       "valar": 2019,
-      "partikod": "1313"
+      "partikod": "1313",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 12,
+        "y": 18,
+        "bredd": 1002,
+        "hojd": 117
+      }
     }
   },
   {
@@ -3271,7 +4681,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1773"
+      "partikod": "1773",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 12,
+        "bredd": 1026,
+        "hojd": 131
+      }
     }
   },
   {
@@ -3298,7 +4718,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1720"
+      "partikod": "1720",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 283,
+        "y": 1,
+        "bredd": 462,
+        "hojd": 152
+      }
     }
   },
   {
@@ -3316,7 +4746,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1788"
+      "partikod": "1788",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 33,
+        "y": 0,
+        "bredd": 960,
+        "hojd": 153
+      }
     }
   },
   {
@@ -3358,7 +4798,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1326.png",
       "valar": 2019,
-      "partikod": "1326"
+      "partikod": "1326",
+      "bild": {
+        "bredd": 1027,
+        "hojd": 154
+      },
+      "bildyta": {
+        "x": 186,
+        "y": 7,
+        "bredd": 620,
+        "hojd": 140
+      }
     }
   },
   {
@@ -3400,7 +4850,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1157"
+      "partikod": "1157",
+      "bild": {
+        "bredd": 1027,
+        "hojd": 154
+      },
+      "bildyta": {
+        "x": 12,
+        "y": 27,
+        "bredd": 1003,
+        "hojd": 111
+      }
     }
   },
   {
@@ -3417,7 +4877,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1800"
+      "partikod": "1800",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 211,
+        "y": 2,
+        "bredd": 604,
+        "hojd": 150
+      }
     }
   },
   {
@@ -3441,7 +4911,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1367"
+      "partikod": "1367",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 342,
+        "y": 27,
+        "bredd": 3559,
+        "hojd": 581
+      }
     }
   },
   {
@@ -3455,7 +4935,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0123"
+      "partikod": "0123",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 10,
+        "y": 18,
+        "bredd": 1003,
+        "hojd": 110
+      }
     }
   },
   {
@@ -3469,7 +4959,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1143"
+      "partikod": "1143",
+      "bild": {
+        "bredd": 1027,
+        "hojd": 154
+      },
+      "bildyta": {
+        "x": 12,
+        "y": 17,
+        "bredd": 1006,
+        "hojd": 120
+      }
     }
   },
   {
@@ -3494,7 +4994,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1305"
+      "partikod": "1305",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 437,
+        "y": 0,
+        "bredd": 152,
+        "hojd": 153
+      }
     }
   },
   {
@@ -3507,7 +5017,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1698"
+      "partikod": "1698",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 74,
+        "y": 0,
+        "bredd": 877,
+        "hojd": 153
+      }
     }
   },
   {
@@ -3532,7 +5052,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/0336.png",
       "valar": 2019,
-      "partikod": "0336"
+      "partikod": "0336",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 47,
+        "y": 56,
+        "bredd": 4050,
+        "hojd": 543
+      }
     }
   },
   {
@@ -3559,7 +5089,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1369.png",
       "valar": 2019,
-      "partikod": "1369"
+      "partikod": "1369",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 370,
+        "y": 2,
+        "bredd": 286,
+        "hojd": 149
+      }
     }
   },
   {
@@ -3579,7 +5119,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1472"
+      "partikod": "1472",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 639
+      },
+      "bildyta": {
+        "x": 116,
+        "y": 3,
+        "bredd": 4068,
+        "hojd": 632
+      }
     }
   },
   {
@@ -3625,7 +5175,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1152"
+      "partikod": "1152",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 11,
+        "y": 2,
+        "bredd": 1004,
+        "hojd": 151
+      }
     }
   },
   {
@@ -3637,7 +5197,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1654"
+      "partikod": "1654",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 170,
+        "y": 0,
+        "bredd": 686,
+        "hojd": 153
+      }
     }
   },
   {
@@ -3663,7 +5233,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1664"
+      "partikod": "1664",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 221,
+        "y": 4,
+        "bredd": 582,
+        "hojd": 146
+      }
     }
   },
   {
@@ -3691,7 +5271,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1544"
+      "partikod": "1544",
+      "bild": {
+        "bredd": 4275,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 450,
+        "y": 14,
+        "bredd": 3292,
+        "hojd": 618
+      }
     }
   },
   {
@@ -3712,7 +5302,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1068"
+      "partikod": "1068",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 4,
+        "y": 24,
+        "bredd": 1018,
+        "hojd": 98
+      }
     }
   },
   {
@@ -3746,7 +5346,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1787"
+      "partikod": "1787",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 3,
+        "y": 1,
+        "bredd": 1019,
+        "hojd": 152
+      }
     }
   },
   {
@@ -3793,7 +5403,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1439"
+      "partikod": "1439",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 4,
+        "y": 11,
+        "bredd": 1018,
+        "hojd": 134
+      }
     }
   },
   {
@@ -3806,7 +5426,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1640"
+      "partikod": "1640",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 1,
+        "y": 0,
+        "bredd": 1025,
+        "hojd": 153
+      }
     }
   },
   {
@@ -3824,7 +5454,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1430"
+      "partikod": "1430",
+      "bild": {
+        "bredd": 1027,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 100,
+        "y": 3,
+        "bredd": 826,
+        "hojd": 149
+      }
     }
   },
   {
@@ -3843,7 +5483,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1823"
+      "partikod": "1823",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 140,
+        "y": 0,
+        "bredd": 704,
+        "hojd": 153
+      }
     }
   },
   {
@@ -3884,7 +5534,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1752"
+      "partikod": "1752",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 277,
+        "y": 0,
+        "bredd": 472,
+        "hojd": 153
+      }
     }
   },
   {
@@ -3904,7 +5564,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0524"
+      "partikod": "0524",
+      "bild": {
+        "bredd": 1027,
+        "hojd": 154
+      },
+      "bildyta": {
+        "x": 107,
+        "y": 6,
+        "bredd": 821,
+        "hojd": 141
+      }
     }
   },
   {
@@ -3924,7 +5594,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1556"
+      "partikod": "1556",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 639
+      },
+      "bildyta": {
+        "x": 983,
+        "y": 40,
+        "bredd": 1988,
+        "hojd": 582
+      }
     }
   },
   {
@@ -3944,7 +5624,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1768"
+      "partikod": "1768",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 446,
+        "y": 0,
+        "bredd": 134,
+        "hojd": 153
+      }
     }
   },
   {
@@ -3986,7 +5676,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1571"
+      "partikod": "1571",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 1640,
+        "y": 30,
+        "bredd": 802,
+        "hojd": 583
+      }
     }
   },
   {
@@ -4013,7 +5713,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1916"
+      "partikod": "1916",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 436,
+        "y": 0,
+        "bredd": 154,
+        "hojd": 153
+      }
     }
   },
   {
@@ -4032,7 +5742,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1922"
+      "partikod": "1922",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 376,
+        "y": 2,
+        "bredd": 330,
+        "hojd": 148
+      }
     }
   },
   {
@@ -4082,7 +5802,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1362.png",
       "valar": 2019,
-      "partikod": "1362"
+      "partikod": "1362",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 235,
+        "y": 1,
+        "bredd": 556,
+        "hojd": 151
+      }
     }
   },
   {
@@ -4096,7 +5826,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1151"
+      "partikod": "1151",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 62,
+        "y": 10,
+        "bredd": 902,
+        "hojd": 134
+      }
     }
   },
   {
@@ -4109,7 +5849,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1801"
+      "partikod": "1801",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 104,
+        "y": 0,
+        "bredd": 818,
+        "hojd": 153
+      }
     }
   },
   {
@@ -4133,7 +5883,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1311.png",
       "valar": 2019,
-      "partikod": "1311"
+      "partikod": "1311",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 92,
+        "y": 12,
+        "bredd": 863,
+        "hojd": 129
+      }
     }
   },
   {
@@ -4145,7 +5905,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1881"
+      "partikod": "1881",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 23,
+        "bredd": 1026,
+        "hojd": 107
+      }
     }
   },
   {
@@ -4211,7 +5981,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1080"
+      "partikod": "1080",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 356,
+        "y": 12,
+        "bredd": 314,
+        "hojd": 130
+      }
     }
   },
   {
@@ -4230,7 +6010,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1128"
+      "partikod": "1128",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 639
+      },
+      "bildyta": {
+        "x": 1010,
+        "y": 97,
+        "bredd": 2295,
+        "hojd": 486
+      }
     }
   },
   {
@@ -4244,7 +6034,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0465"
+      "partikod": "0465",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 90,
+        "y": 12,
+        "bredd": 846,
+        "hojd": 129
+      }
     }
   },
   {
@@ -4266,7 +6066,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0174"
+      "partikod": "0174",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 544,
+        "y": 25,
+        "bredd": 3040,
+        "hojd": 590
+      }
     }
   },
   {
@@ -4279,7 +6089,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1796"
+      "partikod": "1796",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 255,
+        "y": 1,
+        "bredd": 515,
+        "hojd": 151
+      }
     }
   },
   {
@@ -4308,7 +6128,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0205"
+      "partikod": "0205",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 846,
+        "y": 14,
+        "bredd": 2576,
+        "hojd": 612
+      }
     }
   },
   {
@@ -4354,7 +6184,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1441"
+      "partikod": "1441",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 432,
+        "y": 41,
+        "bredd": 3535,
+        "hojd": 555
+      }
     }
   },
   {
@@ -4366,7 +6206,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1838"
+      "partikod": "1838",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 262,
+        "y": 2,
+        "bredd": 511,
+        "hojd": 149
+      }
     }
   },
   {
@@ -4400,7 +6250,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0193"
+      "partikod": "0193",
+      "bild": {
+        "bredd": 4275,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 8,
+        "y": 82,
+        "bredd": 4255,
+        "hojd": 479
+      }
     }
   },
   {
@@ -4421,7 +6281,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0249"
+      "partikod": "0249",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 72,
+        "y": 12,
+        "bredd": 882,
+        "hojd": 129
+      }
     }
   },
   {
@@ -4452,7 +6322,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0250"
+      "partikod": "0250",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 233,
+        "y": 12,
+        "bredd": 560,
+        "hojd": 129
+      }
     }
   },
   {
@@ -4466,7 +6346,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0196"
+      "partikod": "0196",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 214,
+        "y": 12,
+        "bredd": 599,
+        "hojd": 129
+      }
     }
   },
   {
@@ -4487,7 +6377,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0447"
+      "partikod": "0447",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 151,
+        "y": 0,
+        "bredd": 724,
+        "hojd": 153
+      }
     }
   },
   {
@@ -4507,7 +6407,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1533"
+      "partikod": "1533",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 134,
+        "y": 15,
+        "bredd": 3991,
+        "hojd": 606
+      }
     }
   },
   {
@@ -4526,7 +6436,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1216"
+      "partikod": "1216",
+      "bild": {
+        "bredd": 1027,
+        "hojd": 154
+      },
+      "bildyta": {
+        "x": 221,
+        "y": 3,
+        "bredd": 488,
+        "hojd": 146
+      }
     }
   },
   {
@@ -4544,7 +6464,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1754"
+      "partikod": "1754",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 60,
+        "y": 1,
+        "bredd": 907,
+        "hojd": 152
+      }
     }
   },
   {
@@ -4570,7 +6500,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1585"
+      "partikod": "1585",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 33,
+        "y": 0,
+        "bredd": 960,
+        "hojd": 153
+      }
     }
   },
   {
@@ -4589,7 +6529,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1693"
+      "partikod": "1693",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 293,
+        "y": 0,
+        "bredd": 440,
+        "hojd": 153
+      }
     }
   },
   {
@@ -4637,7 +6587,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0131"
+      "partikod": "0131",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 0,
+        "bredd": 1026,
+        "hojd": 138
+      }
     }
   },
   {
@@ -4673,7 +6633,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1257"
+      "partikod": "1257",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 110,
+        "y": 13,
+        "bredd": 806,
+        "hojd": 129
+      }
     }
   },
   {
@@ -4685,7 +6655,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1658"
+      "partikod": "1658",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 20,
+        "y": 1,
+        "bredd": 986,
+        "hojd": 151
+      }
     }
   },
   {
@@ -4715,7 +6695,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/0046.png",
       "valar": 2019,
-      "partikod": "0046"
+      "partikod": "0046",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 164,
+        "y": 2,
+        "bredd": 671,
+        "hojd": 149
+      }
     }
   },
   {
@@ -4728,7 +6718,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1286.png",
       "valar": 2019,
-      "partikod": "1286"
+      "partikod": "1286",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 151
+      },
+      "bildyta": {
+        "x": 9,
+        "y": 5,
+        "bredd": 1016,
+        "hojd": 146
+      }
     }
   },
   {
@@ -4742,7 +6742,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0519"
+      "partikod": "0519",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 1,
+        "bredd": 879,
+        "hojd": 151
+      }
     }
   },
   {
@@ -4775,7 +6785,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0546"
+      "partikod": "0546",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 6,
+        "bredd": 1026,
+        "hojd": 143
+      }
     }
   },
   {
@@ -4802,7 +6822,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1323"
+      "partikod": "1323",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 14,
+        "y": 13,
+        "bredd": 998,
+        "hojd": 129
+      }
     }
   },
   {
@@ -4821,7 +6851,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1799"
+      "partikod": "1799",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 287,
+        "y": 0,
+        "bredd": 452,
+        "hojd": 153
+      }
     }
   },
   {
@@ -4844,7 +6884,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1826"
+      "partikod": "1826",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 1,
+        "y": 4,
+        "bredd": 1024,
+        "hojd": 144
+      }
     }
   },
   {
@@ -4875,7 +6925,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1348.png",
       "valar": 2019,
-      "partikod": "1348"
+      "partikod": "1348",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 4,
+        "y": 4,
+        "bredd": 1022,
+        "hojd": 145
+      }
     }
   },
   {
@@ -4888,7 +6948,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1712"
+      "partikod": "1712",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 7,
+        "y": 0,
+        "bredd": 1013,
+        "hojd": 153
+      }
     }
   },
   {
@@ -4908,7 +6978,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1777"
+      "partikod": "1777",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 437,
+        "y": 0,
+        "bredd": 153,
+        "hojd": 153
+      }
     }
   },
   {
@@ -4926,7 +7006,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1886"
+      "partikod": "1886",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 1,
+        "bredd": 1026,
+        "hojd": 152
+      }
     }
   },
   {
@@ -4982,7 +7072,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0110"
+      "partikod": "0110",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 35,
+        "y": 1,
+        "bredd": 949,
+        "hojd": 151
+      }
     }
   },
   {
@@ -4999,7 +7099,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1920"
+      "partikod": "1920",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 26,
+        "bredd": 1024,
+        "hojd": 102
+      }
     }
   },
   {
@@ -5059,7 +7169,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1647"
+      "partikod": "1647",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 449,
+        "y": 0,
+        "bredd": 128,
+        "hojd": 153
+      }
     }
   },
   {
@@ -5071,7 +7191,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1894"
+      "partikod": "1894",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 302,
+        "y": 0,
+        "bredd": 415,
+        "hojd": 153
+      }
     }
   },
   {
@@ -5085,7 +7215,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1545"
+      "partikod": "1545",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 409,
+        "y": 4,
+        "bredd": 3454,
+        "hojd": 626
+      }
     }
   },
   {
@@ -5106,7 +7246,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1322"
+      "partikod": "1322",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 128,
+        "y": 6,
+        "bredd": 765,
+        "hojd": 141
+      }
     }
   },
   {
@@ -5137,7 +7287,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1450"
+      "partikod": "1450",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 172,
+        "y": 2,
+        "bredd": 682,
+        "hojd": 149
+      }
     }
   },
   {
@@ -5173,7 +7333,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1811"
+      "partikod": "1811",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 43,
+        "y": 1,
+        "bredd": 940,
+        "hojd": 152
+      }
     }
   },
   {
@@ -5187,7 +7357,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1278.png",
       "valar": 2019,
-      "partikod": "1278"
+      "partikod": "1278",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 68,
+        "y": 12,
+        "bredd": 867,
+        "hojd": 130
+      }
     }
   },
   {
@@ -5200,7 +7380,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1896"
+      "partikod": "1896",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 437,
+        "y": 0,
+        "bredd": 153,
+        "hojd": 153
+      }
     }
   },
   {
@@ -5223,7 +7413,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1812"
+      "partikod": "1812",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 261,
+        "y": 2,
+        "bredd": 505,
+        "hojd": 150
+      }
     }
   },
   {
@@ -5237,7 +7437,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0711"
+      "partikod": "0711",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 220,
+        "y": 12,
+        "bredd": 586,
+        "hojd": 129
+      }
     }
   },
   {
@@ -5257,7 +7467,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1076"
+      "partikod": "1076",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 81,
+        "y": 13,
+        "bredd": 864,
+        "hojd": 129
+      }
     }
   },
   {
@@ -5281,7 +7501,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1909"
+      "partikod": "1909",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 35,
+        "y": 1,
+        "bredd": 932,
+        "hojd": 152
+      }
     }
   },
   {
@@ -5316,7 +7546,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1827"
+      "partikod": "1827",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 51,
+        "bredd": 1025,
+        "hojd": 51
+      }
     }
   },
   {
@@ -5328,7 +7568,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1442.png",
       "valar": 2019,
-      "partikod": "1442"
+      "partikod": "1442",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 7,
+        "y": 0,
+        "bredd": 1016,
+        "hojd": 151
+      }
     }
   },
   {
@@ -5352,7 +7602,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0978"
+      "partikod": "0978",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 102,
+        "y": 12,
+        "bredd": 822,
+        "hojd": 129
+      }
     }
   },
   {
@@ -5366,7 +7626,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1452"
+      "partikod": "1452",
+      "bild": {
+        "bredd": 1080,
+        "hojd": 180
+      },
+      "bildyta": {
+        "x": 2,
+        "y": 2,
+        "bredd": 1077,
+        "hojd": 174
+      }
     }
   },
   {
@@ -5378,7 +7648,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1898"
+      "partikod": "1898",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 450,
+        "y": 0,
+        "bredd": 127,
+        "hojd": 153
+      }
     }
   },
   {
@@ -5391,7 +7671,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1572"
+      "partikod": "1572",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 639
+      },
+      "bildyta": {
+        "x": 953,
+        "y": 46,
+        "bredd": 2432,
+        "hojd": 572
+      }
     }
   },
   {
@@ -5410,7 +7700,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://historik.val.se/val/ep2019/regpartier/1138.png",
       "valar": 2019,
-      "partikod": "1138"
+      "partikod": "1138",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 193,
+        "y": 1,
+        "bredd": 640,
+        "hojd": 151
+      }
     }
   },
   {
@@ -5433,7 +7733,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1526"
+      "partikod": "1526",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 98,
+        "y": 21,
+        "bredd": 4051,
+        "hojd": 602
+      }
     }
   },
   {
@@ -5453,7 +7763,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0005"
+      "partikod": "0005",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 96,
+        "y": 1,
+        "bredd": 830,
+        "hojd": 150
+      }
     }
   },
   {
@@ -5470,7 +7790,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1393"
+      "partikod": "1393",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 58,
+        "y": 0,
+        "bredd": 911,
+        "hojd": 153
+      }
     }
   },
   {
@@ -5497,7 +7827,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1492"
+      "partikod": "1492",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 29,
+        "y": 8,
+        "bredd": 4200,
+        "hojd": 619
+      }
     }
   },
   {
@@ -5511,7 +7851,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1122"
+      "partikod": "1122",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 8,
+        "bredd": 1026,
+        "hojd": 133
+      }
     }
   },
   {
@@ -5525,7 +7875,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1785"
+      "partikod": "1785",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 6,
+        "y": 8,
+        "bredd": 1020,
+        "hojd": 140
+      }
     }
   },
   {
@@ -5542,7 +7902,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1355"
+      "partikod": "1355",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 0,
+        "y": 4,
+        "bredd": 1026,
+        "hojd": 145
+      }
     }
   },
   {
@@ -5606,7 +7976,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1154"
+      "partikod": "1154",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 97,
+        "y": 12,
+        "bredd": 832,
+        "hojd": 129
+      }
     }
   },
   {
@@ -5620,7 +8000,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0982"
+      "partikod": "0982",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 41,
+        "y": 8,
+        "bredd": 964,
+        "hojd": 138
+      }
     }
   },
   {
@@ -5634,7 +8024,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1002"
+      "partikod": "1002",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 235,
+        "y": 12,
+        "bredd": 557,
+        "hojd": 129
+      }
     }
   },
   {
@@ -5672,7 +8072,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0993"
+      "partikod": "0993",
+      "bild": {
+        "bredd": 4275,
+        "hojd": 638
+      },
+      "bildyta": {
+        "x": 25,
+        "y": 68,
+        "bredd": 4205,
+        "hojd": 518
+      }
     }
   },
   {
@@ -5691,7 +8101,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1535"
+      "partikod": "1535",
+      "bild": {
+        "bredd": 4276,
+        "hojd": 639
+      },
+      "bildyta": {
+        "x": 1396,
+        "y": 7,
+        "bredd": 1650,
+        "hojd": 621
+      }
     }
   },
   {
@@ -5722,7 +8142,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1888"
+      "partikod": "1888",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 311,
+        "y": 1,
+        "bredd": 404,
+        "hojd": 150
+      }
     }
   },
   {
@@ -5752,7 +8182,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0301"
+      "partikod": "0301",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 31,
+        "y": 1,
+        "bredd": 966,
+        "hojd": 151
+      }
     }
   },
   {
@@ -5764,7 +8204,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1468"
+      "partikod": "1468",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 422,
+        "y": 2,
+        "bredd": 182,
+        "hojd": 149
+      }
     }
   },
   {
@@ -5777,7 +8227,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1676"
+      "partikod": "1676",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 292,
+        "y": 2,
+        "bredd": 442,
+        "hojd": 150
+      }
     }
   },
   {
@@ -5794,7 +8254,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1646"
+      "partikod": "1646",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 210,
+        "y": 0,
+        "bredd": 607,
+        "hojd": 153
+      }
     }
   },
   {
@@ -5810,7 +8280,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1610"
+      "partikod": "1610",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 2,
+        "y": 9,
+        "bredd": 1023,
+        "hojd": 135
+      }
     }
   },
   {
@@ -5827,7 +8307,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "0119"
+      "partikod": "0119",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 376,
+        "y": 1,
+        "bredd": 273,
+        "hojd": 150
+      }
     }
   },
   {
@@ -5857,7 +8347,17 @@
       "kalla": "Valmyndigheten",
       "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
       "valar": 2026,
-      "partikod": "1335"
+      "partikod": "1335",
+      "bild": {
+        "bredd": 1026,
+        "hojd": 153
+      },
+      "bildyta": {
+        "x": 48,
+        "y": 11,
+        "bredd": 932,
+        "hojd": 132
+      }
     }
   },
   {

--- a/data/parti/initiativet/index.json
+++ b/data/parti/initiativet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1374.png",
     "valar": 2019,
-    "partikod": "1374"
+    "partikod": "1374",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 304,
+      "y": 1,
+      "bredd": 418,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/invanarnas-basta/index.json
+++ b/data/parti/invanarnas-basta/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1865"
+    "partikod": "1865",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 447,
+      "y": 0,
+      "bredd": 131,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/jamtlands-val-bracke/index.json
+++ b/data/parti/jamtlands-val-bracke/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1327"
+    "partikod": "1327",
+    "bild": {
+      "bredd": 240,
+      "hojd": 35
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 0,
+      "bredd": 240,
+      "hojd": 35
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/jamtlands-val-krokom/index.json
+++ b/data/parti/jamtlands-val-krokom/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1312"
+    "partikod": "1312",
+    "bild": {
+      "bredd": 1027,
+      "hojd": 154
+    },
+    "bildyta": {
+      "x": 36,
+      "y": 8,
+      "bredd": 956,
+      "hojd": 138
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/johannespartiet-med-extra-alg/index.json
+++ b/data/parti/johannespartiet-med-extra-alg/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1671"
+    "partikod": "1671",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 310,
+      "y": 0,
+      "bredd": 405,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/kalle-ankapartiet/index.json
+++ b/data/parti/kalle-ankapartiet/index.json
@@ -15,7 +15,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1825"
+    "partikod": "1825",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 106,
+      "y": 0,
+      "bredd": 814,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/karlstadpartiet-livskvalitet/index.json
+++ b/data/parti/karlstadpartiet-livskvalitet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1350"
+    "partikod": "1350",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 342,
+      "y": 0,
+      "bredd": 341,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/katrineholm-framat/index.json
+++ b/data/parti/katrineholm-framat/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1764"
+    "partikod": "1764",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 303,
+      "y": 0,
+      "bredd": 420,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/klassiskt-liberala-partiet/index.json
+++ b/data/parti/klassiskt-liberala-partiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0638"
+    "partikod": "0638",
+    "bild": {
+      "bredd": 1027,
+      "hojd": 154
+    },
+    "bildyta": {
+      "x": 9,
+      "y": 6,
+      "bredd": 951,
+      "hojd": 142
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/klimatinitiativ-simrishamn/index.json
+++ b/data/parti/klimatinitiativ-simrishamn/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1560"
+    "partikod": "1560",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 119,
+      "y": 0,
+      "bredd": 789,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/knapptryckarna/index.json
+++ b/data/parti/knapptryckarna/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1505"
+    "partikod": "1505",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 557,
+      "y": 17,
+      "bredd": 3077,
+      "hojd": 604
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/knivsta-nu/index.json
+++ b/data/parti/knivsta-nu/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0303"
+    "partikod": "0303",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 246,
+      "y": 8,
+      "bredd": 453,
+      "hojd": 136
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/kommundemokraterna/index.json
+++ b/data/parti/kommundemokraterna/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1338.png",
     "valar": 2019,
-    "partikod": "1338"
+    "partikod": "1338",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 262,
+      "y": 1,
+      "bredd": 502,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/kommunens-val-0502/index.json
+++ b/data/parti/kommunens-val-0502/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0502"
+    "partikod": "0502",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 247,
+      "y": 12,
+      "bredd": 532,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/kommunens-val-0526/index.json
+++ b/data/parti/kommunens-val-0526/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/0526.png",
     "valar": 2019,
-    "partikod": "0526"
+    "partikod": "0526",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 82,
+      "y": 12,
+      "bredd": 863,
+      "hojd": 130
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/kommunistiska-partiet/index.json
+++ b/data/parti/kommunistiska-partiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0471"
+    "partikod": "0471",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 10,
+      "y": 1,
+      "bredd": 1008,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/kommunpartiet-mellerud/index.json
+++ b/data/parti/kommunpartiet-mellerud/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0593"
+    "partikod": "0593",
+    "bild": {
+      "bredd": 1027,
+      "hojd": 154
+    },
+    "bildyta": {
+      "x": 167,
+      "y": 12,
+      "bredd": 693,
+      "hojd": 130
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/kompass/index.json
+++ b/data/parti/kompass/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1899"
+    "partikod": "1899",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 150,
+      "y": 0,
+      "bredd": 727,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/konsensus-for-vadstenas-basta/index.json
+++ b/data/parti/konsensus-for-vadstenas-basta/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1258"
+    "partikod": "1258",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 108,
+      "y": 1,
+      "bredd": 810,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/kristdemokraterna/index.json
+++ b/data/parti/kristdemokraterna/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0068"
+    "partikod": "0068",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 480,
+      "y": 18,
+      "bredd": 3258,
+      "hojd": 605
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/kristna-familjepartiet/index.json
+++ b/data/parti/kristna-familjepartiet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1766"
+    "partikod": "1766",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 1,
+      "y": 4,
+      "bredd": 1025,
+      "hojd": 146
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/kungsbackaborna/index.json
+++ b/data/parti/kungsbackaborna/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1036"
+    "partikod": "1036",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 47,
+      "y": 12,
+      "bredd": 932,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/kunskapsdemokratiska-partiet/index.json
+++ b/data/parti/kunskapsdemokratiska-partiet/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1781"
+    "partikod": "1781",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 237,
+      "y": 1,
+      "bredd": 549,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/kustlandspartiet/index.json
+++ b/data/parti/kustlandspartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1588"
+    "partikod": "1588",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 71,
+      "y": 1,
+      "bredd": 884,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/laholmspartiet/index.json
+++ b/data/parti/laholmspartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0418"
+    "partikod": "0418",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 201,
+      "y": 12,
+      "bredd": 625,
+      "hojd": 131
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/landsbygdspartiet-oberoende/index.json
+++ b/data/parti/landsbygdspartiet-oberoende/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1011"
+    "partikod": "1011",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 154
+    },
+    "bildyta": {
+      "x": 103,
+      "y": 12,
+      "bredd": 812,
+      "hojd": 130
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/liberalerna-tidigare-folkpartiet/index.json
+++ b/data/parti/liberalerna-tidigare-folkpartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0003"
+    "partikod": "0003",
+    "bild": {
+      "bredd": 1004,
+      "hojd": 150
+    },
+    "bildyta": {
+      "x": 1,
+      "y": 0,
+      "bredd": 1002,
+      "hojd": 150
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/liberalt-initiativ-habo-kommun/index.json
+++ b/data/parti/liberalt-initiativ-habo-kommun/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1824"
+    "partikod": "1824",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 183,
+      "y": 1,
+      "bredd": 660,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/lidingopartiet/index.json
+++ b/data/parti/lidingopartiet/index.json
@@ -15,7 +15,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0019"
+    "partikod": "0019",
+    "bild": {
+      "bredd": 1024,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 1,
+      "bredd": 1024,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/linkopingslistan/index.json
+++ b/data/parti/linkopingslistan/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1458"
+    "partikod": "1458",
+    "bild": {
+      "bredd": 4275,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 33,
+      "y": 36,
+      "bredd": 4211,
+      "hojd": 565
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/livbojen-vaxholmsdemokraterna/index.json
+++ b/data/parti/livbojen-vaxholmsdemokraterna/index.json
@@ -17,7 +17,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1540"
+    "partikod": "1540",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 5,
+      "bredd": 1026,
+      "hojd": 143
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/ljusdalsbygdens-parti/index.json
+++ b/data/parti/ljusdalsbygdens-parti/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0535"
+    "partikod": "0535",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 140
+    },
+    "bildyta": {
+      "x": 13,
+      "y": 6,
+      "bredd": 938,
+      "hojd": 130
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/lokalpartiet-malung-salen/index.json
+++ b/data/parti/lokalpartiet-malung-salen/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1750"
+    "partikod": "1750",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 261,
+      "y": 0,
+      "bredd": 504,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/lysekilspartiet/index.json
+++ b/data/parti/lysekilspartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0248"
+    "partikod": "0248",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 639
+    },
+    "bildyta": {
+      "x": 414,
+      "y": 82,
+      "bredd": 3525,
+      "hojd": 488
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/majoriteten/index.json
+++ b/data/parti/majoriteten/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1775"
+    "partikod": "1775",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 306,
+      "y": 0,
+      "bredd": 414,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/malaropartiet/index.json
+++ b/data/parti/malaropartiet/index.json
@@ -18,7 +18,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0498"
+    "partikod": "0498",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 305,
+      "y": 0,
+      "bredd": 416,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/malmolistan/index.json
+++ b/data/parti/malmolistan/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1459"
+    "partikod": "1459",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 1,
+      "y": 3,
+      "bredd": 1024,
+      "hojd": 147
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/medborgarpartiet-i-gislaved-mig/index.json
+++ b/data/parti/medborgarpartiet-i-gislaved-mig/index.json
@@ -17,7 +17,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1575"
+    "partikod": "1575",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 101,
+      "y": 0,
+      "bredd": 825,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/medborgerlig-samling/index.json
+++ b/data/parti/medborgerlig-samling/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1296"
+    "partikod": "1296",
+    "bild": {
+      "bredd": 1004,
+      "hojd": 150
+    },
+    "bildyta": {
+      "x": 71,
+      "y": 0,
+      "bredd": 862,
+      "hojd": 150
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/miljopartiet-de-grona/index.json
+++ b/data/parti/miljopartiet-de-grona/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0055"
+    "partikod": "0055",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 67,
+      "y": 4,
+      "bredd": 892,
+      "hojd": 144
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/mod-manskliga-rattigheter-och-demokrati/index.json
+++ b/data/parti/mod-manskliga-rattigheter-och-demokrati/index.json
@@ -16,7 +16,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1568"
+    "partikod": "1568",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 639
+    },
+    "bildyta": {
+      "x": 948,
+      "y": 34,
+      "bredd": 2380,
+      "hojd": 572
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/moderaterna/index.json
+++ b/data/parti/moderaterna/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0001"
+    "partikod": "0001",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 100,
+      "y": 0,
+      "bredd": 826,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/molndalslistan/index.json
+++ b/data/parti/molndalslistan/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1760"
+    "partikod": "1760",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 3,
+      "bredd": 1025,
+      "hojd": 149
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/multidimensionella-partiet/index.json
+++ b/data/parti/multidimensionella-partiet/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1861"
+    "partikod": "1861",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 153,
+      "y": 1,
+      "bredd": 723,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/nackalistan/index.json
+++ b/data/parti/nackalistan/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0543"
+    "partikod": "0543",
+    "bild": {
+      "bredd": 2139,
+      "hojd": 320
+    },
+    "bildyta": {
+      "x": 104,
+      "y": 15,
+      "bredd": 1920,
+      "hojd": 291
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/nagot-annat/index.json
+++ b/data/parti/nagot-annat/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1877"
+    "partikod": "1877",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 62,
+      "y": 4,
+      "bredd": 887,
+      "hojd": 148
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/naturens-parti/index.json
+++ b/data/parti/naturens-parti/index.json
@@ -17,7 +17,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1281"
+    "partikod": "1281",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 303,
+      "y": 4,
+      "bredd": 425,
+      "hojd": 145
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/nks-nya-koalitionssamlingen/index.json
+++ b/data/parti/nks-nya-koalitionssamlingen/index.json
@@ -9,6 +9,16 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1340.png",
     "valar": 2019,
-    "partikod": "1340"
+    "partikod": "1340",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 33,
+      "y": 1,
+      "bredd": 960,
+      "hojd": 151
+    }
   }
 }

--- a/data/parti/norapartiet/index.json
+++ b/data/parti/norapartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0985"
+    "partikod": "0985",
+    "bild": {
+      "bredd": 1027,
+      "hojd": 154
+    },
+    "bildyta": {
+      "x": 72,
+      "y": 13,
+      "bredd": 883,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/nordvarmlands-kommunparti/index.json
+++ b/data/parti/nordvarmlands-kommunparti/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1446"
+    "partikod": "1446",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 43,
+      "y": 75,
+      "bredd": 4182,
+      "hojd": 487
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/norrlandska-valfardspartiet/index.json
+++ b/data/parti/norrlandska-valfardspartiet/index.json
@@ -9,6 +9,16 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1313.png",
     "valar": 2019,
-    "partikod": "1313"
+    "partikod": "1313",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 12,
+      "y": 18,
+      "bredd": 1002,
+      "hojd": 117
+    }
   }
 }

--- a/data/parti/norrlandspartiet/index.json
+++ b/data/parti/norrlandspartiet/index.json
@@ -14,7 +14,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1773"
+    "partikod": "1773",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 12,
+      "bredd": 1026,
+      "hojd": 131
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/ny-allians/index.json
+++ b/data/parti/ny-allians/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1720"
+    "partikod": "1720",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 283,
+      "y": 1,
+      "bredd": 462,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/ny-kurs-nykvarn/index.json
+++ b/data/parti/ny-kurs-nykvarn/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1788"
+    "partikod": "1788",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 33,
+      "y": 0,
+      "bredd": 960,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/nya-kirunapartiet/index.json
+++ b/data/parti/nya-kirunapartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1326.png",
     "valar": 2019,
-    "partikod": "1326"
+    "partikod": "1326",
+    "bild": {
+      "bredd": 1027,
+      "hojd": 154
+    },
+    "bildyta": {
+      "x": 186,
+      "y": 7,
+      "bredd": 620,
+      "hojd": 140
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/nya-ulricehamn/index.json
+++ b/data/parti/nya-ulricehamn/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1157"
+    "partikod": "1157",
+    "bild": {
+      "bredd": 1027,
+      "hojd": 154
+    },
+    "bildyta": {
+      "x": 12,
+      "y": 27,
+      "bredd": 1003,
+      "hojd": 111
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/nybro-landsbygds-stadsparti/index.json
+++ b/data/parti/nybro-landsbygds-stadsparti/index.json
@@ -14,7 +14,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1800"
+    "partikod": "1800",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 211,
+      "y": 2,
+      "bredd": 604,
+      "hojd": 150
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/nyframtid/index.json
+++ b/data/parti/nyframtid/index.json
@@ -18,7 +18,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1367"
+    "partikod": "1367",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 342,
+      "y": 27,
+      "bredd": 3559,
+      "hojd": 581
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/nykvarnspartiet/index.json
+++ b/data/parti/nykvarnspartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0123"
+    "partikod": "0123",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 10,
+      "y": 18,
+      "bredd": 1003,
+      "hojd": 110
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/nystart-enkoping-ne/index.json
+++ b/data/parti/nystart-enkoping-ne/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1143"
+    "partikod": "1143",
+    "bild": {
+      "bredd": 1027,
+      "hojd": 154
+    },
+    "bildyta": {
+      "x": 12,
+      "y": 17,
+      "bredd": 1006,
+      "hojd": 120
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/oberoende-realister/index.json
+++ b/data/parti/oberoende-realister/index.json
@@ -15,7 +15,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1305"
+    "partikod": "1305",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 437,
+      "y": 0,
+      "bredd": 152,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/oberoende-s/index.json
+++ b/data/parti/oberoende-s/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1698"
+    "partikod": "1698",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 74,
+      "y": 0,
+      "bredd": 877,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/olandspartiet/index.json
+++ b/data/parti/olandspartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/0336.png",
     "valar": 2019,
-    "partikod": "0336"
+    "partikod": "0336",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 47,
+      "y": 56,
+      "bredd": 4050,
+      "hojd": 543
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/omsorg-for-alla/index.json
+++ b/data/parti/omsorg-for-alla/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1369.png",
     "valar": 2019,
-    "partikod": "1369"
+    "partikod": "1369",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 370,
+      "y": 2,
+      "bredd": 286,
+      "hojd": 149
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/ond-kyckling-partiet/index.json
+++ b/data/parti/ond-kyckling-partiet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1472"
+    "partikod": "1472",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 639
+    },
+    "bildyta": {
+      "x": 116,
+      "y": 3,
+      "bredd": 4068,
+      "hojd": 632
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/orebropartiet/index.json
+++ b/data/parti/orebropartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1152"
+    "partikod": "1152",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 11,
+      "y": 2,
+      "bredd": 1004,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/origo/index.json
+++ b/data/parti/origo/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1654"
+    "partikod": "1654",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 170,
+      "y": 0,
+      "bredd": 686,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/oskarshamnspartiet/index.json
+++ b/data/parti/oskarshamnspartiet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1664"
+    "partikod": "1664",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 221,
+      "y": 4,
+      "bredd": 582,
+      "hojd": 146
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/ostgotapartiet/index.json
+++ b/data/parti/ostgotapartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1544"
+    "partikod": "1544",
+    "bild": {
+      "bredd": 4275,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 450,
+      "y": 14,
+      "bredd": 3292,
+      "hojd": 618
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/overtorneas-fria-alternativ/index.json
+++ b/data/parti/overtorneas-fria-alternativ/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1068"
+    "partikod": "1068",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 4,
+      "y": 24,
+      "bredd": 1018,
+      "hojd": 98
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/partiet-arkitekturupproret/index.json
+++ b/data/parti/partiet-arkitekturupproret/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1787"
+    "partikod": "1787",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 3,
+      "y": 1,
+      "bredd": 1019,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/partiet-nyans/index.json
+++ b/data/parti/partiet-nyans/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1439"
+    "partikod": "1439",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 4,
+      "y": 11,
+      "bredd": 1018,
+      "hojd": 134
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/partiet-sunt-fornuft/index.json
+++ b/data/parti/partiet-sunt-fornuft/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1640"
+    "partikod": "1640",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 1,
+      "y": 0,
+      "bredd": 1025,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/partiet-vandpunkt/index.json
+++ b/data/parti/partiet-vandpunkt/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1430"
+    "partikod": "1430",
+    "bild": {
+      "bredd": 1027,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 100,
+      "y": 3,
+      "bredd": 826,
+      "hojd": 149
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/party-people/index.json
+++ b/data/parti/party-people/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1823"
+    "partikod": "1823",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 140,
+      "y": 0,
+      "bredd": 704,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/perspektiv-varnamo/index.json
+++ b/data/parti/perspektiv-varnamo/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1752"
+    "partikod": "1752",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 277,
+      "y": 0,
+      "bredd": 472,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/piratpartiet/index.json
+++ b/data/parti/piratpartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0524"
+    "partikod": "0524",
+    "bild": {
+      "bredd": 1027,
+      "hojd": 154
+    },
+    "bildyta": {
+      "x": 107,
+      "y": 6,
+      "bredd": 821,
+      "hojd": 141
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/plus55/index.json
+++ b/data/parti/plus55/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1556"
+    "partikod": "1556",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 639
+    },
+    "bildyta": {
+      "x": 983,
+      "y": 40,
+      "bredd": 1988,
+      "hojd": 582
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/politiskt-erovrande-demokratiska-organisationen/index.json
+++ b/data/parti/politiskt-erovrande-demokratiska-organisationen/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1768"
+    "partikod": "1768",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 446,
+      "y": 0,
+      "bredd": 134,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/prj-partiet-for-rattvisa-och-jamstalldhet/index.json
+++ b/data/parti/prj-partiet-for-rattvisa-och-jamstalldhet/index.json
@@ -17,7 +17,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1571"
+    "partikod": "1571",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 1640,
+      "y": 30,
+      "bredd": 802,
+      "hojd": 583
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/quisling-partiet/index.json
+++ b/data/parti/quisling-partiet/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1916"
+    "partikod": "1916",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 436,
+      "y": 0,
+      "bredd": 154,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/radda-sverige/index.json
+++ b/data/parti/radda-sverige/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1922"
+    "partikod": "1922",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 376,
+      "y": 2,
+      "bredd": 330,
+      "hojd": 148
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/rattvisa-rorelse-partiet/index.json
+++ b/data/parti/rattvisa-rorelse-partiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1362.png",
     "valar": 2019,
-    "partikod": "1362"
+    "partikod": "1362",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 235,
+      "y": 1,
+      "bredd": 556,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/realistpartiet-i-halmstad/index.json
+++ b/data/parti/realistpartiet-i-halmstad/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1801"
+    "partikod": "1801",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 104,
+      "y": 0,
+      "bredd": 818,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/realistpartiet/index.json
+++ b/data/parti/realistpartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1151"
+    "partikod": "1151",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 62,
+      "y": 10,
+      "bredd": 902,
+      "hojd": 134
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/regionens-framtid/index.json
+++ b/data/parti/regionens-framtid/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1311.png",
     "valar": 2019,
-    "partikod": "1311"
+    "partikod": "1311",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 92,
+      "y": 12,
+      "bredd": 863,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/regleraai-nu/index.json
+++ b/data/parti/regleraai-nu/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1881"
+    "partikod": "1881",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 23,
+      "bredd": 1026,
+      "hojd": 107
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/ronningepartiet/index.json
+++ b/data/parti/ronningepartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1080"
+    "partikod": "1080",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 356,
+      "y": 12,
+      "bredd": 314,
+      "hojd": 130
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/roslagens-oberoende-parti/index.json
+++ b/data/parti/roslagens-oberoende-parti/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1128"
+    "partikod": "1128",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 639
+    },
+    "bildyta": {
+      "x": 1010,
+      "y": 97,
+      "bredd": 2295,
+      "hojd": 486
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/roslagspartiet/index.json
+++ b/data/parti/roslagspartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0465"
+    "partikod": "0465",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 90,
+      "y": 12,
+      "bredd": 846,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/safe-solidaritet-arbete-fred-ekologi/index.json
+++ b/data/parti/safe-solidaritet-arbete-fred-ekologi/index.json
@@ -18,7 +18,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0174"
+    "partikod": "0174",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 544,
+      "y": 25,
+      "bredd": 3040,
+      "hojd": 590
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/saffle-reformparti/index.json
+++ b/data/parti/saffle-reformparti/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1796"
+    "partikod": "1796",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 255,
+      "y": 1,
+      "bredd": 515,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/sakpolitikerna/index.json
+++ b/data/parti/sakpolitikerna/index.json
@@ -18,7 +18,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0205"
+    "partikod": "0205",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 846,
+      "y": 14,
+      "bredd": 2576,
+      "hojd": 612
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/sans-o-balans/index.json
+++ b/data/parti/sans-o-balans/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1441"
+    "partikod": "1441",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 432,
+      "y": 41,
+      "bredd": 3535,
+      "hojd": 555
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/sekulara-humanistiska-partiet/index.json
+++ b/data/parti/sekulara-humanistiska-partiet/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1838"
+    "partikod": "1838",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 262,
+      "y": 2,
+      "bredd": 511,
+      "hojd": 149
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/sjukvardspartiet-gavleborg/index.json
+++ b/data/parti/sjukvardspartiet-gavleborg/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0249"
+    "partikod": "0249",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 72,
+      "y": 12,
+      "bredd": 882,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/sjukvardspartiet-i-varmland/index.json
+++ b/data/parti/sjukvardspartiet-i-varmland/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0250"
+    "partikod": "0250",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 233,
+      "y": 12,
+      "bredd": 560,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/sjukvardspartiet-vasternorrland/index.json
+++ b/data/parti/sjukvardspartiet-vasternorrland/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0196"
+    "partikod": "0196",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 214,
+      "y": 12,
+      "bredd": 599,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/sjukvardspartiet-vastra-gotaland/index.json
+++ b/data/parti/sjukvardspartiet-vastra-gotaland/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0447"
+    "partikod": "0447",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 151,
+      "y": 0,
+      "bredd": 724,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/sjukvardspartiet/index.json
+++ b/data/parti/sjukvardspartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0193"
+    "partikod": "0193",
+    "bild": {
+      "bredd": 4275,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 8,
+      "y": 82,
+      "bredd": 4255,
+      "hojd": 479
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/skargardspartiet/index.json
+++ b/data/parti/skargardspartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1533"
+    "partikod": "1533",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 134,
+      "y": 15,
+      "bredd": 3991,
+      "hojd": 606
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/skol-och-landsbygdspartiet/index.json
+++ b/data/parti/skol-och-landsbygdspartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1216"
+    "partikod": "1216",
+    "bild": {
+      "bredd": 1027,
+      "hojd": 154
+    },
+    "bildyta": {
+      "x": 221,
+      "y": 3,
+      "bredd": 488,
+      "hojd": 146
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/skolforaldrar/index.json
+++ b/data/parti/skolforaldrar/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1754"
+    "partikod": "1754",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 60,
+      "y": 1,
+      "bredd": 907,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/skovdepartiet/index.json
+++ b/data/parti/skovdepartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1585"
+    "partikod": "1585",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 33,
+      "y": 0,
+      "bredd": 960,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/skp-kommunisterna/index.json
+++ b/data/parti/skp-kommunisterna/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1693"
+    "partikod": "1693",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 293,
+      "y": 0,
+      "bredd": 440,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/socialistiskt-alternativ-tidigare-rattvisepartiet-socialisterna/index.json
+++ b/data/parti/socialistiskt-alternativ-tidigare-rattvisepartiet-socialisterna/index.json
@@ -18,7 +18,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0131"
+    "partikod": "0131",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 0,
+      "bredd": 1026,
+      "hojd": 138
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/sol-partiet-solvesborg-och-lister/index.json
+++ b/data/parti/sol-partiet-solvesborg-och-lister/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1257"
+    "partikod": "1257",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 110,
+      "y": 13,
+      "bredd": 806,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/solens-frihetsparti/index.json
+++ b/data/parti/solens-frihetsparti/index.json
@@ -13,7 +13,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1658"
+    "partikod": "1658",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 20,
+      "y": 1,
+      "bredd": 986,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/sollentunapartiet/index.json
+++ b/data/parti/sollentunapartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/0046.png",
     "valar": 2019,
-    "partikod": "0046"
+    "partikod": "0046",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 164,
+      "y": 2,
+      "bredd": 671,
+      "hojd": 149
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/solnapartiet/index.json
+++ b/data/parti/solnapartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1286.png",
     "valar": 2019,
-    "partikod": "1286"
+    "partikod": "1286",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 151
+    },
+    "bildyta": {
+      "x": 9,
+      "y": 5,
+      "bredd": 1016,
+      "hojd": 146
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/sorundanet-nynashamns-kommunparti/index.json
+++ b/data/parti/sorundanet-nynashamns-kommunparti/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0519"
+    "partikod": "0519",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 1,
+      "bredd": 879,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/sport-och-kommunpartiet/index.json
+++ b/data/parti/sport-och-kommunpartiet/index.json
@@ -19,7 +19,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0546"
+    "partikod": "0546",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 6,
+      "bredd": 1026,
+      "hojd": 143
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/stenungsundspartiet/index.json
+++ b/data/parti/stenungsundspartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1323"
+    "partikod": "1323",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 14,
+      "y": 13,
+      "bredd": 998,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/stockholms-vansterallians/index.json
+++ b/data/parti/stockholms-vansterallians/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1799"
+    "partikod": "1799",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 287,
+      "y": 0,
+      "bredd": 452,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/stoppa-drogkriget/index.json
+++ b/data/parti/stoppa-drogkriget/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1826"
+    "partikod": "1826",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 1,
+      "y": 4,
+      "bredd": 1024,
+      "hojd": 144
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/sundbybergs-lokalparti-slp/index.json
+++ b/data/parti/sundbybergs-lokalparti-slp/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1348.png",
     "valar": 2019,
-    "partikod": "1348"
+    "partikod": "1348",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 4,
+      "y": 4,
+      "bredd": 1022,
+      "hojd": 145
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/sundbybergspartiet/index.json
+++ b/data/parti/sundbybergspartiet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1712"
+    "partikod": "1712",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 7,
+      "y": 0,
+      "bredd": 1013,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/sunt-fornuft-bengtsfors/index.json
+++ b/data/parti/sunt-fornuft-bengtsfors/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1777"
+    "partikod": "1777",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 437,
+      "y": 0,
+      "bredd": 153,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/svensk-finska-unionspartiet/index.json
+++ b/data/parti/svensk-finska-unionspartiet/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1886"
+    "partikod": "1886",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 1,
+      "bredd": 1026,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/sverigedemokraterna/index.json
+++ b/data/parti/sverigedemokraterna/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0110"
+    "partikod": "0110",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 35,
+      "y": 1,
+      "bredd": 949,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/sveriges-intellektuella-demokrater/index.json
+++ b/data/parti/sveriges-intellektuella-demokrater/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1920"
+    "partikod": "1920",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 26,
+      "bredd": 1024,
+      "hojd": 102
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/the-unforgiven/index.json
+++ b/data/parti/the-unforgiven/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1647"
+    "partikod": "1647",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 449,
+      "y": 0,
+      "bredd": 128,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/tido/index.json
+++ b/data/parti/tido/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1894"
+    "partikod": "1894",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 302,
+      "y": 0,
+      "bredd": 415,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/tierpslistan/index.json
+++ b/data/parti/tierpslistan/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1545"
+    "partikod": "1545",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 409,
+      "y": 4,
+      "bredd": 3454,
+      "hojd": 626
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/timrapartiet/index.json
+++ b/data/parti/timrapartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1322"
+    "partikod": "1322",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 128,
+      "y": 6,
+      "bredd": 765,
+      "hojd": 141
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/tjugofyrasju/index.json
+++ b/data/parti/tjugofyrasju/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1450"
+    "partikod": "1450",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 172,
+      "y": 2,
+      "bredd": 682,
+      "hojd": 149
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/tristdemokraterna/index.json
+++ b/data/parti/tristdemokraterna/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1811"
+    "partikod": "1811",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 43,
+      "y": 1,
+      "bredd": 940,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/trollhattans-framtid/index.json
+++ b/data/parti/trollhattans-framtid/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1278.png",
     "valar": 2019,
-    "partikod": "1278"
+    "partikod": "1278",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 68,
+      "y": 12,
+      "bredd": 867,
+      "hojd": 130
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/trosa-vagnharad-partiet/index.json
+++ b/data/parti/trosa-vagnharad-partiet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1896"
+    "partikod": "1896",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 437,
+      "y": 0,
+      "bredd": 153,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/tulipan/index.json
+++ b/data/parti/tulipan/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1812"
+    "partikod": "1812",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 261,
+      "y": 2,
+      "bredd": 505,
+      "hojd": 150
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/tullingepartiet/index.json
+++ b/data/parti/tullingepartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0711"
+    "partikod": "0711",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 220,
+      "y": 12,
+      "bredd": 586,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/uddevallapartiet/index.json
+++ b/data/parti/uddevallapartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1076"
+    "partikod": "1076",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 81,
+      "y": 13,
+      "bredd": 864,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/ungdomspartiet/index.json
+++ b/data/parti/ungdomspartiet/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1909"
+    "partikod": "1909",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 35,
+      "y": 1,
+      "bredd": 932,
+      "hojd": 152
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/uppsala-ansvarspartiet/index.json
+++ b/data/parti/uppsala-ansvarspartiet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1827"
+    "partikod": "1827",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 51,
+      "bredd": 1025,
+      "hojd": 51
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/uppvidingedemokraterna/index.json
+++ b/data/parti/uppvidingedemokraterna/index.json
@@ -9,6 +9,16 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1442.png",
     "valar": 2019,
-    "partikod": "1442"
+    "partikod": "1442",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 7,
+      "y": 0,
+      "bredd": 1016,
+      "hojd": 151
+    }
   }
 }

--- a/data/parti/utvecklingspartiet-demokraterna/index.json
+++ b/data/parti/utvecklingspartiet-demokraterna/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1452"
+    "partikod": "1452",
+    "bild": {
+      "bredd": 1080,
+      "hojd": 180
+    },
+    "bildyta": {
+      "x": 2,
+      "y": 2,
+      "bredd": 1077,
+      "hojd": 174
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/utvecklingspartiet/index.json
+++ b/data/parti/utvecklingspartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0978"
+    "partikod": "0978",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 102,
+      "y": 12,
+      "bredd": 822,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/vagen/index.json
+++ b/data/parti/vagen/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1898"
+    "partikod": "1898",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 450,
+      "y": 0,
+      "bredd": 127,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/vagval-falun/index.json
+++ b/data/parti/vagval-falun/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1572"
+    "partikod": "1572",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 639
+    },
+    "bildyta": {
+      "x": 953,
+      "y": 46,
+      "bredd": 2432,
+      "hojd": 572
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/vagvalet/index.json
+++ b/data/parti/vagvalet/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://historik.val.se/val/ep2019/regpartier/1138.png",
     "valar": 2019,
-    "partikod": "1138"
+    "partikod": "1138",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 193,
+      "y": 1,
+      "bredd": 640,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/valsamverkanspartiet/index.json
+++ b/data/parti/valsamverkanspartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1526"
+    "partikod": "1526",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 98,
+      "y": 21,
+      "bredd": 4051,
+      "hojd": 602
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/vansterpartiet/index.json
+++ b/data/parti/vansterpartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0005"
+    "partikod": "0005",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 96,
+      "y": 1,
+      "bredd": 830,
+      "hojd": 150
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/var-framtid/index.json
+++ b/data/parti/var-framtid/index.json
@@ -18,7 +18,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1393"
+    "partikod": "1393",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 58,
+      "y": 0,
+      "bredd": 911,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/varbergspartiet/index.json
+++ b/data/parti/varbergspartiet/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1492"
+    "partikod": "1492",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 29,
+      "y": 8,
+      "bredd": 4200,
+      "hojd": 619
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/vard-for-pengarna/index.json
+++ b/data/parti/vard-for-pengarna/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1122"
+    "partikod": "1122",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 8,
+      "bredd": 1026,
+      "hojd": 133
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/vard-i-kronoberg/index.json
+++ b/data/parti/vard-i-kronoberg/index.json
@@ -11,7 +11,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1785"
+    "partikod": "1785",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 6,
+      "y": 8,
+      "bredd": 1020,
+      "hojd": 140
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/varddemokraterna/index.json
+++ b/data/parti/varddemokraterna/index.json
@@ -18,7 +18,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1355"
+    "partikod": "1355",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 0,
+      "y": 4,
+      "bredd": 1026,
+      "hojd": 145
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/vasbys-basta/index.json
+++ b/data/parti/vasbys-basta/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1154"
+    "partikod": "1154",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 97,
+      "y": 12,
+      "bredd": 832,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/vastjamtlands-val/index.json
+++ b/data/parti/vastjamtlands-val/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0982"
+    "partikod": "0982",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 41,
+      "y": 8,
+      "bredd": 964,
+      "hojd": 138
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/vastra-initiativet/index.json
+++ b/data/parti/vastra-initiativet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1002"
+    "partikod": "1002",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 235,
+      "y": 12,
+      "bredd": 557,
+      "hojd": 129
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/vetlanda-framatanda/index.json
+++ b/data/parti/vetlanda-framatanda/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0993"
+    "partikod": "0993",
+    "bild": {
+      "bredd": 4275,
+      "hojd": 638
+    },
+    "bildyta": {
+      "x": 25,
+      "y": 68,
+      "bredd": 4205,
+      "hojd": 518
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/vi-i-perstorp/index.json
+++ b/data/parti/vi-i-perstorp/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1535"
+    "partikod": "1535",
+    "bild": {
+      "bredd": 4276,
+      "hojd": 639
+    },
+    "bildyta": {
+      "x": 1396,
+      "y": 7,
+      "bredd": 1650,
+      "hojd": 621
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/viking/index.json
+++ b/data/parti/viking/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1888"
+    "partikod": "1888",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 311,
+      "y": 1,
+      "bredd": 404,
+      "hojd": 150
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/vingakerspartiet-vip/index.json
+++ b/data/parti/vingakerspartiet-vip/index.json
@@ -18,7 +18,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0301"
+    "partikod": "0301",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 31,
+      "y": 1,
+      "bredd": 966,
+      "hojd": 151
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/vinningspartiet/index.json
+++ b/data/parti/vinningspartiet/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1468"
+    "partikod": "1468",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 422,
+      "y": 2,
+      "bredd": 182,
+      "hojd": 149
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/vision-framatanda/index.json
+++ b/data/parti/vision-framatanda/index.json
@@ -10,7 +10,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1676"
+    "partikod": "1676",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 292,
+      "y": 2,
+      "bredd": 442,
+      "hojd": 150
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/visionpartiet/index.json
+++ b/data/parti/visionpartiet/index.json
@@ -9,7 +9,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1646"
+    "partikod": "1646",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 210,
+      "y": 0,
+      "bredd": 607,
+      "hojd": 153
+    }
   },
   "deltagande": {
     "2026": {

--- a/data/parti/volt/index.json
+++ b/data/parti/volt/index.json
@@ -16,7 +16,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1610"
+    "partikod": "1610",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 2,
+      "y": 9,
+      "bredd": 1023,
+      "hojd": 135
+    }
   },
   "deltagande": {
     "2022": {

--- a/data/parti/vox-humana-folkets-rost/index.json
+++ b/data/parti/vox-humana-folkets-rost/index.json
@@ -18,7 +18,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "0119"
+    "partikod": "0119",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 376,
+      "y": 1,
+      "bredd": 273,
+      "hojd": 150
+    }
   },
   "deltagande": {
     "2018": {

--- a/data/parti/westbopartiet/index.json
+++ b/data/parti/westbopartiet/index.json
@@ -12,7 +12,17 @@
     "kalla": "Valmyndigheten",
     "kallurl": "https://data.val.se/filer/val2026/parti/partisymboler.zip",
     "valar": 2026,
-    "partikod": "1335"
+    "partikod": "1335",
+    "bild": {
+      "bredd": 1026,
+      "hojd": 153
+    },
+    "bildyta": {
+      "x": 48,
+      "y": 11,
+      "bredd": 932,
+      "hojd": 132
+    }
   },
   "deltagande": {
     "2018": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "import-val": "node scripts/import-val.js",
     "import-riksdagsval": "node scripts/import-riksdagsval.js",
     "import-partisymboler": "node scripts/import-partisymboler.js",
+    "measure-partisymboler": "node scripts/measure-partisymboler.js",
     "validate:data": "node scripts/validate.js",
     "typecheck": "tsc --noEmit",
     "start": "node .release/server.js",

--- a/scripts/fixtures/png.js
+++ b/scripts/fixtures/png.js
@@ -1,0 +1,111 @@
+const zlib = require('node:zlib');
+
+/**
+ * Builds PNG files in memory so a test can state the picture it measures. The
+ * chunk CRCs are left at zero, which the reader under test does not check.
+ */
+
+const SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const CHANNELS = { 0: 1, 2: 3, 4: 2, 6: 4 };
+
+function paeth (a, b, c) {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+  if (pa <= pb && pa <= pc) return a;
+  return pb <= pc ? b : c;
+}
+
+function chunk (type, data) {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length);
+  const body = Buffer.concat([Buffer.from(type, 'latin1'), data]);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(0);
+  return Buffer.concat([length, body, crc]);
+}
+
+/**
+ * Builds a PNG from a pixel grid, so a test states the picture it measures.
+ * @param  {Object[][]} pixels Rows of { r, g, b, a }
+ * @param  {Object} [options] { colorType, bitDepth, interlace, filters }
+ * @return {Buffer}
+ */
+function png (pixels, { colorType = 6, bitDepth = 8, interlace = 0, filters } = {}) {
+  const height = pixels.length;
+  const width = pixels[0].length;
+  const pixelBytes = CHANNELS[colorType] || 4;
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = bitDepth;
+  header[9] = colorType;
+  header[12] = interlace;
+
+  const raw = pixels.map(row => {
+    const line = Buffer.alloc(width * pixelBytes);
+    row.forEach((pixel, x) => {
+      const at = x * pixelBytes;
+      if (colorType === 0 || colorType === 4) {
+        line[at] = pixel.r;
+        if (colorType === 4) line[at + 1] = pixel.a;
+      } else {
+        line[at] = pixel.r;
+        line[at + 1] = pixel.g;
+        line[at + 2] = pixel.b;
+        if (colorType === 6) line[at + 3] = pixel.a;
+      }
+    });
+    return line;
+  });
+
+  const rows = raw.map((line, y) => {
+    const filter = filters ? filters[y % filters.length] : 0;
+    const previous = y > 0 ? raw[y - 1] : Buffer.alloc(width * pixelBytes);
+    const encoded = Buffer.alloc(line.length);
+    for (let i = 0; i < line.length; i++) {
+      const left = i >= pixelBytes ? line[i - pixelBytes] : 0;
+      const above = previous[i];
+      const upperLeft = i >= pixelBytes ? previous[i - pixelBytes] : 0;
+      const subtract = filter === 1 ? left
+        : filter === 2 ? above
+          : filter === 3 ? (left + above) >> 1
+            : filter === 4 ? paeth(left, above, upperLeft)
+              : 0;
+      encoded[i] = (line[i] - subtract) & 0xff;
+    }
+    return Buffer.concat([Buffer.from([filter]), encoded]);
+  });
+
+  return Buffer.concat([
+    SIGNATURE,
+    chunk('IHDR', header),
+    chunk('IDAT', zlib.deflateSync(Buffer.concat(rows))),
+    chunk('IEND', Buffer.alloc(0))
+  ]);
+}
+
+const WHITE = { r: 255, g: 255, b: 255, a: 255 };
+const CLEAR = { r: 0, g: 0, b: 0, a: 0 };
+const INK = { r: 20, g: 40, b: 60, a: 255 };
+
+/**
+ * A sheet with the mark placed in a rectangle inside it.
+ * @param  {Object} margin The pixel the margin is drawn with
+ * @return {Object[][]}
+ */
+function sheet (margin, mark = INK, { width = 10, height = 6, x = 3, y = 1, markWidth = 4, markHeight = 2 } = {}) {
+  return Array.from({ length: height }, (unusedRow, row) =>
+    Array.from({ length: width }, (unusedColumn, column) =>
+      row >= y && row < y + markHeight && column >= x && column < x + markWidth ? mark : margin));
+}
+
+/**
+ * Exports
+ */
+exports.png = png;
+exports.sheet = sheet;
+exports.WHITE = WHITE;
+exports.CLEAR = CLEAR;
+exports.INK = INK;

--- a/scripts/fixtures/tree.js
+++ b/scripts/fixtures/tree.js
@@ -67,7 +67,7 @@ function fixture (name) {
 function makeTree ({ parties = PARTIER, kodbyten = null, kandidatlistor = [] } = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'partidata-'));
   fs.mkdirSync(path.join(dir, 'scripts'));
-  for (const file of ['utils.js', 'parti.js', 'import-val.js', 'import-partisymboler.js']) {
+  for (const file of ['utils.js', 'parti.js', 'png.js', 'import-val.js', 'import-partisymboler.js', 'measure-partisymboler.js']) {
     fs.copyFileSync(path.join(SCRIPTS, file), path.join(dir, 'scripts', file));
   }
   fs.mkdirSync(path.join(dir, 'data', 'parti'), { recursive: true });
@@ -135,6 +135,21 @@ function runSymbolImport (dir, year, zip, legacyDir = null) {
 }
 
 /**
+ * runMeasureSymbols
+ * Measures the committed symbols in a tree.
+ * @param  {String} dir Tree from makeTree()
+ * @return {{ status: Number, stdout: String, stderr: String }}
+ */
+function runMeasureSymbols (dir) {
+  const result = spawnSync(
+    process.execPath,
+    [path.join(dir, 'scripts', 'measure-partisymboler.js')],
+    { encoding: 'utf8' }
+  );
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+/**
  * runParti
  * Rebuilds the registry from the committed data in a tree.
  * @param  {String} dir Tree from makeTree()
@@ -187,6 +202,7 @@ exports.makeTree = makeTree;
 exports.removeTree = removeTree;
 exports.runImport = runImport;
 exports.runSymbolImport = runSymbolImport;
+exports.runMeasureSymbols = runMeasureSymbols;
 exports.runParti = runParti;
 exports.readJson = readJson;
 exports.snapshot = snapshot;

--- a/scripts/home-filtering.test.js
+++ b/scripts/home-filtering.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 
 const {
+  defaultFilters,
   emptyFilters,
   filterParties,
   matchesQuery,
@@ -16,8 +17,8 @@ const PARTIES = [
     filnamn: 'ostra-folkpartiet',
     forkortning: 'ÖF',
     deltagande: {
-      2018: { riksdag: true, regionLan: [], kommunLan: [] },
-      2022: { riksdag: false, regionLan: ['01'], kommunLan: ['01', '12'] }
+      2018: { riksdag: true, regionLan: [], kommunKoder: [] },
+      2022: { riksdag: false, regionLan: ['01'], kommunKoder: ['0114', '1280'] }
     }
   },
   {
@@ -27,7 +28,7 @@ const PARTIES = [
     forkortning: 'SKP',
     omrade: 'Malmö',
     deltagande: {
-      2022: { riksdag: false, regionLan: ['12'], kommunLan: ['12'] }
+      2022: { riksdag: false, regionLan: ['12'], kommunKoder: ['1233', '1280'] }
     }
   },
   {
@@ -35,7 +36,7 @@ const PARTIES = [
     beteckning: 'Rikspartiet',
     filnamn: 'rikspartiet',
     deltagande: {
-      2018: { riksdag: true, regionLan: [], kommunLan: [] }
+      2018: { riksdag: true, regionLan: [], kommunKoder: [] }
     }
   },
   {
@@ -70,6 +71,12 @@ test('search matches name and abbreviation without diacritics', () => {
   assert.ok(matchesQuery(PARTIES[2], 'riks'), 'a party without abbreviation is still searchable by name');
 });
 
+test('the default filters open on the latest year the data carries', () => {
+  assert.deepEqual(defaultFilters(['2018', '2022', '2026']), { ...emptyFilters, valar: '2026' });
+  assert.deepEqual(defaultFilters([]), emptyFilters);
+  assert.deepEqual(slugs(defaultFilters(['2018', '2022'])), ['ostra-folkpartiet', 'skanepartiet']);
+});
+
 test('no filter leaves every party', () => {
   assert.deepEqual(slugs({}), PARTIES.map(party => party.filnamn));
 });
@@ -99,11 +106,34 @@ test('the county is tested against the facet of the chosen election type', () =>
   assert.deepEqual(slugs({ valar: '2018', valtyp: 'kommun', lan: '01' }), []);
 });
 
-test('a county left over from another election type is dropped', () => {
+test('a county survives every election type but the nationwide one', () => {
   assert.deepEqual(pruneFilters({ ...emptyFilters, valtyp: 'riksdag', lan: '12' }).lan, '');
-  assert.deepEqual(pruneFilters({ ...emptyFilters, lan: '12' }).lan, '');
+  assert.deepEqual(pruneFilters({ ...emptyFilters, lan: '12' }).lan, '12');
   assert.deepEqual(pruneFilters({ ...emptyFilters, valtyp: 'kommun', lan: '12' }).lan, '12');
   assert.deepEqual(slugs({ valtyp: 'riksdag', lan: '12' }), ['ostra-folkpartiet', 'rikspartiet']);
+});
+
+test('a municipality asks for the municipal ballot in that municipality alone', () => {
+  assert.deepEqual(slugs({ kommun: '1280' }), ['ostra-folkpartiet', 'skanepartiet']);
+  assert.deepEqual(slugs({ kommun: '1233' }), ['skanepartiet']);
+  assert.deepEqual(slugs({ kommun: '0114' }), ['ostra-folkpartiet']);
+  assert.deepEqual(slugs({ kommun: '1233', valar: '2018' }), [], 'året gäller före kommunen');
+});
+
+test('a municipality outside the chosen county, or under another election type, is dropped', () => {
+  assert.deepEqual(pruneFilters({ ...emptyFilters, lan: '12', kommun: '0114' }).kommun, '');
+  assert.deepEqual(pruneFilters({ ...emptyFilters, lan: '12', kommun: '1280' }).kommun, '1280');
+  assert.deepEqual(pruneFilters({ ...emptyFilters, kommun: '1280' }).kommun, '1280');
+  assert.deepEqual(pruneFilters({ ...emptyFilters, valtyp: 'region', kommun: '1280' }).kommun, '');
+  assert.deepEqual(pruneFilters({ ...emptyFilters, valtyp: 'kommun', kommun: '1280' }).kommun, '1280');
+  assert.deepEqual(pruneFilters({ ...emptyFilters, valtyp: 'riksdag', lan: '12', kommun: '1280' }), { ...emptyFilters, valtyp: 'riksdag' });
+});
+
+test('a county on its own asks for either ballot in that county', () => {
+  assert.deepEqual(slugs({ lan: '12' }), ['ostra-folkpartiet', 'skanepartiet']);
+  assert.deepEqual(slugs({ lan: '01' }), ['ostra-folkpartiet']);
+  assert.deepEqual(slugs({ lan: '14' }), []);
+  assert.deepEqual(slugs({ lan: '01', valar: '2018' }), [], 'året gäller före länet');
 });
 
 test('search and filters narrow together', () => {

--- a/scripts/home-sorting.test.js
+++ b/scripts/home-sorting.test.js
@@ -1,0 +1,59 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { emptyFilters } = require('../src/components/home/filtering.ts');
+const { isSortOrder, sortLabels, sortOrders, sortParties } = require('../src/components/home/sorting.ts');
+
+function facet ({ riksdag = false, kommunAntal = 0 } = {}) {
+  return { riksdag, regionLan: [], kommunKoder: Array.from({ length: kommunAntal }, (unused, index) => String(1200 + index)) };
+}
+
+/** The parties arrive from the server in Swedish name order. */
+const PARTIES = [
+  { filnamn: 'brett-parti', deltagande: { 2018: facet({ kommunAntal: 40 }), 2026: facet({ kommunAntal: 200 }) } },
+  { filnamn: 'gammalt-parti', deltagande: { 2014: facet({ kommunAntal: 3 }), 2018: facet({ kommunAntal: 2 }), 2022: facet({ kommunAntal: 1 }) } },
+  { filnamn: 'nytt-parti', deltagande: { 2026: facet({ kommunAntal: 5 }) } },
+  { filnamn: 'utan-parti', deltagande: {} }
+];
+
+function order (sort, filters = {}) {
+  return sortParties(PARTIES, sort, { ...emptyFilters, ...filters }).map(party => party.filnamn);
+}
+
+test('the name order is the list as it arrived', () => {
+  assert.deepEqual(order('namn'), PARTIES.map(party => party.filnamn));
+});
+
+test('the municipality ranking reads the party best year', () => {
+  assert.deepEqual(order('kommuner'), ['brett-parti', 'nytt-parti', 'gammalt-parti', 'utan-parti']);
+});
+
+test('a chosen year ranks on that year alone', () => {
+  assert.deepEqual(order('kommuner', { valar: '2018' }), ['brett-parti', 'gammalt-parti', 'nytt-parti', 'utan-parti']);
+  assert.deepEqual(order('kommuner', { valar: '2014' }), ['gammalt-parti', 'brett-parti', 'nytt-parti', 'utan-parti']);
+});
+
+test('the latest ballot ranks the most recently registered party first', () => {
+  assert.deepEqual(order('senaste'), ['brett-parti', 'nytt-parti', 'gammalt-parti', 'utan-parti']);
+});
+
+test('parties that rank equally keep their name order', () => {
+  const tied = [
+    { filnamn: 'alfa', deltagande: { 2026: facet({ kommunAntal: 7 }) } },
+    { filnamn: 'beta', deltagande: { 2026: facet({ kommunAntal: 7 }) } }
+  ];
+  assert.deepEqual(sortParties(tied, 'kommuner', emptyFilters).map(party => party.filnamn), ['alfa', 'beta']);
+});
+
+test('sorting leaves the matches it was given untouched', () => {
+  const before = PARTIES.map(party => party.filnamn);
+  sortParties(PARTIES, 'kommuner', emptyFilters);
+  assert.deepEqual(PARTIES.map(party => party.filnamn), before);
+});
+
+test('every order has a label and only known orders are accepted', () => {
+  assert.deepEqual(sortOrders, ['namn', 'kommuner', 'senaste']);
+  assert.deepEqual(sortOrders.map(value => sortLabels[value]), ['A–Ö', 'Flest kommuner', 'Senast anmält']);
+  assert.ok(isSortOrder('kommuner'));
+  assert.ok(!isSortOrder('valar'));
+});

--- a/scripts/home-summary.test.js
+++ b/scripts/home-summary.test.js
@@ -2,9 +2,8 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 
 const {
-  cardMeta,
+  ballots,
   cardSub,
-  participationLevels,
   participationYears,
   partyLabel,
   queryEcho,
@@ -16,16 +15,39 @@ function party (deltagande) {
 }
 
 const ALL_LEVELS = party({
-  2018: { riksdag: true, regionLan: [], kommunLan: [] },
-  2022: { riksdag: false, regionLan: ['01'], kommunLan: ['12'] }
+  2018: { riksdag: true, regionLan: [], kommunKoder: [] },
+  2022: { riksdag: false, regionLan: ['01'], kommunKoder: ['1214', '1230', '1231', '1233'] }
 });
 const NOTHING = party({});
 
-test('participation levels collapse every year the party stood in', () => {
-  assert.deepEqual(participationLevels(ALL_LEVELS), ['Riksdag', 'Region', 'Kommun']);
-  assert.deepEqual(participationLevels(party({ 2022: { riksdag: false, regionLan: [], kommunLan: ['12'] } })), ['Kommun']);
-  assert.deepEqual(participationLevels(party({ 2022: { riksdag: true, regionLan: [], kommunLan: [] } })), ['Riksdag']);
-  assert.deepEqual(participationLevels(NOTHING), []);
+test('the ballots collapse every year the party stood in', () => {
+  assert.deepEqual(ballots(ALL_LEVELS), [
+    { valtyp: 'riksdag' },
+    { valtyp: 'region', antal: 1 },
+    { valtyp: 'kommun', antal: 4 }
+  ]);
+  assert.deepEqual(ballots(party({ 2022: { riksdag: true, regionLan: [], kommunKoder: [] } })), [{ valtyp: 'riksdag' }]);
+  assert.deepEqual(ballots(NOTHING), []);
+});
+
+test('a chosen year is the only one the ballots count', () => {
+  assert.deepEqual(ballots(ALL_LEVELS, '2018'), [{ valtyp: 'riksdag' }]);
+  assert.deepEqual(ballots(ALL_LEVELS, '2022'), [
+    { valtyp: 'region', antal: 1 },
+    { valtyp: 'kommun', antal: 4 }
+  ]);
+  assert.deepEqual(ballots(ALL_LEVELS, '2026'), [], 'ett år partiet inte deltog i räknar ingenting');
+});
+
+test('the widest year sets the count when no year is chosen', () => {
+  const growing = party({
+    2018: { riksdag: false, regionLan: ['01'], kommunKoder: ['0114', '0115'] },
+    2022: { riksdag: false, regionLan: ['01', '12'], kommunKoder: ['0114', '0115', '0117', '0120', '0123', '0125', '0126', '0127', '0128'] }
+  });
+  assert.deepEqual(ballots(growing), [
+    { valtyp: 'region', antal: 2 },
+    { valtyp: 'kommun', antal: 9 }
+  ]);
 });
 
 test('participation years are listed newest first', () => {
@@ -34,8 +56,7 @@ test('participation years are listed newest first', () => {
 });
 
 test('the card footer never renders empty', () => {
-  assert.equal(cardMeta(ALL_LEVELS), 'Riksdag · Region · Kommun');
-  assert.equal(cardMeta(NOTHING), 'Inget anmält deltagande');
+  assert.deepEqual(ballots(NOTHING), [], 'ett parti utan valsedlar får ingen bricka');
   assert.equal(cardSub(ALL_LEVELS), 'Valår 2022, 2018');
   assert.equal(cardSub(NOTHING), undefined);
 });

--- a/scripts/http-smoke.js
+++ b/scripts/http-smoke.js
@@ -25,6 +25,25 @@ function comparePartyOrder (a, b) {
   return collator.compare(a.beteckning, b.beteckning) || collator.compare(a.filnamn, b.filnamn);
 }
 
+/**
+ * The parties the start page opens on: the ones standing in the latest election
+ * the data carries, which is the year the filters default to.
+ */
+function standingParties (projectRoot, parties) {
+  const electionRoot = path.join(projectRoot, 'data', 'val');
+  const years = fs.readdirSync(electionRoot, { withFileTypes: true })
+    .filter(entry => entry.isDirectory() && /^\d{4}$/.test(entry.name))
+    .map(entry => entry.name)
+    .toSorted();
+  const latest = years.findLast(year =>
+    fs.existsSync(path.join(electionRoot, year, 'partideltagande', 'partier.json')));
+  assert.ok(latest, 'ett valår med partideltagande hittades');
+  const participating = new Set(JSON.parse(
+    fs.readFileSync(path.join(electionRoot, latest, 'partideltagande', 'partier.json'), 'utf8')
+  ).map(party => party.uuid));
+  return { latest, standing: parties.filter(party => participating.has(party.uuid)) };
+}
+
 /** Extracts the party links of the "Alla partier" grid in document order. */
 function partyGridLinks (html) {
   const section = html.slice(html.indexOf('id="alla-partier"'));
@@ -67,7 +86,8 @@ async function main () {
   const current = parties.find(party => party.filnamn === 'miljopartiet-de-grona') ?? parties[0];
   const duplicate = parties.find(party => party.filnamn === 'kommunens-val-0503');
   const withoutParticipation = parties.find(party => party.filnamn === 'angfarjepartiet');
-  const expectedOrder = parties.toSorted(comparePartyOrder).slice(0, homePageSize).map(party => party.filnamn);
+  const { latest, standing } = standingParties(projectRoot, parties);
+  const expectedOrder = standing.toSorted(comparePartyOrder).slice(0, homePageSize).map(party => party.filnamn);
   const [first] = expectedOrder;
   const previous = parties.find(party => party.tidigare_filnamn?.length > 0);
   const cleanedSlug = parties.find(party =>
@@ -102,7 +122,14 @@ async function main () {
     assert.match(homeBody, /<link rel="canonical" href="https:\/\/www\.partidata\.se\/"[^>]*>/);
     assert.match(homeBody, /Sök parti på namn eller förkortning/);
     assert.match(homeBody, /Alla partier/, 'partilistan har en rubrik');
-    assert.match(homeBody, new RegExp(`>${parties.length}</span>`), 'rubriken räknar partierna ur datan');
+    assert.match(
+      homeBody,
+      new RegExp(`>${standing.length}(<!-- -->)? av (<!-- -->)?${parties.length}</span>`),
+      'rubriken räknar partierna i det förvalda valåret mot hela registret'
+    );
+    assert.match(homeBody, new RegExp(`<option value="${latest}" selected="">${latest}</option>`), 'valårsfiltret står på det senaste valet');
+    assert.match(homeBody, /<option value="namn" selected="">Sorterat <!-- -->A–Ö<\/option>/, 'sorteringen står på bokstavsordning');
+    assert.match(homeBody, /<option value="kommuner">Sorterat <!-- -->Flest kommuner<\/option>/, 'sorteringen kan rangordna på kommuner');
     assert.match(homeBody, new RegExp(`/parti/${first}`), 'partigridet länkar till en partisida');
     assert.match(homeBody, /Riksdagspartier/);
     assert.match(homeBody, /Största partierna utanför riksdagen/);
@@ -115,7 +142,7 @@ async function main () {
     assert.match(homeBody, /Alternativet \(Ljungby\)/, 'alla synliga namndubbletter särskiljs');
 
     const gridLinks = partyGridLinks(homeBody);
-    assert.equal(gridLinks.length, Math.min(homePageSize, parties.length), 'partigridet renderar en hel sida partier');
+    assert.equal(gridLinks.length, Math.min(homePageSize, standing.length), 'partigridet renderar en hel sida partier');
     assert.deepEqual(gridLinks, expectedOrder, 'partigridet följer svensk bokstavsordning');
 
     const riksdagCards = homeBody.split('party-card--large').length - 1;

--- a/scripts/import-partisymboler.js
+++ b/scripts/import-partisymboler.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 const { unzipSync } = require('fflate');
 
+const { contentBox } = require('./png.js');
 const { ROOT, dataPath, fetchBuffer, toFileName } = require('./utils.js');
 const {
   loadParties,
@@ -53,6 +54,18 @@ function assertStoredSymbolFileName (fileName) {
   if (path.basename(fileName) !== fileName || !/^\d{4}-[a-z0-9-]+\.png$/.test(fileName)) {
     throw new Error(`Invalid stored symbol filename: ${fileName}`);
   }
+}
+
+/**
+ * measurements
+ * The sheet a symbol is delivered on, and where the drawing sits inside it, so
+ * a renderer can show every symbol at the same optical size. A file this
+ * reader leaves unmeasured is stored without the fields.
+ * @param  {Buffer} data
+ * @return {Object} { bild, bildyta }, or empty
+ */
+function measurements (data) {
+  return contentBox(data) || {};
 }
 
 /**
@@ -217,7 +230,8 @@ function mapSymbols (registry, current, legacy, year) {
       kalla: 'Valmyndigheten',
       kallurl: sourceUrl,
       valar: Number(sourceYear),
-      partikod: symbol.code
+      partikod: symbol.code,
+      ...measurements(symbol.data)
     };
     imports.push({ party, data: symbol.data, previousFileName });
     return true;
@@ -288,6 +302,7 @@ exports.symbolFileName = symbolFileName;
 exports.assertStoredSymbolFileName = assertStoredSymbolFileName;
 exports.parseArgs = parseArgs;
 exports.assertPng = assertPng;
+exports.measurements = measurements;
 exports.normalizeCode = normalizeCode;
 exports.readZipSymbols = readZipSymbols;
 exports.readLegacySymbols = readLegacySymbols;

--- a/scripts/import-partisymboler.test.js
+++ b/scripts/import-partisymboler.test.js
@@ -14,6 +14,7 @@ const {
   symbolFileName,
   symbolUrl
 } = require('./import-partisymboler.js');
+const { png, sheet, CLEAR } = require('./fixtures/png.js');
 const {
   makeTree,
   removeTree,
@@ -113,6 +114,23 @@ test('current symbols win and a legacy symbol fills a missing party', t => {
   const rebuilt = runParti(dir);
   assert.equal(rebuilt.status, 0, rebuilt.stderr);
   assert.deepEqual(readJson(dir, 'data/parti/testpartiet/index.json').partisymbol, current.partisymbol);
+});
+
+test('an imported symbol is measured as it is written', t => {
+  const dir = makeTree();
+  t.after(() => removeTree(dir));
+  const zip = writeZip(dir, { '9001_Val 2026.png': png(sheet(CLEAR)) });
+
+  assert.equal(runSymbolImport(dir, '2026', zip).status, 0);
+  assert.deepEqual(readJson(dir, 'data/parti/testpartiet/index.json').partisymbol, {
+    filnamn: '9001-testpartiet.png',
+    kalla: 'Valmyndigheten',
+    kallurl: symbolUrl('2026'),
+    valar: 2026,
+    partikod: '9001',
+    bild: { bredd: 10, hojd: 6 },
+    bildyta: { x: 3, y: 1, bredd: 4, hojd: 2 }
+  });
 });
 
 test('an unknown symbol code stops the import before writing', t => {

--- a/scripts/measure-partisymboler.js
+++ b/scripts/measure-partisymboler.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const path = require('path');
+
+const { contentBox } = require('./png.js');
+const { ROOT, dataPath } = require('./utils.js');
+const {
+  loadParties,
+  loadYearFiles,
+  buildParties,
+  validate,
+  applyRenames,
+  writeFiles
+} = require('./parti.js');
+
+/**
+ * measureParties
+ * Reads every committed symbol and records the sheet it was delivered on
+ * together with the box its drawing occupies. A file the reader leaves
+ * unmeasured keeps its provenance and loses any stale measurement.
+ * @param  {Object} registry From loadParties()
+ * @param  {Function} [readSymbol] Party to symbol bytes
+ * @return {{ measured: String[], unmeasured: String[] }} Party filnamn
+ */
+function measureParties (registry, readSymbol = party =>
+  fs.readFileSync(dataPath('parti', party.filnamn, party.partisymbol.filnamn))) {
+  const measured = [];
+  const unmeasured = [];
+  for (const party of registry.parties) {
+    if (!party.partisymbol) {
+      continue;
+    }
+    const box = contentBox(readSymbol(party));
+    const { bild, bildyta, ...provenance } = party.partisymbol;
+    party.partisymbol = box ? { ...provenance, ...box } : provenance;
+    (box ? measured : unmeasured).push(party.filnamn);
+  }
+  return { measured, unmeasured };
+}
+
+function main () {
+  const registry = loadParties();
+  const { measured, unmeasured } = measureParties(registry);
+  const yearFiles = loadYearFiles();
+  const build = buildParties(registry, yearFiles);
+  validate(build, yearFiles);
+  applyRenames(build.renamed);
+  const written = writeFiles(build.writeSet);
+
+  console.log(`Mätta symboler: ${measured.length}`);
+  console.log(`Omätta symboler: ${unmeasured.length}`);
+  for (const filnamn of unmeasured) {
+    console.log(`  ${path.relative(ROOT, dataPath('parti', filnamn))}`);
+  }
+  console.log(`Skrivna JSON-filer: ${written.length}`);
+}
+
+exports.measureParties = measureParties;
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/scripts/measure-partisymboler.test.js
+++ b/scripts/measure-partisymboler.test.js
@@ -1,0 +1,92 @@
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { test } = require('node:test');
+
+const { png, sheet, CLEAR } = require('./fixtures/png.js');
+const { measureParties } = require('./measure-partisymboler.js');
+const { makeTree, removeTree, runMeasureSymbols, readJson } = require('./fixtures/tree.js');
+
+const SYMBOL = png(sheet(CLEAR));
+const UNREADABLE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x01]);
+
+function registry (partisymbol) {
+  return { parties: [{ filnamn: 'testpartiet', partisymbol }] };
+}
+
+test('measureParties records the sheet and the box the drawing occupies', () => {
+  const provenance = {
+    filnamn: '9001-testpartiet.png',
+    kalla: 'Valmyndigheten',
+    kallurl: 'https://data.val.se/filer/val2026/parti/partisymboler.zip',
+    valar: 2026,
+    partikod: '9001'
+  };
+  const parties = registry({ ...provenance });
+  const result = measureParties(parties, () => SYMBOL);
+
+  assert.deepEqual(result, { measured: ['testpartiet'], unmeasured: [] });
+  assert.deepEqual(parties.parties[0].partisymbol, {
+    ...provenance,
+    bild: { bredd: 10, hojd: 6 },
+    bildyta: { x: 3, y: 1, bredd: 4, hojd: 2 }
+  });
+});
+
+test('an unmeasurable symbol keeps its provenance and loses a stale measurement', () => {
+  const parties = registry({
+    filnamn: '9001-testpartiet.png',
+    kalla: 'Valmyndigheten',
+    kallurl: 'https://example.com/symbol.png',
+    valar: 2026,
+    partikod: '9001',
+    bild: { bredd: 100, hojd: 20 },
+    bildyta: { x: 0, y: 0, bredd: 100, hojd: 20 }
+  });
+  const result = measureParties(parties, () => UNREADABLE);
+
+  assert.deepEqual(result, { measured: [], unmeasured: ['testpartiet'] });
+  assert.deepEqual(parties.parties[0].partisymbol, {
+    filnamn: '9001-testpartiet.png',
+    kalla: 'Valmyndigheten',
+    kallurl: 'https://example.com/symbol.png',
+    valar: 2026,
+    partikod: '9001'
+  });
+});
+
+test('a party without a symbol is left alone', () => {
+  const parties = registry(undefined);
+  assert.deepEqual(measureParties(parties, () => {
+    throw new Error('should not read a symbol');
+  }), { measured: [], unmeasured: [] });
+  assert.equal(parties.parties[0].partisymbol, undefined);
+});
+
+test('the script writes measurements into the committed registry', t => {
+  const dir = makeTree();
+  t.after(() => removeTree(dir));
+  const partyDir = path.join(dir, 'data/parti/testpartiet');
+  fs.writeFileSync(path.join(partyDir, '9001-testpartiet.png'), SYMBOL);
+  const party = readJson(partyDir, 'index.json');
+  party.partisymbol = {
+    filnamn: '9001-testpartiet.png',
+    kalla: 'Valmyndigheten',
+    kallurl: 'https://data.val.se/filer/val2026/parti/partisymboler.zip',
+    valar: 2026,
+    partikod: '9001'
+  };
+  fs.writeFileSync(path.join(partyDir, 'index.json'), JSON.stringify(party, null, 2) + '\n');
+
+  const result = runMeasureSymbols(dir);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Mätta symboler: 1/);
+  assert.match(result.stdout, /Omätta symboler: 0/);
+
+  const measured = readJson(partyDir, 'index.json').partisymbol;
+  assert.deepEqual(measured.bild, { bredd: 10, hojd: 6 });
+  assert.deepEqual(measured.bildyta, { x: 3, y: 1, bredd: 4, hojd: 2 });
+
+  const indexEntry = readJson(dir, 'data/parti/index.json').find(entry => entry.filnamn === 'testpartiet');
+  assert.deepEqual(indexEntry.partisymbol, measured);
+});

--- a/scripts/party-data.test.js
+++ b/scripts/party-data.test.js
@@ -313,8 +313,8 @@ test('home data lists parties in Swedish alphabetical order with participation f
     forkortning: 'A',
     symbolSrc: '/partisymbol/alfapartiet/9001-alfapartiet.png',
     deltagande: {
-      2022: { riksdag: true, regionLan: ['01', '12'], kommunLan: ['01', '12'] },
-      2026: { riksdag: false, regionLan: [], kommunLan: [] }
+      2022: { riksdag: true, regionLan: ['01', '12'], kommunKoder: ['0114', '1280', '1281'] },
+      2026: { riksdag: false, regionLan: [], kommunKoder: [] }
     }
   });
   assert.equal(home.parties[1].symbolSrc, undefined);

--- a/scripts/png.js
+++ b/scripts/png.js
@@ -1,0 +1,226 @@
+const zlib = require('node:zlib');
+
+const SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/**
+ * CHANNELS
+ * Samples per pixel for the colour types this reader decodes. Palette images
+ * (type 3) are absent from Valmyndigheten's symbols and are left unread.
+ * @type {Object}
+ */
+const CHANNELS = { 0: 1, 2: 3, 4: 2, 6: 4 };
+
+/**
+ * WHITE_FLOOR
+ * A channel value at or above this counts as the paper the symbol is drawn on,
+ * so a sheet with a white margin measures the same as one with a transparent
+ * margin.
+ * @type {Number}
+ */
+const WHITE_FLOOR = 243;
+
+/**
+ * ALPHA_FLOOR
+ * Below this an edge pixel contributes too little to move the content box.
+ * @type {Number}
+ */
+const ALPHA_FLOOR = 16;
+
+/**
+ * readHeader
+ * @param  {Buffer} data
+ * @return {Object|null} IHDR fields, or null when the buffer is not a PNG
+ */
+function readHeader (data) {
+  if (data.length < 33 || !data.subarray(0, 8).equals(SIGNATURE)) {
+    return null;
+  }
+  if (data.toString('latin1', 12, 16) !== 'IHDR') {
+    return null;
+  }
+  return {
+    bredd: data.readUInt32BE(16),
+    hojd: data.readUInt32BE(20),
+    bitDepth: data[24],
+    colorType: data[25],
+    interlace: data[28]
+  };
+}
+
+/**
+ * readPixelData
+ * Concatenates and inflates the IDAT chunks.
+ * @param  {Buffer} data
+ * @return {Buffer}
+ */
+function readPixelData (data) {
+  const parts = [];
+  let offset = 8;
+  while (offset + 8 <= data.length) {
+    const length = data.readUInt32BE(offset);
+    const type = data.toString('latin1', offset + 4, offset + 8);
+    if (type === 'IDAT') {
+      parts.push(data.subarray(offset + 8, offset + 8 + length));
+    } else if (type === 'IEND') {
+      break;
+    }
+    offset += length + 12;
+  }
+  return zlib.inflateSync(Buffer.concat(parts));
+}
+
+/**
+ * paeth
+ * @param  {Number} a Left
+ * @param  {Number} b Above
+ * @param  {Number} c Upper left
+ * @return {Number}
+ */
+function paeth (a, b, c) {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+  if (pa <= pb && pa <= pc) return a;
+  return pb <= pc ? b : c;
+}
+
+/**
+ * unfilterRow
+ * Reverses the per-scanline filter in place, reading the already restored row
+ * above.
+ * @param  {Number} filter
+ * @param  {Buffer} row
+ * @param  {Buffer} previous
+ * @param  {Number} pixelBytes
+ */
+function unfilterRow (filter, row, previous, pixelBytes) {
+  for (let i = 0; i < row.length; i++) {
+    const left = i >= pixelBytes ? row[i - pixelBytes] : 0;
+    const above = previous[i];
+    const upperLeft = i >= pixelBytes ? previous[i - pixelBytes] : 0;
+    switch (filter) {
+      case 0: break;
+      case 1: row[i] = (row[i] + left) & 0xff; break;
+      case 2: row[i] = (row[i] + above) & 0xff; break;
+      case 3: row[i] = (row[i] + ((left + above) >> 1)) & 0xff; break;
+      case 4: row[i] = (row[i] + paeth(left, above, upperLeft)) & 0xff; break;
+      default: throw new Error(`Unknown PNG filter type ${filter}`);
+    }
+  }
+}
+
+/**
+ * sampleReader
+ * @param  {Number} colorType
+ * @return {Function} Row and pixel index to { grey|red, green, blue, alpha }
+ */
+function sampleReader (colorType) {
+  const pixelBytes = CHANNELS[colorType];
+  if (colorType === 0) {
+    return (row, index) => {
+      const value = row[index * pixelBytes];
+      return { r: value, g: value, b: value, a: 255 };
+    };
+  }
+  if (colorType === 4) {
+    return (row, index) => {
+      const value = row[index * pixelBytes];
+      return { r: value, g: value, b: value, a: row[index * pixelBytes + 1] };
+    };
+  }
+  if (colorType === 2) {
+    return (row, index) => ({
+      r: row[index * pixelBytes],
+      g: row[index * pixelBytes + 1],
+      b: row[index * pixelBytes + 2],
+      a: 255
+    });
+  }
+  return (row, index) => ({
+    r: row[index * pixelBytes],
+    g: row[index * pixelBytes + 1],
+    b: row[index * pixelBytes + 2],
+    a: row[index * pixelBytes + 3]
+  });
+}
+
+/**
+ * boxFrom
+ * @param  {Object} bounds
+ * @param  {Number} width
+ * @param  {Number} height
+ * @return {Object|null} { x, y, bredd, hojd }
+ */
+function boxFrom (bounds, width, height) {
+  if (bounds.left > bounds.right) {
+    return null;
+  }
+  return {
+    x: bounds.left,
+    y: bounds.top,
+    bredd: Math.min(bounds.right - bounds.left + 1, width),
+    hojd: Math.min(bounds.bottom - bounds.top + 1, height)
+  };
+}
+
+/**
+ * contentBox
+ * Measures where the drawing sits inside the sheet it was delivered on. Symbols
+ * arrive on a fixed canvas with the mark placed anywhere inside it, so the box
+ * is what lets a renderer show every symbol at the same optical size.
+ *
+ * The visible box ignores both transparent and white margins; the opaque box
+ * ignores only transparent ones, and carries a symbol drawn entirely in white.
+ * @param  {Buffer} data
+ * @return {Object|null} { bild: { bredd, hojd }, bildyta: { x, y, bredd, hojd } },
+ *                       or null when the format is one this reader leaves unmeasured
+ */
+function contentBox (data) {
+  const header = readHeader(data);
+  if (!header || header.bitDepth !== 8 || header.interlace !== 0 || !CHANNELS[header.colorType]) {
+    return null;
+  }
+
+  const { bredd: width, hojd: height, colorType } = header;
+  const pixelBytes = CHANNELS[colorType];
+  const rowBytes = width * pixelBytes;
+  const pixels = readPixelData(data);
+  if (pixels.length < (rowBytes + 1) * height) {
+    return null;
+  }
+
+  const sample = sampleReader(colorType);
+  const visible = { left: width, right: -1, top: height, bottom: -1 };
+  const opaque = { left: width, right: -1, top: height, bottom: -1 };
+  let previous = Buffer.alloc(rowBytes);
+  let row = Buffer.alloc(rowBytes);
+
+  for (let y = 0; y < height; y++) {
+    const start = y * (rowBytes + 1);
+    pixels.copy(row, 0, start + 1, start + 1 + rowBytes);
+    unfilterRow(pixels[start], row, previous, pixelBytes);
+    for (let x = 0; x < width; x++) {
+      const { r, g, b, a } = sample(row, x);
+      if (a < ALPHA_FLOOR) continue;
+      if (x < opaque.left) opaque.left = x;
+      if (x > opaque.right) opaque.right = x;
+      if (y < opaque.top) opaque.top = y;
+      if (y > opaque.bottom) opaque.bottom = y;
+      if (r >= WHITE_FLOOR && g >= WHITE_FLOOR && b >= WHITE_FLOOR) continue;
+      if (x < visible.left) visible.left = x;
+      if (x > visible.right) visible.right = x;
+      if (y < visible.top) visible.top = y;
+      if (y > visible.bottom) visible.bottom = y;
+    }
+    const done = previous;
+    previous = row;
+    row = done;
+  }
+
+  const bildyta = boxFrom(visible, width, height) || boxFrom(opaque, width, height);
+  return bildyta ? { bild: { bredd: width, hojd: height }, bildyta } : null;
+}
+
+exports.contentBox = contentBox;
+exports.readHeader = readHeader;

--- a/scripts/png.test.js
+++ b/scripts/png.test.js
@@ -1,0 +1,64 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { contentBox, readHeader } = require('./png.js');
+const { png, sheet, WHITE, CLEAR, INK } = require('./fixtures/png.js');
+
+test('the content box ignores a transparent margin', () => {
+  assert.deepEqual(contentBox(png(sheet(CLEAR))), {
+    bild: { bredd: 10, hojd: 6 },
+    bildyta: { x: 3, y: 1, bredd: 4, hojd: 2 }
+  });
+});
+
+test('the content box ignores a white margin', () => {
+  assert.deepEqual(contentBox(png(sheet(WHITE), { colorType: 2 })).bildyta, { x: 3, y: 1, bredd: 4, hojd: 2 });
+});
+
+test('a nearly white margin counts as margin', () => {
+  const nearlyWhite = { r: 250, g: 248, b: 252, a: 255 };
+  assert.deepEqual(contentBox(png(sheet(nearlyWhite))).bildyta, { x: 3, y: 1, bredd: 4, hojd: 2 });
+});
+
+test('a mark drawn in white keeps the box its transparency gives it', () => {
+  assert.deepEqual(contentBox(png(sheet(CLEAR, WHITE))).bildyta, { x: 3, y: 1, bredd: 4, hojd: 2 });
+});
+
+test('a sheet the mark fills measures the whole sheet', () => {
+  const filled = sheet(INK, INK, { width: 4, height: 3, x: 0, y: 0, markWidth: 4, markHeight: 3 });
+  assert.deepEqual(contentBox(png(filled)), {
+    bild: { bredd: 4, hojd: 3 },
+    bildyta: { x: 0, y: 0, bredd: 4, hojd: 3 }
+  });
+});
+
+test('greyscale and greyscale with alpha measure the same box', () => {
+  const grey = { r: 30, g: 30, b: 30, a: 255 };
+  assert.deepEqual(contentBox(png(sheet(WHITE, grey), { colorType: 0 })).bildyta, { x: 3, y: 1, bredd: 4, hojd: 2 });
+  assert.deepEqual(contentBox(png(sheet(CLEAR, grey), { colorType: 4 })).bildyta, { x: 3, y: 1, bredd: 4, hojd: 2 });
+});
+
+test('filtered scanlines are restored before they are measured', () => {
+  assert.deepEqual(contentBox(png(sheet(CLEAR), { filters: [0, 1, 2, 3, 4] })).bildyta, { x: 3, y: 1, bredd: 4, hojd: 2 });
+});
+
+test('an empty sheet has no content box', () => {
+  assert.equal(contentBox(png(sheet(CLEAR, CLEAR))), null);
+});
+
+test('formats the reader leaves unmeasured return null', () => {
+  assert.equal(contentBox(png(sheet(CLEAR), { interlace: 1 })), null);
+  assert.equal(contentBox(png(sheet(CLEAR), { bitDepth: 16 })), null);
+  assert.equal(contentBox(Buffer.from('not a png at all, not even close')), null);
+});
+
+test('the header reports the sheet the symbol was delivered on', () => {
+  assert.deepEqual(readHeader(png(sheet(CLEAR))), {
+    bredd: 10,
+    hojd: 6,
+    bitDepth: 8,
+    colorType: 6,
+    interlace: 0
+  });
+  assert.equal(readHeader(Buffer.alloc(4)), null);
+});

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -3,6 +3,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { checkPartyProfileParliamentView } = require('./build-derived-data.js');
+const { readHeader } = require('./png.js');
 const { ROOT, toFileName } = require('./utils.js');
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -216,6 +217,48 @@ function validatePartyProfile (profile, context) {
   }
 }
 
+function requireInteger (value, context, minimum = 0) {
+  assert.ok(Number.isInteger(value) && value >= minimum, `${context} ska vara ett heltal från ${minimum}`);
+}
+
+/**
+ * validatePartySymbol
+ * The symbol file has to exist, and any measurement of it has to describe that
+ * file: a sheet of the size the file reports, and a box inside that sheet.
+ */
+function validatePartySymbol (symbol, file, context) {
+  requireString(symbol.filnamn, `${context}.filnamn`);
+  requireString(symbol.kalla, `${context}.kalla`);
+  requireUrl(symbol.kallurl, `${context}.kallurl`);
+  requireInteger(symbol.valar, `${context}.valar`, 1900);
+  requireString(symbol.partikod, `${context}.partikod`);
+  assert.ok(fs.existsSync(file), `${context}: symbolfilen ${symbol.filnamn} saknas`);
+
+  const measured = symbol.bild !== undefined || symbol.bildyta !== undefined;
+  if (!measured) return;
+  assert.ok(symbol.bild && symbol.bildyta, `${context}: bild och bildyta hör ihop`);
+  requireInteger(symbol.bild.bredd, `${context}.bild.bredd`, 1);
+  requireInteger(symbol.bild.hojd, `${context}.bild.hojd`, 1);
+  requireInteger(symbol.bildyta.x, `${context}.bildyta.x`);
+  requireInteger(symbol.bildyta.y, `${context}.bildyta.y`);
+  requireInteger(symbol.bildyta.bredd, `${context}.bildyta.bredd`, 1);
+  requireInteger(symbol.bildyta.hojd, `${context}.bildyta.hojd`, 1);
+  assert.ok(
+    symbol.bildyta.x + symbol.bildyta.bredd <= symbol.bild.bredd &&
+    symbol.bildyta.y + symbol.bildyta.hojd <= symbol.bild.hojd,
+    `${context}.bildyta ligger utanför bilden`
+  );
+
+  const header = readHeader(fs.readFileSync(file));
+  if (header) {
+    assert.deepEqual(
+      { bredd: header.bredd, hojd: header.hojd },
+      { bredd: symbol.bild.bredd, hojd: symbol.bild.hojd },
+      `${context}.bild stämmer inte med ${symbol.filnamn}`
+    );
+  }
+}
+
 function requireUnique (items, key, context) {
   const seen = new Set();
   for (const item of items) {
@@ -284,6 +327,14 @@ function validatePartyRegistry (dataDirectory) {
     );
     partiesByUuid.set(party.uuid, party);
     partySlugs.add(party.filnamn);
+
+    if (party.partisymbol !== undefined) {
+      validatePartySymbol(
+        party.partisymbol,
+        path.join(partyDirectory, entry.filnamn, party.partisymbol.filnamn || ''),
+        `${entry.filnamn}.partisymbol`
+      );
+    }
 
     const profileFile = path.join(partyDirectory, entry.filnamn, 'profil.json');
     if (fs.existsSync(profileFile)) {

--- a/src/components/PartyCard.tsx
+++ b/src/components/PartyCard.tsx
@@ -1,7 +1,8 @@
-import Image from 'next/image';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { ArrowUpRightIcon } from 'src/components/home/icons';
+import PartySymbol from 'src/components/PartySymbol';
+import type { SymbolFrame } from 'src/server/party-data';
 
 export type PartyCardVariant = 'large' | 'medium' | 'small';
 
@@ -10,6 +11,7 @@ export interface PartyCardProps {
   filnamn: string;
   forkortning?: string;
   symbolSrc?: string;
+  symbolFrame?: SymbolFrame;
   variant?: PartyCardVariant;
   meta?: ReactNode;
   sub?: ReactNode;
@@ -17,52 +19,33 @@ export interface PartyCardProps {
 
 const symbolSizes: Record<PartyCardVariant, string> = {
   large: '(max-width: 700px) 60vw, 210px',
-  medium: '(max-width: 700px) 50vw, 160px',
-  small: '(max-width: 700px) 45vw, 128px',
+  medium: '(max-width: 700px) 55vw, 208px',
+  small: '(max-width: 700px) 55vw, 208px',
 };
-
-/**
- * The abbreviation stands in for a symbol the registry does not have. It is
- * never shown next to one, since the symbol already carries that identity.
- */
-function SymbolSlot ({ beteckning, forkortning, symbolSrc, variant }: {
-  beteckning: string;
-  forkortning?: string;
-  symbolSrc?: string;
-  variant: PartyCardVariant;
-}) {
-  if (symbolSrc) {
-    return (
-      <span className="party-card__symbol">
-        <Image src={symbolSrc} alt="" aria-hidden="true" fill sizes={symbolSizes[variant]} unoptimized />
-      </span>
-    );
-  }
-
-  return (
-    <span className="party-card__symbol party-card__symbol--empty">
-      <span className="party-card__abbreviation" aria-hidden="true">
-        {forkortning ?? beteckning.trim().slice(0, 3).toUpperCase()}
-      </span>
-    </span>
-  );
-}
 
 function PartyCard ({
   beteckning,
   filnamn,
   forkortning,
   symbolSrc,
+  symbolFrame,
   variant = 'small',
   meta,
   sub,
 }: PartyCardProps) {
   return (
     <Link href={`/parti/${filnamn}`} className={`party-card party-card--${variant}`}>
-      <SymbolSlot beteckning={beteckning} forkortning={forkortning} symbolSrc={symbolSrc} variant={variant} />
+      <span className="party-card__symbol">
+        {symbolSrc
+          ? <PartySymbol src={symbolSrc} frame={symbolFrame} sizes={symbolSizes[variant]} />
+          : <span className="party-card__symbol-missing">Partisymbol saknas</span>}
+      </span>
 
       <span className="party-card__body">
-        <span className="party-card__name">{beteckning}</span>
+        <span className="party-card__heading">
+          <span className="party-card__name">{beteckning}</span>
+          {forkortning && <span className="party-card__abbreviation">{forkortning}</span>}
+        </span>
         {sub && <span className="party-card__sub">{sub}</span>}
       </span>
 

--- a/src/components/PartySymbol.tsx
+++ b/src/components/PartySymbol.tsx
@@ -1,0 +1,56 @@
+import Image from 'next/image';
+import type { CSSProperties } from 'react';
+import type { SymbolFrame } from 'src/server/party-data';
+
+export interface PartySymbolProps {
+  src: string;
+  frame?: SymbolFrame;
+  alt?: string;
+  sizes: string;
+  className?: string;
+  priority?: boolean;
+}
+
+/**
+ * Renders a party symbol at the size of its drawing rather than the size of the
+ * sheet it was delivered on: the frame takes the drawing's aspect ratio, and
+ * the file is scaled and shifted inside it so the sheet's margins fall outside.
+ * A symbol without a measured frame keeps the whole sheet and is fitted to the
+ * box it is given.
+ */
+function PartySymbol ({ src, frame, alt = '', sizes, className, priority }: PartySymbolProps) {
+  const classes = ['party-symbol', frame ? 'party-symbol--beskuren' : 'party-symbol--hel', className]
+    .filter(Boolean)
+    .join(' ');
+  const image = {
+    src,
+    sizes,
+    unoptimized: true,
+    ...(alt ? {} : { 'aria-hidden': 'true' as const }),
+    ...(priority ? { loading: 'eager' as const } : {}),
+  };
+
+  return (
+    <span className={classes} style={frame ? { '--party-symbol-ratio': String(frame.ratio) } as CSSProperties : undefined}>
+      {frame ? (
+        <Image
+          {...image}
+          alt={alt}
+          width={frame.bildbredd}
+          height={frame.bildhojd}
+          style={{
+            position: 'absolute',
+            width: `${frame.bredd * 100}%`,
+            height: `${frame.hojd * 100}%`,
+            left: `${frame.x * -100}%`,
+            top: `${frame.y * -100}%`,
+          }}
+        />
+      ) : (
+        <Image {...image} alt={alt} fill />
+      )}
+    </span>
+  );
+}
+
+export default PartySymbol;

--- a/src/components/home/HomeContent.tsx
+++ b/src/components/home/HomeContent.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useState } from 'react';
 import type { HomeData, HomeParty } from 'src/server/party-data';
 import type { ElectionKind, HomeFilters } from './filtering';
-import { PAGE_SIZE, emptyFilters, filterParties, pruneFilters } from './filtering';
+import { PAGE_SIZE, defaultFilters, filterParties, pruneFilters } from './filtering';
+import type { SortOrder } from './sorting';
+import { defaultOrder, sortParties } from './sorting';
 import PartyFilters from './PartyFilters';
 import PartyResults from './PartyResults';
 import RiksdagSection from './RiksdagSection';
@@ -13,7 +15,7 @@ function availableKinds (parties: HomeParty[]): ElectionKind[] {
     for (const facet of Object.values(party.deltagande)) {
       if (facet.riksdag) kinds.add('riksdag');
       if (facet.regionLan.length > 0) kinds.add('region');
-      if (facet.kommunLan.length > 0) kinds.add('kommun');
+      if (facet.kommunKoder.length > 0) kinds.add('kommun');
     }
   }
   return (['riksdag', 'region', 'kommun'] as const).filter(kind => kinds.has(kind));
@@ -22,12 +24,17 @@ function availableKinds (parties: HomeParty[]): ElectionKind[] {
 /**
  * Owns the filter state the controls write and the result grid reads.
  */
-function HomeContent ({ parties, valar, lan, riksdag, outsideParliament }: HomeData) {
-  const [filters, setFilters] = useState<HomeFilters>(emptyFilters);
+function HomeContent ({ parties, valar, lan, kommuner, riksdag, outsideParliament }: HomeData) {
+  const initialFilters = useMemo(() => defaultFilters(valar), [valar]);
+  const [filters, setFilters] = useState<HomeFilters>(initialFilters);
+  const [order, setOrder] = useState<SortOrder>(defaultOrder);
   const [visible, setVisible] = useState(PAGE_SIZE);
 
   const kinds = useMemo(() => availableKinds(parties), [parties]);
-  const matches = useMemo(() => filterParties(parties, filters), [parties, filters]);
+  const matches = useMemo(
+    () => sortParties(filterParties(parties, filters), order, filters),
+    [parties, filters, order],
+  );
 
   // The reveal count belongs to the result set it was reached in, so every
   // change of the filters starts over at the first page. Clearing the filters
@@ -46,9 +53,10 @@ function HomeContent ({ parties, valar, lan, riksdag, outsideParliament }: HomeD
         filters={filters}
         valar={valar}
         lan={lan}
+        kommuner={kommuner}
         kinds={kinds}
         onChange={update}
-        onReset={() => update(emptyFilters)}
+        onReset={() => update(initialFilters)}
       />
 
       <PartyResults
@@ -56,8 +64,11 @@ function HomeContent ({ parties, valar, lan, riksdag, outsideParliament }: HomeD
         total={parties.length}
         visible={visible}
         query={filters.query}
+        valar={filters.valar}
+        order={order}
+        onOrderChange={setOrder}
         onShowMore={() => setVisible(current => current + PAGE_SIZE)}
-        onReset={() => update(emptyFilters)}
+        onReset={() => update(initialFilters)}
       />
     </>
   );

--- a/src/components/home/OutsideParliamentSection.tsx
+++ b/src/components/home/OutsideParliamentSection.tsx
@@ -22,6 +22,7 @@ function OutsideParliamentSection ({ data }: { data: OutsideParliamentData }) {
               filnamn={party.filnamn}
               forkortning={party.forkortning}
               symbolSrc={party.symbolSrc}
+              symbolFrame={party.symbolFrame}
               variant="medium"
               meta={`${percentageFormatter.format(party.rostandel)} %`}
               sub={`Riksdagsvalet ${party.valar}`}

--- a/src/components/home/PartyFilters.tsx
+++ b/src/components/home/PartyFilters.tsx
@@ -1,7 +1,7 @@
-import { useId } from 'react';
-import type { HomeCounty } from 'src/server/party-data';
+import { useId, useMemo } from 'react';
+import type { HomeCounty, HomeMunicipality } from 'src/server/party-data';
 import type { ElectionKind, HomeFilters } from './filtering';
-import { countyApplies, electionKindLabels } from './filtering';
+import { countyApplies, electionKindLabels, municipalityApplies } from './filtering';
 import { ChevronDownIcon, RotateCcwIcon, SearchIcon } from './icons';
 import { toggleKind } from './summary';
 
@@ -9,13 +9,20 @@ export interface PartyFiltersProps {
   filters: HomeFilters;
   valar: string[];
   lan: HomeCounty[];
+  kommuner: HomeMunicipality[];
   kinds: ElectionKind[];
   onChange: (patch: Partial<HomeFilters>) => void;
   onReset: () => void;
 }
 
-function PartyFilters ({ filters, valar, lan, kinds, onChange, onReset }: PartyFiltersProps) {
+function PartyFilters ({ filters, valar, lan, kommuner, kinds, onChange, onReset }: PartyFiltersProps) {
   const fieldId = useId();
+  // A chosen county is the shorter way into its municipalities; without one the
+  // whole country is on offer.
+  const municipalities = useMemo(
+    () => filters.lan ? kommuner.filter(kommun => kommun.lan === filters.lan) : kommuner,
+    [kommuner, filters.lan],
+  );
 
   return (
     <section className="home-search" aria-label="Sök och filtrera partier">
@@ -53,6 +60,7 @@ function PartyFilters ({ filters, valar, lan, kinds, onChange, onReset }: PartyF
               aria-label="Län"
               value={filters.lan}
               disabled={!countyApplies(filters.valtyp)}
+              title={countyApplies(filters.valtyp) ? undefined : 'Riksdagsvalet är rikstäckande och har inget län'}
               onChange={event => onChange({ lan: event.target.value })}
             >
               <option value="">Hela landet</option>
@@ -62,16 +70,38 @@ function PartyFilters ({ filters, valar, lan, kinds, onChange, onReset }: PartyF
           </span>
         )}
 
+        {municipalities.length > 0 && (
+          <span className="home-select home-select--wide">
+            <select
+              aria-label="Kommun"
+              value={filters.kommun}
+              disabled={!municipalityApplies(filters.valtyp)}
+              title={municipalityApplies(filters.valtyp) ? undefined : 'Bara kommunvalet gäller en enskild kommun'}
+              onChange={event => onChange({
+                kommun: event.target.value,
+                ...(event.target.value ? { lan: event.target.value.slice(0, 2) } : {}),
+              })}
+            >
+              <option value="">Alla kommuner</option>
+              {municipalities.map(kommun => <option key={kommun.kod} value={kommun.kod}>{kommun.namn}</option>)}
+            </select>
+            <ChevronDownIcon className="home-select__chevron" />
+          </span>
+        )}
+
         {kinds.length > 0 && (
           <div className="home-chips" role="group" aria-label="Valtyp">
             {kinds.map(kind => {
               const pressed = filters.valtyp === kind;
+              const locked = (kind === 'riksdag' && Boolean(filters.lan)) || (kind !== 'kommun' && Boolean(filters.kommun));
               return (
                 <button
                   key={kind}
                   type="button"
                   className={`home-chip${pressed ? ' home-chip--on' : ''}`}
                   aria-pressed={pressed}
+                  disabled={locked}
+                  title={locked ? `${electionKindLabels[kind]} gäller inte ett valt område — välj Hela landet och Alla kommuner först` : undefined}
                   onClick={() => onChange({ valtyp: toggleKind(filters.valtyp, kind) })}
                 >
                   {electionKindLabels[kind]}

--- a/src/components/home/PartyResults.tsx
+++ b/src/components/home/PartyResults.tsx
@@ -1,20 +1,47 @@
 import PartyCard from 'src/components/PartyCard';
 import type { HomeParty } from 'src/server/party-data';
 import { ChevronDownIcon, SearchXIcon } from './icons';
-import { cardMeta, cardSub, partyLabel, queryEcho } from './summary';
+import type { SortOrder } from './sorting';
+import { isSortOrder, sortLabels, sortOrders } from './sorting';
+import { ballots, cardSub, levelLabels, noBallotLabel, partyLabel, queryEcho } from './summary';
 
 const numberFormatter = new Intl.NumberFormat('sv-SE');
+
+/**
+ * The elections a party stands in, each on the colour of the ballot paper it is
+ * voted with: yellow for parliament, blue for the region and white for the
+ * municipality. The regional and municipal ballots carry how many areas they
+ * cover.
+ */
+function BallotBadges ({ party, valar }: { party: HomeParty; valar: string }) {
+  const ballotList = ballots(party, valar);
+  if (ballotList.length === 0) return <>{noBallotLabel}</>;
+
+  return (
+    <span className="party-card__ballots">
+      {ballotList.map(ballot => (
+        <span key={ballot.valtyp} className={`party-card__ballot party-card__ballot--${ballot.valtyp}`}>
+          {levelLabels[ballot.valtyp]}
+          {ballot.antal !== undefined && <span className="party-card__ballot-count">{numberFormatter.format(ballot.antal)}</span>}
+        </span>
+      ))}
+    </span>
+  );
+}
 
 export interface PartyResultsProps {
   matches: HomeParty[];
   total: number;
   visible: number;
   query: string;
+  valar: string;
+  order: SortOrder;
+  onOrderChange: (order: SortOrder) => void;
   onShowMore: () => void;
   onReset: () => void;
 }
 
-function PartyResults ({ matches, total, visible, query, onShowMore, onReset }: PartyResultsProps) {
+function PartyResults ({ matches, total, visible, query, valar, order, onOrderChange, onShowMore, onReset }: PartyResultsProps) {
   const shown = matches.slice(0, visible);
   const remaining = matches.length - shown.length;
   const echo = queryEcho(query);
@@ -23,9 +50,18 @@ function PartyResults ({ matches, total, visible, query, onShowMore, onReset }: 
     <section className="home-section" aria-labelledby="alla-partier">
       <div className="home-section__header">
         <h2 id="alla-partier">
-          Alla partier <span className="home-section__count">{numberFormatter.format(matches.length)}</span>
+          Alla partier <span className="home-section__count">{numberFormatter.format(matches.length)} av {numberFormatter.format(total)}</span>
         </h2>
-        <p>Sorterat A–Ö</p>
+        <span className="home-select">
+          <select
+            aria-label="Sortering"
+            value={order}
+            onChange={event => isSortOrder(event.target.value) && onOrderChange(event.target.value)}
+          >
+            {sortOrders.map(value => <option key={value} value={value}>Sorterat {sortLabels[value]}</option>)}
+          </select>
+          <ChevronDownIcon className="home-select__chevron" />
+        </span>
       </div>
 
       <p className="sr-only" aria-live="polite">
@@ -42,8 +78,9 @@ function PartyResults ({ matches, total, visible, query, onShowMore, onReset }: 
                   filnamn={party.filnamn}
                   forkortning={party.forkortning}
                   symbolSrc={party.symbolSrc}
+                  symbolFrame={party.symbolFrame}
                   variant="small"
-                  meta={cardMeta(party)}
+                  meta={<BallotBadges party={party} valar={valar} />}
                   sub={cardSub(party)}
                 />
               </li>

--- a/src/components/home/RiksdagSection.tsx
+++ b/src/components/home/RiksdagSection.tsx
@@ -35,6 +35,7 @@ function RiksdagSection ({ years }: { years: ParliamentYear[] }) {
                 filnamn={party.filnamn}
                 forkortning={party.forkortning}
                 symbolSrc={party.symbolSrc}
+                symbolFrame={party.symbolFrame}
                 variant="large"
                 meta={`${party.mandat} mandat`}
               />

--- a/src/components/home/filtering.ts
+++ b/src/components/home/filtering.ts
@@ -7,11 +7,21 @@ export interface HomeFilters {
   valar: string;
   valtyp: ElectionKind | '';
   lan: string;
+  kommun: string;
 }
 
 export const PAGE_SIZE = 48;
 
-export const emptyFilters: HomeFilters = { query: '', valar: '', valtyp: '', lan: '' };
+export const emptyFilters: HomeFilters = { query: '', valar: '', valtyp: '', lan: '', kommun: '' };
+
+/**
+ * The filters the start page opens on: the latest election year the data
+ * carries, or no year at all when it carries none.
+ */
+export function defaultFilters (valar: string[]): HomeFilters {
+  const latest = valar.at(-1);
+  return latest ? { ...emptyFilters, valar: latest } : emptyFilters;
+}
 
 export const electionKindLabels: Record<ElectionKind, string> = {
   riksdag: 'Riksdagsval',
@@ -41,41 +51,67 @@ export function matchesQuery (party: HomeParty, query: string): boolean {
 }
 
 /**
- * The county filter narrows a ballot to its area, which only regional and
- * municipal ballots have.
+ * The county filter narrows a ballot to its area, which the regional and
+ * municipal ballots have and the nationwide parliamentary one does not.
  */
 export function countyApplies (valtyp: HomeFilters['valtyp']): boolean {
-  return valtyp === 'region' || valtyp === 'kommun';
+  return valtyp !== 'riksdag';
 }
 
 /**
- * Drops filter values the current election type leaves without meaning, so a
- * county chosen for a municipal election does not survive a switch to the
- * parliamentary one.
+ * A municipality names one municipal ballot, so it is the municipal election it
+ * narrows and no other.
+ */
+export function municipalityApplies (valtyp: HomeFilters['valtyp']): boolean {
+  return valtyp === '' || valtyp === 'kommun';
+}
+
+/**
+ * Drops filter values the rest of the filters leave without meaning: an area
+ * does not survive a switch to the nationwide election, and a municipality
+ * survives neither the regional election nor a county it lies outside.
  */
 export function pruneFilters (filters: HomeFilters): HomeFilters {
-  return countyApplies(filters.valtyp) ? filters : { ...filters, lan: '' };
+  const lan = countyApplies(filters.valtyp) ? filters.lan : '';
+  const keepsKommun = municipalityApplies(filters.valtyp) && (!lan || filters.kommun.startsWith(lan));
+  const kommun = keepsKommun ? filters.kommun : '';
+  return lan === filters.lan && kommun === filters.kommun ? filters : { ...filters, lan, kommun };
 }
 
 function participated (facet: ParticipationFacet): boolean {
-  return facet.riksdag || facet.regionLan.length > 0 || facet.kommunLan.length > 0;
+  return facet.riksdag || facet.regionLan.length > 0 || facet.kommunKoder.length > 0;
+}
+
+function inCounty (codes: string[], lan: string): boolean {
+  return codes.some(kod => kod.startsWith(lan));
 }
 
 function matchesKind (facet: ParticipationFacet, valtyp: ElectionKind, lan: string): boolean {
   if (valtyp === 'riksdag') return facet.riksdag;
-  const counties = valtyp === 'region' ? facet.regionLan : facet.kommunLan;
-  return lan ? counties.includes(lan) : counties.length > 0;
+  if (valtyp === 'region') return lan ? facet.regionLan.includes(lan) : facet.regionLan.length > 0;
+  return lan ? inCounty(facet.kommunKoder, lan) : facet.kommunKoder.length > 0;
+}
+
+/**
+ * A county on its own asks where a party is on the ballot at all, which the
+ * regional and the municipal election both answer.
+ */
+function inCountyArea (facet: ParticipationFacet, lan: string): boolean {
+  return facet.regionLan.includes(lan) || inCounty(facet.kommunKoder, lan);
 }
 
 export function matchesParticipation (party: HomeParty, filters: HomeFilters): boolean {
-  if (!filters.valar && !filters.valtyp) return true;
+  if (!filters.valar && !filters.valtyp && !filters.lan && !filters.kommun) return true;
 
   const facets = filters.valar
     ? [party.deltagande[filters.valar]].filter(Boolean)
     : Object.values(party.deltagande);
 
-  if (!filters.valtyp) return facets.some(participated);
+  if (filters.kommun) return facets.some(facet => facet.kommunKoder.includes(filters.kommun));
   const valtyp = filters.valtyp;
+  if (!valtyp) {
+    return filters.lan ? facets.some(facet => inCountyArea(facet, filters.lan)) : facets.some(participated);
+  }
   return facets.some(facet => matchesKind(facet, valtyp, filters.lan));
 }
 

--- a/src/components/home/sorting.ts
+++ b/src/components/home/sorting.ts
@@ -1,0 +1,43 @@
+import type { HomeParty } from 'src/server/party-data';
+import type { HomeFilters } from './filtering';
+import { yearFacets } from './summary.ts';
+
+export type SortOrder = 'namn' | 'kommuner' | 'senaste';
+
+export const defaultOrder: SortOrder = 'namn';
+
+export const sortLabels: Record<SortOrder, string> = {
+  namn: 'A–Ö',
+  kommuner: 'Flest kommuner',
+  senaste: 'Senast anmält',
+};
+
+export const sortOrders = Object.keys(sortLabels) as SortOrder[];
+
+export function isSortOrder (value: string): value is SortOrder {
+  return sortOrders.includes(value as SortOrder);
+}
+
+function municipalities (party: HomeParty, valar: HomeFilters['valar']): number {
+  return Math.max(0, ...yearFacets(party, valar).map(facet => facet.kommunKoder.length));
+}
+
+function latestYear (party: HomeParty): number {
+  return Math.max(0, ...Object.keys(party.deltagande).map(Number));
+}
+
+const rankings: Record<Exclude<SortOrder, 'namn'>, (party: HomeParty, valar: HomeFilters['valar']) => number> = {
+  kommuner: municipalities,
+  senaste: latestYear,
+};
+
+/**
+ * Ranks the matches for the chosen order. The parties arrive in Swedish name
+ * order and the sort is stable, so every ranking keeps that order within a tie
+ * and 'namn' is the list as it came.
+ */
+export function sortParties (parties: HomeParty[], order: SortOrder, filters: HomeFilters): HomeParty[] {
+  if (order === 'namn') return parties;
+  const rank = rankings[order];
+  return parties.toSorted((a, b) => rank(b, filters.valar) - rank(a, filters.valar));
+}

--- a/src/components/home/summary.ts
+++ b/src/components/home/summary.ts
@@ -1,35 +1,48 @@
-import type { HomeParty } from 'src/server/party-data';
+import type { HomeParty, ParticipationFacet } from 'src/server/party-data';
 import type { ElectionKind, HomeFilters } from './filtering';
 
-const levelLabels: Record<ElectionKind, string> = {
+export const levelLabels: Record<ElectionKind, string> = {
   riksdag: 'Riksdag',
   region: 'Region',
   kommun: 'Kommun',
 };
 
+export const noBallotLabel = 'Inget anmält deltagande';
+
+export interface Ballot {
+  valtyp: ElectionKind;
+  antal?: number;
+}
+
 /**
- * The levels a party has stood in, across every year it took part in.
+ * The years a reading covers: the chosen one alone when the filters name a
+ * year, otherwise every year the party took part in.
  */
-export function participationLevels (party: HomeParty): string[] {
-  const facets = Object.values(party.deltagande);
-  const levels: string[] = [];
-  if (facets.some(facet => facet.riksdag)) levels.push(levelLabels.riksdag);
-  if (facets.some(facet => facet.regionLan.length > 0)) levels.push(levelLabels.region);
-  if (facets.some(facet => facet.kommunLan.length > 0)) levels.push(levelLabels.kommun);
-  return levels;
+export function yearFacets (party: HomeParty, valar: HomeFilters['valar']): ParticipationFacet[] {
+  return valar
+    ? [party.deltagande[valar]].filter(Boolean)
+    : Object.values(party.deltagande);
+}
+
+/**
+ * The ballots a party stands on, with the number of regions and municipalities
+ * each covers. Across several years the widest year counts.
+ */
+export function ballots (party: HomeParty, valar: HomeFilters['valar'] = ''): Ballot[] {
+  const facets = yearFacets(party, valar);
+  const widest = (read: (facet: ParticipationFacet) => number) => Math.max(0, ...facets.map(read));
+  const region = widest(facet => facet.regionLan.length);
+  const kommun = widest(facet => facet.kommunKoder.length);
+
+  return [
+    ...(facets.some(facet => facet.riksdag) ? [{ valtyp: 'riksdag' as const }] : []),
+    ...(region > 0 ? [{ valtyp: 'region' as const, antal: region }] : []),
+    ...(kommun > 0 ? [{ valtyp: 'kommun' as const, antal: kommun }] : []),
+  ];
 }
 
 export function participationYears (party: HomeParty): string[] {
   return Object.keys(party.deltagande).sort((a, b) => Number(b) - Number(a));
-}
-
-/**
- * The card footer states what the party has stood in. A party the registry
- * carries without any recorded ballot says so rather than showing an empty bar.
- */
-export function cardMeta (party: HomeParty): string {
-  const levels = participationLevels(party);
-  return levels.length > 0 ? levels.join(' · ') : 'Inget anmält deltagande';
 }
 
 export function cardSub (party: HomeParty): string | undefined {

--- a/src/components/party-profile/overview.tsx
+++ b/src/components/party-profile/overview.tsx
@@ -1,5 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import PartySymbol from 'src/components/PartySymbol';
+import type { SymbolFrame } from 'src/server/party-data';
 import type {
   Parti,
   PartiDeltagande,
@@ -42,6 +44,7 @@ export function ProfileHero ({
   displayName,
   symbol,
   symbolSrc,
+  symbolFrame,
   latestResult,
   latestParticipation,
 }: {
@@ -51,6 +54,7 @@ export function ProfileHero ({
   displayName: string;
   symbol?: Parti['partisymbol'];
   symbolSrc?: string;
+  symbolFrame?: SymbolFrame;
   latestResult?: PartiProfilValresultatPost;
   latestParticipation?: [string, PartiDeltagande];
 }) {
@@ -71,7 +75,16 @@ export function ProfileHero ({
         </div>
         {symbolSrc && symbol && (
           <figure className={`profile-logo${profile.symbolvisning === 'mark' ? ' profile-logo--mark' : ''}`}>
-            <div><Image src={symbolSrc} alt={`Logotyp för ${displayName}`} fill sizes="(max-width: 800px) 80vw, 26vw" loading="eager" unoptimized /></div>
+            <div>
+              <PartySymbol
+                src={symbolSrc}
+                frame={symbolFrame}
+                alt={`Logotyp för ${displayName}`}
+                sizes="(max-width: 800px) 80vw, 26vw"
+                className="profile-logo__frame"
+                priority
+              />
+            </div>
             <figcaption>Partisymbol från <a href={symbol.kallurl}>{symbol.kalla}</a>, återgiven för identifiering.</figcaption>
           </figure>
         )}

--- a/src/pages/parti/[filnamn].tsx
+++ b/src/pages/parti/[filnamn].tsx
@@ -27,6 +27,7 @@ function PartyPage ({
   candidateLists = {},
   profile,
   symbolSrc,
+  symbolFrame,
 }: PartyPageProps) {
   const displayName = profile?.namn ?? registeredName;
   const pageName = duplicateName && area ? `${displayName} (${area})` : displayName;
@@ -50,7 +51,7 @@ function PartyPage ({
           <link rel="icon" href="/img/partidata/mark.svg" type="image/svg+xml" />
           <link rel="canonical" href={`https://www.partidata.se/parti/${slug}/`} />
         </Head>
-        <ProfileHero code={code} abbreviation={abbreviation} profile={resolvedProfile} displayName={pageName} symbol={symbol} symbolSrc={symbolSrc} latestResult={latestResult} latestParticipation={participationYears[0]} />
+        <ProfileHero code={code} abbreviation={abbreviation} profile={resolvedProfile} displayName={pageName} symbol={symbol} symbolSrc={symbolSrc} symbolFrame={symbolFrame} latestResult={latestResult} latestParticipation={participationYears[0]} />
         <DocumentsSection profile={resolvedProfile} abbreviation={abbreviation} />
         <RepresentativesSection profile={resolvedProfile} abbreviation={abbreviation} mandateCount={latestResult?.mandat} />
         {profile?.valresultat && <ElectionResultsSection results={profile.valresultat} partyLabel={abbreviation} />}

--- a/src/server/party-data.ts
+++ b/src/server/party-data.ts
@@ -1,9 +1,15 @@
 import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 
-import type { Parti, PartiIndexEntry, PartiProfil, PartiProfilKalla } from '../types';
+import type { Parti, PartiIndexEntry, PartiProfil, PartiProfilKalla, PartiSymbol } from '../types';
 import { assertSwedishCollation, compareSv } from './collation.ts';
 
+/**
+ * The election a candidate list belongs to, as `val/<år>/kandidatlistor/` names
+ * it: riksdag, landsting (region) and kommun. `R` and `K` are also
+ * DELTAGANDEGRUND values in `val/<år>/partideltagande/`, where they mean
+ * something else entirely.
+ */
 export type ElectionType = 'R' | 'L' | 'K';
 export type CandidateLists = Record<string, ElectionType[]>;
 
@@ -12,12 +18,31 @@ export interface PartyPageData extends Parti {
   duplicateName: boolean;
   profile?: PartiProfil;
   symbolSrc?: string;
+  symbolFrame?: SymbolFrame;
 }
 
 export type PartyResolution =
   | { kind: 'party'; props: PartyPageData }
   | { kind: 'redirect'; destination: string }
   | { kind: 'notFound' };
+
+/**
+ * A symbol's drawing measured in its own widths and heights: the aspect ratio
+ * of the drawing, the sheet it was delivered on as a multiple of the drawing,
+ * and the drawing's offset within that sheet. Symbols arrive on a fixed canvas
+ * with the mark placed anywhere inside it, so these are the multiples a
+ * renderer scales and shifts the file by to show every symbol at the same
+ * optical size. `bildbredd` and `bildhojd` are the sheet in pixels.
+ */
+export interface SymbolFrame {
+  ratio: number;
+  bredd: number;
+  hojd: number;
+  x: number;
+  y: number;
+  bildbredd: number;
+  bildhojd: number;
+}
 
 export interface PartySymbolData {
   body: Buffer;
@@ -26,14 +51,14 @@ export interface PartySymbolData {
 
 /**
  * A party's participation in one election year, reduced to what the start page
- * filters on: whether it stood for parliament, and the counties its regional
- * and municipal ballots fall in. Municipal codes carry their county in their
- * first two digits.
+ * filters and sorts on: whether it stood for parliament, the counties its
+ * regional ballots fall in, and the municipalities its municipal ballots cover.
+ * Municipal codes carry their county in their first two digits.
  */
 export interface ParticipationFacet {
   riksdag: boolean;
   regionLan: string[];
-  kommunLan: string[];
+  kommunKoder: string[];
 }
 
 export interface HomeParty {
@@ -44,12 +69,19 @@ export interface HomeParty {
   omrade?: string;
   duplicateName?: boolean;
   symbolSrc?: string;
+  symbolFrame?: SymbolFrame;
   deltagande: Record<string, ParticipationFacet>;
 }
 
 export interface HomeCounty {
   kod: string;
   namn: string;
+}
+
+export interface HomeMunicipality {
+  kod: string;
+  namn: string;
+  lan: string;
 }
 
 export interface ParliamentParty {
@@ -59,6 +91,7 @@ export interface ParliamentParty {
   beteckning?: string;
   filnamn?: string;
   symbolSrc?: string;
+  symbolFrame?: SymbolFrame;
 }
 
 export interface ParliamentYear {
@@ -73,6 +106,7 @@ export interface OutsideParliamentParty {
   filnamn: string;
   forkortning?: string;
   symbolSrc?: string;
+  symbolFrame?: SymbolFrame;
   valar: number;
   roster: number;
   rostandel: number;
@@ -89,6 +123,7 @@ export interface HomeData {
   parties: HomeParty[];
   valar: string[];
   lan: HomeCounty[];
+  kommuner: HomeMunicipality[];
   riksdag: ParliamentYear[];
   outsideParliament?: OutsideParliamentData;
 }
@@ -96,6 +131,7 @@ export interface HomeData {
 interface RegionFile {
   kod: string;
   namn: string;
+  kommuner?: Array<{ kod: string; namn: string }>;
 }
 
 interface ParliamentResultFile {
@@ -152,6 +188,22 @@ function symbolSource (party: Pick<Parti, 'filnamn' | 'partisymbol'>): string | 
     : undefined;
 }
 
+export function symbolFrame (symbol?: PartiSymbol): SymbolFrame | undefined {
+  const { bild, bildyta } = symbol ?? {};
+  if (!bild || !bildyta || bild.bredd <= 0 || bild.hojd <= 0 || bildyta.bredd <= 0 || bildyta.hojd <= 0) {
+    return undefined;
+  }
+  return {
+    ratio: bildyta.bredd / bildyta.hojd,
+    bredd: bild.bredd / bildyta.bredd,
+    hojd: bild.hojd / bildyta.hojd,
+    x: bildyta.x / bildyta.bredd,
+    y: bildyta.y / bildyta.hojd,
+    bildbredd: bild.bredd,
+    bildhojd: bild.hojd,
+  };
+}
+
 function partyNameKey (name: string): string {
   return name.trim().toLocaleLowerCase('sv-SE').replace(/\s+/g, ' ');
 }
@@ -162,7 +214,7 @@ function facet (participation: Parti['deltagande']): Record<string, Participatio
     facets[year] = {
       riksdag: Boolean(entry.riksdag),
       regionLan: [...new Set(entry.region ?? [])].sort(),
-      kommunLan: [...new Set((entry.kommun ?? []).map(kod => kod.slice(0, 2)))].sort(),
+      kommunKoder: [...new Set(entry.kommun ?? [])].sort(),
     };
   }
   return facets;
@@ -241,6 +293,7 @@ export function createPartyDataStore (
       readCandidateLists(slug),
     ]);
     const symbolSrc = symbolSource(party);
+    const frame = symbolFrame(party.partisymbol);
 
     return {
       ...party,
@@ -248,6 +301,7 @@ export function createPartyDataStore (
       duplicateName,
       ...(profile ? { profile } : {}),
       ...(symbolSrc ? { symbolSrc } : {}),
+      ...(frame ? { symbolFrame: frame } : {}),
     };
   }
 
@@ -272,12 +326,14 @@ export function createPartyDataStore (
         partier: result.mandatfordelning.partier.map(entry => {
           const party = byUuid.get(entry.parti_uuid);
           const symbolSrc = party ? symbolSource(party) : undefined;
+          const frame = symbolFrame(party?.partisymbol);
           return {
             uuid: entry.parti_uuid,
             forkortning: party?.forkortning ?? entry.kallkod ?? entry.partibeteckning,
             mandat: entry.mandat,
             ...(party ? { beteckning: party.beteckning, filnamn: party.filnamn } : {}),
             ...(symbolSrc ? { symbolSrc } : {}),
+            ...(frame ? { symbolFrame: frame } : {}),
           };
         }),
       }))
@@ -291,12 +347,14 @@ export function createPartyDataStore (
       const party = byUuid.get(result.parti_uuid);
       if (!party) return undefined;
       const symbolSrc = symbolSource(party);
+      const frame = symbolFrame(party.partisymbol);
       return {
         uuid: party.uuid,
         beteckning: party.beteckning,
         filnamn: party.filnamn,
         ...(party.forkortning ? { forkortning: party.forkortning } : {}),
         ...(symbolSrc ? { symbolSrc } : {}),
+        ...(frame ? { symbolFrame: frame } : {}),
         valar: result.valar,
         roster: result.roster,
         rostandel: result.rostandel,
@@ -317,6 +375,7 @@ export function createPartyDataStore (
     const parties: HomeParty[] = (await Promise.all(index.parties.map(async entry => {
       const party = await readJson<Parti>(path.join(dataRoot, 'parti', entry.filnamn, 'index.json'));
       const symbolSrc = symbolSource(entry);
+      const frame = symbolFrame(entry.partisymbol);
       return {
         uuid: entry.uuid,
         beteckning: entry.beteckning,
@@ -325,6 +384,7 @@ export function createPartyDataStore (
         ...(entry.omrade ? { omrade: entry.omrade } : {}),
         ...(index.duplicateNames.has(partyNameKey(entry.beteckning)) ? { duplicateName: true } : {}),
         ...(symbolSrc ? { symbolSrc } : {}),
+        ...(frame ? { symbolFrame: frame } : {}),
         deltagande: facet(party.deltagande),
       };
     }))).sort((a, b) => compareSv(a.beteckning, b.beteckning) || compareSv(a.filnamn, b.filnamn));
@@ -335,6 +395,9 @@ export function createPartyDataStore (
     const lan = regions
       .map(region => ({ kod: region.kod, namn: region.namn }))
       .sort((a, b) => compareSv(a.namn, b.namn));
+    const kommuner = regions
+      .flatMap(region => (region.kommuner ?? []).map(kommun => ({ kod: kommun.kod, namn: kommun.namn, lan: region.kod })))
+      .sort((a, b) => compareSv(a.namn, b.namn));
 
     const byUuid = new Map(index.parties.map(party => [party.uuid, party]));
     const [riksdag, outsideParliament] = await Promise.all([
@@ -342,7 +405,7 @@ export function createPartyDataStore (
       readOutsideParliament(byUuid),
     ]);
 
-    return { parties, valar, lan, riksdag, ...(outsideParliament ? { outsideParliament } : {}) };
+    return { parties, valar, lan, kommuner, riksdag, ...(outsideParliament ? { outsideParliament } : {}) };
   }
 
   return {

--- a/src/styles/_home.scss
+++ b/src/styles/_home.scss
@@ -114,6 +114,16 @@
   font-size: 1rem;
 }
 
+.home-chip:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.home-chip:disabled:hover {
+  border-color: var(--partidata-chip-off-line);
+  color: var(--partidata-ink);
+}
+
 .home-chip:hover {
   border-color: var(--partidata-navy);
   color: var(--partidata-navy);

--- a/src/styles/_party-card.scss
+++ b/src/styles/_party-card.scss
@@ -1,12 +1,13 @@
 .party-card {
   --party-card-pad: 1rem 1rem 0.875rem;
   --party-card-gap: 0.75rem;
-  --party-card-symbol-width: 8rem;
-  --party-card-symbol-height: 1.5rem;
+  --party-card-symbol-width: 13rem;
+  --party-card-symbol-height: 2rem;
   --party-card-name: 1rem;
   --party-card-meta: 0.875rem;
   --party-card-abbreviation: 0.78125rem;
   --party-card-abbreviation-pad: 0.25rem 0.5rem;
+  --party-card-ballot: 0.75rem;
   --party-card-foot-pad: 0.6875rem;
   --party-card-icon: 0.9375rem;
   --party-card-radius: 0.625rem;
@@ -34,25 +35,49 @@
 }
 
 .party-card__symbol {
-  position: relative;
-  display: block;
-  width: 100%;
-  max-width: var(--party-card-symbol-width);
-  height: var(--party-card-symbol-height);
-}
-
-.party-card__symbol img {
-  object-fit: contain;
-  object-position: left center;
-}
-
-.party-card__symbol--empty {
   display: flex;
+  height: var(--party-card-symbol-height);
   align-items: center;
 }
 
+.party-card__symbol .party-symbol--beskuren {
+  width: min(var(--party-card-symbol-width), var(--party-card-symbol-height) * var(--party-symbol-ratio));
+  max-width: var(--party-card-symbol-width);
+  max-height: 100%;
+}
+
+.party-card__symbol .party-symbol--hel {
+  width: 100%;
+  max-width: var(--party-card-symbol-width);
+  height: 100%;
+}
+
+.party-card__symbol .party-symbol--hel img {
+  object-position: left center;
+}
+
+.party-card__symbol-missing {
+  display: inline-flex;
+  height: 100%;
+  align-items: center;
+  padding: 0 0.5rem;
+  border: 1px dashed var(--partidata-line);
+  border-radius: 0.25rem;
+  color: var(--partidata-muted);
+  font-size: var(--party-card-ballot);
+  opacity: 0.6;
+}
+
+.party-card__heading {
+  display: flex;
+  gap: 0.625rem;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
 .party-card__abbreviation {
-  max-width: 100%;
+  flex: none;
+  max-width: 45%;
   padding: var(--party-card-abbreviation-pad);
   border: 1.5px solid var(--partidata-chip-line);
   border-radius: 0.25rem;
@@ -75,6 +100,7 @@
 }
 
 .party-card__name {
+  min-width: 0;
   font-size: var(--party-card-name);
   font-weight: 600;
   letter-spacing: -0.012em;
@@ -114,6 +140,50 @@
   overflow-wrap: anywhere;
 }
 
+.party-card__ballots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3125rem;
+}
+
+.party-card__ballot {
+  padding: 0.1875rem 0.4375rem;
+  border: 1px solid;
+  border-radius: 0.25rem;
+  color: var(--partidata-ink);
+  font-size: var(--party-card-ballot);
+  letter-spacing: 0.01em;
+  line-height: 1.25;
+  white-space: nowrap;
+}
+
+.party-card__ballot-count::before {
+  content: " (";
+}
+
+.party-card__ballot-count::after {
+  content: ")";
+}
+
+.party-card__ballot-count {
+  font-variant-numeric: tabular-nums;
+}
+
+.party-card__ballot--riksdag {
+  border-color: var(--partidata-valsedel-riksdag-line);
+  background: var(--partidata-valsedel-riksdag);
+}
+
+.party-card__ballot--region {
+  border-color: var(--partidata-valsedel-region-line);
+  background: var(--partidata-valsedel-region);
+}
+
+.party-card__ballot--kommun {
+  border-color: var(--partidata-valsedel-kommun-line);
+  background: var(--partidata-valsedel-kommun);
+}
+
 .party-card__arrow {
   width: var(--party-card-icon);
   height: var(--party-card-icon);
@@ -124,8 +194,8 @@
 .party-card--medium {
   --party-card-pad: 1.25rem;
   --party-card-gap: 1rem;
-  --party-card-symbol-width: 10rem;
-  --party-card-symbol-height: 1.875rem;
+  --party-card-symbol-width: 13rem;
+  --party-card-symbol-height: 2.25rem;
   --party-card-name: 1.0625rem;
   --party-card-meta: 0.9375rem;
   --party-card-abbreviation: 0.875rem;

--- a/src/styles/_party-profile.scss
+++ b/src/styles/_party-profile.scss
@@ -103,28 +103,36 @@
 }
 
 .profile-logo {
+  --profile-logo-height: clamp(4.5rem, 7vw, 6rem);
   margin: 0;
 }
 
 .profile-logo > div {
-  position: relative;
+  display: flex;
   min-height: clamp(8rem, 12vw, 10.5rem);
+  align-items: center;
+  justify-content: center;
   padding: clamp(1.25rem, 2.2vw, 1.875rem) clamp(1.375rem, 2.4vw, 2.125rem);
   border-radius: 0.75rem;
   background: var(--profile-card);
 }
 
-.profile-logo img {
-  object-fit: contain;
-  padding: clamp(1.125rem, 1.7vw, 1.75rem);
+.profile-logo__frame.party-symbol--beskuren {
+  width: min(100%, var(--profile-logo-height) * var(--party-symbol-ratio));
+  max-height: var(--profile-logo-height);
+}
+
+.profile-logo__frame.party-symbol--hel {
+  width: 100%;
+  height: clamp(5rem, 8vw, 7rem);
+}
+
+.profile-logo--mark {
+  --profile-logo-height: clamp(4rem, 6vw, 5.25rem);
 }
 
 .profile-logo--mark > div {
   max-width: 15rem;
-}
-
-.profile-logo--mark img {
-  padding: 2rem;
 }
 
 .profile-logo figcaption {

--- a/src/styles/_party-symbol.scss
+++ b/src/styles/_party-symbol.scss
@@ -1,0 +1,20 @@
+.party-symbol {
+  position: relative;
+  display: block;
+  overflow: hidden;
+}
+
+/* The frame takes the drawing's own aspect ratio, and the image inside it is
+   scaled and shifted by the multiples the measurement gives, so the sheet's
+   margins fall outside the frame. */
+.party-symbol--beskuren {
+  aspect-ratio: var(--party-symbol-ratio);
+}
+
+.party-symbol--beskuren img {
+  max-width: none;
+}
+
+.party-symbol--hel img {
+  object-fit: contain;
+}

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -1,5 +1,6 @@
 @use "./home";
 @use "./party-card";
+@use "./party-symbol";
 @use "./party-profile";
 
 :root {
@@ -13,6 +14,12 @@
   --partidata-card-divider: #e6e2d6;
   --partidata-control-line: #b9b4a4;
   --partidata-chip-line: #c3cdde;
+  --partidata-valsedel-riksdag: #fdf7dc;
+  --partidata-valsedel-riksdag-line: #eee3b6;
+  --partidata-valsedel-region: #eaf1f9;
+  --partidata-valsedel-region-line: #d5e2ef;
+  --partidata-valsedel-kommun: #fcfbf7;
+  --partidata-valsedel-kommun-line: #e4e0d4;
   --partidata-chip-off-line: #cfcbbd;
   --partidata-footer: var(--partidata-soft);
   --partidata-text: #131313;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,10 @@ export interface Parti {
 }
 
 /**
- * The best known symbol for a party and its provenance.
+ * The best known symbol for a party and its provenance. `bild` is the sheet the
+ * symbol file measures, and `bildyta` the box its drawing occupies inside that
+ * sheet, both in pixels; a symbol delivered in a format the importer leaves
+ * unmeasured carries neither.
  */
 export interface PartiSymbol {
   filnamn: string;
@@ -26,6 +29,20 @@ export interface PartiSymbol {
   kallurl: string;
   valar: number;
   partikod: string;
+  bild?: PartiSymbolBild;
+  bildyta?: PartiSymbolBildyta;
+}
+
+export interface PartiSymbolBild {
+  bredd: number;
+  hojd: number;
+}
+
+export interface PartiSymbolBildyta {
+  x: number;
+  y: number;
+  bredd: number;
+  hojd: number;
 }
 
 /**


### PR DESCRIPTION
The start page cards showed either the logotype or the abbreviation as if the two were interchangeable, and many logotypes rendered as postage stamps. This PR normalises the symbols, rebuilds the card and extends the filtering and the sorting.

## Normalised party symbols

Valmyndigheten's symbols sit on a fixed canvas (usually 1026×153) with the drawing placed anywhere inside it — the content occupies between 4% and 100% of the width. `scripts/png.js` is a PNG reader in plain Node (zlib, no new dependencies) that measures the sheet and the drawing's box. Both transparent and white margins count as margin; a symbol drawn entirely in white gets the box its transparency gives it.

The measurements are stored as `partisymbol.bild` and `partisymbol.bildyta` in pixels. The original files are untouched, so the provenance chain to Valmyndigheten stays intact. 250 of 251 symbols are measured — the only unmeasured one is interlaced and in practice fills its sheet, so it renders as before.

- `npm run import-partisymboler` measures at import time
- `npm run measure-partisymboler` measures the already committed symbols after the fact
- `npm run validate:data` checks that the symbol file exists and that `bild` matches the PNG header

`PartySymbol` renders the frame in the drawing's own aspect ratio and scales and shifts the file so that the sheet's margins fall outside. The same component is used in the party page hero.

## The card

- The abbreviation appears as a right-aligned badge beside the name, not in the logotype's place, and only when `forkortning` exists in the data — the invented three-letter stub is gone
- Cards without a symbol get the placeholder "Partisymbol saknas" so the row stays aligned
- The card footer shows participation as badges in the ballot papers' colours (yellow parliament, blue region, white municipality) with the number of regions and municipalities, for example `Region (20)` `Kommun (290)` against `Kommun (1)`
- The badges follow the election year filter: with the filter on 2026 it counts 2026, otherwise the party's widest year
- The symbol area on the small cards is larger, so a wide logotype is not clipped by the width long before the height

## Filters and sorting

- The start page opens on the latest election year in the data instead of on the whole registry, and the heading shows the matches against the total: "Alla partier 416 av 670"
- Sorting by A–Ö, most municipalities or most recent registration, in a control beside the heading. The sorting respects the election year filter and is stable, so parties that rank equally keep their alphabetical order
- The county filter is open from the start and instead locks "Riksdagsval"; the lock is mutual and both controls explain why in their `title`
- A county on its own means "stands in the regional or the municipal election in that county" — previously the county was silently ignored when no election type was chosen
- A municipality selector filters on a single municipality. Without a county chosen it lists all 290 municipalities, with one it lists that county's. Choosing a municipality sets the county automatically, and switching county clears a municipality outside it

`ParticipationFacet` now carries `kommunKoder` instead of `kommunLan` and `kommunAntal`. County membership is the code's first two digits and the count is the list's length, so two derived fields could be removed. The payload grows by 7 kB gzip (2 kB brotli) — four-digit codes compress almost away.

## Documentation

The README now describes Valmyndigheten's participation grounds `A`, `R` and `K` with a source link, and that all three mean participation and differ only in how the party qualified. A new section sets the three code systems in `data/val/` side by side, since `R` and `K` mean different things in two of them: participation ground and the candidate lists' election type. `ElectionType` in the code carries the same warning.

The quote about a parliamentary registration applying to regional and municipal councils nationwide stays, but is followed by what the file actually shows: 156 parties have `A` in the parliamentary election, of which 115 appear in all 290 municipalities and 41 in between 0 and 287, while seven parties appear in all 290 without `A` in the parliamentary election. The file therefore does not distinguish a registration of its own per electoral area from one that applies more widely.

## Test

`npm run precommit` is green. New tests: `scripts/png.test.js` (10), `scripts/measure-partisymboler.test.js` (4), `scripts/home-sorting.test.js` (7), plus extended filtering and summary tests. The HTTP smoke checks that the page opens on the latest election year, that the heading counts against the total and that the sort control is present.

The rendering has been checked in the browser on both desktop and mobile, and the filter figures are verified against the data: Skåne 163, Malmö 131, Vellinge 128 parties for 2026.
