### PR TITLE
Report the built version in the health check and the footer

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,6 +32,18 @@ jobs:
           cache: npm
 
       - run: npm ci
+
+      # The artifact reports the version from package.json, so a tag that names
+      # a different one would deploy a build that misidentifies itself.
+      - name: Verify the tag matches package.json
+        if: github.ref_type == 'tag'
+        run: |
+          version="v$(node -p "require('./package.json').version")"
+          if [ "$version" != "$GITHUB_REF_NAME" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match package.json $version" >&2
+            exit 1
+          fi
+
       - run: npm run precommit
 
       - name: Install deploy key

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -9,13 +9,22 @@ included in the artifact and read by the Node process at request time.
 
 ## Release
 
+The version in `package.json` is what the deployed artifact reports, in
+`/api/health` and in the site footer. A release raises it and tags the same
+number; the workflow refuses to build a `v*` tag that names a different one.
+
 ```bash
 git switch main && git pull
-git tag v0.6.0
-git push origin v0.6.0
+npm version minor --no-git-tag-version   # or patch / major
+git commit -am "Släpp $(node -p "require('./package.json').version")"
+git push origin main
+git tag "v$(node -p "require('./package.json').version")"
+git push origin "v$(node -p "require('./package.json').version")"
 ```
 
-To return to older code, run the workflow manually from an earlier tag.
+To return to older code, run the workflow manually from an earlier tag. The
+version check is skipped then, so the artifact reports the version that ref
+carries.
 
 ## One-time server setup
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,19 @@
+import { readFileSync } from 'node:fs';
+
 import type { NextConfig } from 'next';
 
+/**
+ * The released version, read from package.json at build time and inlined into
+ * both bundles as `process.env.PARTIDATA_VERSION`. The deploy workflow refuses
+ * to build a `v*` tag that names a different version, so what the artifact
+ * reports is the tag it was built from.
+ */
+const { version } = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf8'),
+) as { version: string };
+
 const nextConfig: NextConfig = {
+  env: { PARTIDATA_VERSION: version },
   output: 'standalone',
   trailingSlash: true,
   images: { unoptimized: true },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partidata",
-  "version": "0.1.0",
+  "version": "0.10.0",
   "description": "Öppen data om politiska partier i Sverige",
   "private": true,
   "repository": {

--- a/scripts/http-smoke.js
+++ b/scripts/http-smoke.js
@@ -78,6 +78,7 @@ async function waitForHealth (baseUrl, child, output) {
 
 async function main () {
   if (!fs.existsSync(path.join(releaseRoot, 'server.js'))) throw new Error('Kör npm run build:release före npm run test:http');
+  const { version } = JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8'));
   const parties = JSON.parse(fs.readFileSync(path.join(projectRoot, 'data', 'parti', 'index.json'), 'utf8'));
   const derivedParliament = JSON.parse(fs.readFileSync(path.join(projectRoot, 'data', 'derived', 'riksdag.json'), 'utf8'));
   const chamber = derivedParliament.kammare;
@@ -190,7 +191,9 @@ async function main () {
     const health = await fetch(`${baseUrl}/api/health`);
     assert.equal(health.status, 200);
     assert.equal(health.headers.get('cache-control'), 'no-store');
-    assert.deepEqual(await health.json(), { status: 'ok' });
+    assert.deepEqual(await health.json(), { status: 'ok', version }, 'hälsokontrollen anger versionen som byggdes');
+
+    assert.match(homeBody, new RegExp(`Version <!-- -->${version.replace(/\./g, '\\.')}`), 'sidfoten visar versionen');
     console.log('HTTP-smoke passerade');
   } finally {
     if (child.exitCode === null && child.signalCode === null) {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,7 @@
 import Image from 'next/image';
 
+const version = process.env.PARTIDATA_VERSION;
+
 function Footer () {
   return (
     <footer id="om-tjansten" className="site-footer">
@@ -36,6 +38,11 @@ function Footer () {
           <ul>
             <li><a href="https://github.com/swedev/partidata">Källkod och data på GitHub</a></li>
             <li><a href="https://creativecommons.org/publicdomain/zero/1.0/">Licens: CC0 1.0</a></li>
+            {version && (
+              <li>
+                <a href={`https://github.com/swedev/partidata/tree/v${version}`}>Version {version}</a>
+              </li>
+            )}
           </ul>
         </div>
 

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -14,11 +14,11 @@ export default async function handler (request: NextApiRequest, response: NextAp
     await partyData.assertHealthy();
     response.status(200);
     if (request.method === 'HEAD') response.end();
-    else response.json({ status: 'ok' });
+    else response.json({ status: 'ok', version: process.env.PARTIDATA_VERSION });
   } catch (error) {
     console.error('Hälsokontrollen misslyckades', error);
     response.status(500);
     if (request.method === 'HEAD') response.end();
-    else response.json({ status: 'error' });
+    else response.json({ status: 'error', version: process.env.PARTIDATA_VERSION });
   }
 }


### PR DESCRIPTION
`package.json` had stood at `0.1.0` through nine tags and is read nowhere — not in the deploy, not in the build, not in the code. The deployed app could therefore not answer which version it runs; the only way to tell what was live was to grep the public HTML for a known change. This PR makes `package.json` the single source of truth for the version and exposes it.

## How they are tied together

| Where | What |
|-------|------|
| `next.config.ts` | reads `version` from `package.json` at build time and inlines it as `PARTIDATA_VERSION` in both the server and the client bundle |
| `/api/health` | answers `{"status":"ok","version":"0.10.0"}` |
| The footer | "Version 0.10.0" under Öppenhet, linked to the tag's tree on GitHub |
| `deploy.yaml` | refuses to build a `v*` tag that names a version other than `package.json` |

The guard in the deploy is skipped for a manual `workflow_dispatch`, which deliberately runs an older ref — the artifact then reports the version that ref carries.

## The release routine

`deploy/README.md` describes the flow: raise the version with `npm version <patch|minor|major> --no-git-tag-version`, commit, push and tag the same number. In this PR the bump rides along with the change, so the tag after merge is `v0.10.0`.

The version choice is a judgement call: a visible new feature, no breaking interface, hence a minor from v0.9.0.

## Test

`npm run precommit` is green. The HTTP smoke now checks both that `/api/health` answers with the version from `package.json` and that the footer renders it, so a forgotten bump or a broken inlining fails CI.

Checked against the built artifact and not only in dev: `node .release/server.js` answers `{"status":"ok","version":"0.10.0"}` and the footer renders "Version 0.10.0".
