### PR TITLE
Party files silently lose fields they are not expected to have

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ En fil per parti. `uuid` sätts en gång och ändras aldrig — det är den iden
 | `partisymbol` | Filnamn och proveniens för partiets senast kända symbol |
 | `deltagande` | Anmält deltagande per valår |
 
+Tabellen är de fält skripten hanterar. Ytterligare fält får läggas till för hand så länge namnet är snake_case (`^[a-z][a-z0-9_]*$`); de bevaras vid ombyggnad och import, med valfritt JSON-värde, och skrivs efter fälten ovan i bokstavsordning. De tas inte upp i `parti/index.json` — den som behöver ett sådant fält läser partifilen.
+
 `deltagande` har ett uppslag per valår: `{ riksdag: bool, region: [länskod], kommun: [kommunkod] }`. Från 2022 listas alla val partiet deltar i, även deltagande som följer av anmälan på högre nivå. 2018 års data är insamlad på annat sätt och speglar därför årets filer, där ett riksdagsparti inte har några region- eller kommunposter alls.
 
 När `partisymbol` finns ligger PNG-filen i samma katalog som partiets `index.json`. Filnamnet innehåller både den partikod symbolen hämtades under och en läsbar namn-slug, till exempel `0001-moderaterna.png`. Symbolen från det senaste importerade valet används. För partier som saknar symbol i 2026 års paket används i vissa fall den senast kända symbolen från Valmyndighetens arkiv för EU-valet 2019. `valar`, `partikod` och `kallurl` anger symbolens proveniens.

--- a/agent-docs/issue/79-party-files-silently-lose-fields/index.md
+++ b/agent-docs/issue/79-party-files-silently-lose-fields/index.md
@@ -1,0 +1,32 @@
+# Issue #79: Party files silently lose fields they are not expected to have
+
+**Baserad på:** main
+
+## Sammanfattning
+
+`loadParties()` i `scripts/parti.js` läser bara en fast fältuppsättning och `buildParties()`/`_orderKeys()` skriver bara nycklarna i `PARTY_KEY_ORDER`, så ett fält som läggs till för hand i `data/parti/<filnamn>/index.json` försvinner tyst vid nästa ombyggnad eller import — trots att filerna kallas sanningskälla och hela produkten bjuder in till rättelser via pull request. Planen låter `loadParties()` bära med sig okända nycklar och `buildParties()` skriva tillbaka dem på en stabil, alfabetisk plats efter de kända fälten, så utskriften förblir byte-stabil och idempotenstesterna behåller sin mening. Extrafält har friforma värden men snake_case-nyckelnamn; kravet upprätthålls både i skrivvägen (`loadParties()` stoppar en ogiltig nyckel innan något skrivs) och i `scripts/validate.js`, och docblocken skrivs om så de beskriver det faktiska ägarskapet. Detta avblockerar #78 (grundandedatum från Wikidata).
+
+## Triageringsstatus
+
+| Fält | Värde |
+|------|-------|
+| **Redo att arbeta** | Ja |
+| **Risk** | Låg–Medel |
+| **Säker för junior** | Ja |
+
+## Plangranskning
+
+**Status:** Granskad
+**Granskad:** 2026-08-28
+**Feedback:** Två granskningsrundor. Första rundan: preciserade fältägarskapet (`PARTY_KEY_ORDER` är serialiseringsordning, inte ägarschema — kontrakt tillagt i docblocken), flyttade nyckelnamnskontrollen även till skrivvägen så en ogiltig nyckel stoppar körningen innan något skrivs (täcker även `__proto__`), ersatte "ordagrant" med JSON-djuplikhetskontraktet, rättade `party.party.extra`-felskrivningen och lade till README-dokumentation av utökningskontraktet. Andra rundan: rättade fältkategoriseringen (`valmyndigheten_registreringsdatum` bevaras av `parti.js` själv), preciserade att mönstret fångar malformade namn men inte felstavningar, lade till bevarandetester genom symbolskriptens båda ingångar, bytte no-diff-kontrollen till `git status --porcelain -- data/parti` med ren baslinje, samt noterade att `--report-name-collisions` också omfattas av nyckelkontrollen och att README-noten tangerar #25.
+
+## Relaterade filer
+
+- [plan.md](plan.md) — Fullständig implementationsplan
+- [progress.md](progress.md) — Implementationsframsteg
+
+## Relaterade issues
+
+- #78 — Grundandedatum från Wikidata; deklarerar "Depends on #79" och avgör själv fältformen
+- #80 — Flytt av `data/parti/index.json` till `data/derived/`; berör också `scripts/parti.js`, bör inte arbetas parallellt
+- #26 — Publicerat JSON-gränssnitt; extrafältens form påverkar så småningom det dokumenterade formatet

--- a/agent-docs/issue/79-party-files-silently-lose-fields/plan.md
+++ b/agent-docs/issue/79-party-files-silently-lose-fields/plan.md
@@ -1,0 +1,180 @@
+# Plan: Issue #79 — Party files silently lose fields they are not expected to have
+
+## Mål
+
+Gör partifilerna (`data/parti/<filnamn>/index.json`) till en faktisk sanningskälla: ett fält som lagts till för hand ska överleva både `node scripts/parti.js` och en om-import, i stället för att tyst försvinna. Skripten fortsätter äga de fält de hanterar; allt annat passerar igenom med bevarat innehåll, på en stabil plats i filen så att utskriften förblir byte-stabil. `scripts/validate.js` definierar vad ett acceptabelt extrafält är, och samma krav upprätthålls i skrivvägen så att en ogiltig nyckel stoppar körningen innan något skrivs.
+
+## Triagering
+
+> Beslutsunderlag för detta issue.
+
+| Fält | Värde |
+|------|-------|
+| **Blockeras av** | Inget |
+| **Blockerar** | #78 (grundandedatum från Wikidata behöver ett fält som överlever ombyggnad) |
+| **Relaterade issues** | #78, #80, #26 |
+| **Omfattning** | 7 filer: `scripts/parti.js`, `scripts/validate.js`, fyra testfiler, `README.md` |
+| **Risk** | Låg–Medel (delad kod som skriver om samtliga 670 partifiler via fyra ingångar; hålls nere av no-diff-verifiering mot committad data) |
+| **Komplexitet** | Låg–Medel |
+| **Säker för junior** | Ja |
+| **Konfliktrisk** | Låg så länge #80 inte arbetas parallellt (#80 berör också `scripts/parti.js`/indexskrivningen men har ingen plan ännu; alla befintliga planmappar hör till stängda issues). README-noten tangerar #25 (README-uppdatering), utan aktiv PR |
+
+### Triagemässiga noteringar
+
+- #78 (grundad-datum från Wikidata) deklarerar uttryckligen "Depends on #79" — det här issuet bör göras först, och fältformen i #78 avgörs där, inte här.
+- #80 föreslår att flytta `data/parti/index.json` till `data/derived/parti.json`. Den här planen rör inte indexets plats, bara vad partifilerna behåller — men båda ändrar `scripts/parti.js`, så de bör inte arbetas parallellt.
+- Inget projektbräde är konfigurerat (`agent-docs/github/project.json` saknas), så ingen board-status att stämma av.
+
+## Angreppssätt
+
+`loadParties()` (`scripts/parti.js:46`) läser varje partifil men plockar bara ut en fast fältuppsättning; `buildParties()` (`scripts/parti.js:372`) bygger om `data` från grunden och `_orderKeys()` (`scripts/parti.js:530`) skriver enbart nycklarna i `PARTY_KEY_ORDER`. Ett handtillagt fält försvinner alltså tyst vid nästa körning av `node scripts/parti.js`, `npm run import-val`, `npm run import-partisymboler` eller `scripts/measure-partisymboler.js` — alla fyra går genom samma `loadParties()` → `buildParties()` → `writeFiles()`-kedja, så en fix i de delade funktionerna täcker samtliga ingångar.
+
+**Fältgränsen.** `PARTY_KEY_ORDER` är i dag en serialiseringsordning, men den är också exakt uppsättningen nycklar skripten hanterar — med olika företrädesregler per fält:
+
+- *Härledda från valdata:* `kod`, `tidigare_koder`, `beteckning`, `tidigare_beteckningar`, `omrade`, `deltagande` byggs om från årsfilerna vid varje bygge; `forkortning` och `registrerad_partibeteckning` skrivs över när ett derived-årsrekord finns och behålls från filen annars.
+- *Identitet och historik:* `uuid`, `filnamn`, `tidigare_filnamn` — läses från filen och underhålls av registrets egen allokerings-/omdöpningslogik.
+- *Bevarade från filen:* `valmyndigheten_registreringsdatum` skrivs tillbaka som det lästes; `partisymbol` likaså, men sätts/uppdateras av import-/measure-partisymboler-skripten.
+
+Allt utanför listan blir *utökningsfält* som passerar igenom. `PARTY_KEY_ORDER`-docblocken får det uttryckliga kontraktet: en nyckel i listan är en nyckel skripten tar ansvar för — den som lägger till en måste också läsa den i `loadParties()` och skriva den i `buildParties()`, annars återinförs den tysta förlusten för just den nyckeln.
+
+Kärnidén:
+
+1. **`loadParties()` bär med sig okända nycklar.** Varje parti får ett `extra`-objekt med alla poster i filen vars nyckel inte finns i `PARTY_KEY_ORDER`. Redan här valideras nyckelnamnet mot mönstret `^[a-z][a-z0-9_]*$` — en ogiltig nyckel kastar fel innan någonting byggts eller skrivits, med samma allt-eller-inget-beteende som registrets övriga fel. Det stoppar också `__proto__` (matchar inte mönstret) innan nyckeln någonsin tilldelas i ett vanligt objekt.
+2. **`buildParties()` skriver tillbaka dem.** `party.data` byggs som i dag men extranycklarna (`party.extra`) följer med in i `_orderKeys()`, som efter `PARTY_KEY_ORDER`-nycklarna lägger ut alla utökningsnycklar i alfabetisk ordning (kodpunktsordning). Alfabetisk ordning ger en kanonisk, stabil plats: samma innehåll ger samma utskrift oavsett var i filen fältet lades till för hand.
+3. **Bevarandekontraktet:** utökningsvärden bevaras JSON-djuplika (`JSON.parse`/`JSON.stringify`-rundan behåller värdet och nästlade objekts nyckelordning men normaliserar formateringen — blanksteg, escapes, talskrivning). Första ombyggnaden efter en handredigering normaliserar alltså serialiseringen; varje ombyggnad därefter är byte-identisk. Ingen tomhetsrensning görs på utökningsfält — `null`, `false`, `0`, `""`, `[]` och `{}` skrivs tillbaka som värden (till skillnad från de kända fälten, där `_orderKeys()` fortsatt rensar tomma).
+4. **Nya partier** som skapas av `upsertParties()` har inga utökningsnycklar (`extra` tomt) — inget att bevara.
+5. **`data/parti/index.json` förblir en ren projektion** av sju kända fält och tar inte upp utökningsnycklar. `validate.js`:s befintliga kontroll att varje indexnyckel matchar partifilen påverkas inte (indexposten är en delmängd av partifilen).
+6. **`scripts/validate.js` ställer samma krav på committad data:** värden är friform-JSON, nyckelnamnet måste matcha mönstret. Mönstret och den kända fältuppsättningen exporteras från `scripts/parti.js` (`PARTY_KEY_ORDER` exporteras redan) så regeln bara finns på ett ställe. Skrivvägens kontroll i `loadParties()` hindrar skripten från att själva skriva en ogiltig nyckel; `validate.js`-kontrollen fångar det som committas på annan väg.
+7. **Kommentaren vid `loadParties()`** skrivs om så den beskriver vad koden faktiskt gör: partifilerna är sanningskälla för identitet, historik och utökningsfält; de valdata-härledda fälten byggs om från årsfilerna vid varje bygge.
+8. **README dokumenterar utökningskontraktet:** en kort not i fälttabellens avsnitt för `parti/<filnamn>/index.json` — ytterligare fält med snake_case-namn bevaras av skripten men tas inte upp i det genererade indexet.
+
+Viktiga kantfall:
+
+- Ett parti som byter namn (katalogflytt via `applyRenames()`) behåller sina utökningsnycklar — de sitter på partiobjektet och skrivs i den nya katalogen.
+- Nästlade objektvärden är JSON-djuplika efter rundan och behåller sin nyckelordning; formateringen normaliseras första gången men är stabil därefter.
+- Kontrollen i `loadParties()` gäller även det läs-enbara `--report-name-collisions`-läget — en ogiltig nyckel fäller alltså också rapporten. Det är avsiktligt konsekvent: samma laddning, samma krav.
+- En nyckel som redan finns i `PARTY_KEY_ORDER` kan aldrig hamna i `extra` (filtreringen utgår från listan), så ett spreadat `extra` kan inte skugga ett hanterat fält.
+- En ogiltig nyckel stoppar körningen innan något skrivits eller flyttats — datamängden lämnas orörd (samma garanti som `Duplicate uuid`-fallen).
+- Den committade datamängden har inga utökningsfält i dag (allt sådant har redan rensats av tidigare körningar), så en ombyggnad efter ändringen ska ge noll diff i `data/parti/` — det verifieras explicit.
+
+## Steg
+
+### Fas 1: Pass-through i scripts/parti.js
+
+1. Definiera gränsen och kontraktet
+   - Exportera nyckelnamnsmönstret (t.ex. `EXTRA_KEY_PATTERN = /^[a-z][a-z0-9_]*$/`) bredvid `PARTY_KEY_ORDER`
+   - Utöka `PARTY_KEY_ORDER`-docblocken med ansvarskontraktet (en nyckel i listan måste läsas i `loadParties()` och skrivas i `buildParties()`)
+   - Filer att ändra: `scripts/parti.js` (rad ~6–26)
+2. Låt `loadParties()` samla och granska okända nycklar
+   - Bygg `extra` av alla poster vars nyckel inte finns i `PARTY_KEY_ORDER`; kasta fel med filens sökväg och nyckelnamnet när en nyckel inte matchar mönstret
+   - Filer att ändra: `scripts/parti.js` (`loadParties()`, rad ~46–78)
+3. Låt `buildParties()` skriva tillbaka dem
+   - Skicka med `party.extra` in i `data`-bygget (spread före de explicita fälten, eller som separat argument till `_orderKeys()`)
+   - `index`-projektionen lämnas orörd — inga utökningsnycklar där
+   - Filer att ändra: `scripts/parti.js` (`buildParties()`, rad ~477–500)
+4. Utöka `_orderKeys()` med stabil placering
+   - Efter `PARTY_KEY_ORDER`-loopen: lägg ut kvarvarande nycklar sorterade alfabetiskt, utan tomhetsrensning för utökningsnycklar
+   - Uppdatera funktionens docblock
+   - Filer att ändra: `scripts/parti.js` (`_orderKeys()`, rad ~526–546)
+5. Skriv om kommentaren så den stämmer med koden
+   - `loadParties()`-docblocken (rad ~40–45) beskriver ägarskapet: identitet, historik och utökningsfält från partifilerna; valdata-härledda fält byggs om från årsfilerna
+   - Filer att ändra: `scripts/parti.js`
+
+### Fas 2: Validering i scripts/validate.js
+
+1. Ställ samma krav på committad data i `validatePartyRegistry()`
+   - Importera `PARTY_KEY_ORDER` och nyckelnamnsmönstret från `./parti.js`
+   - För varje nyckel i partifilen som inte är känd: kräv att nyckeln matchar mönstret, med ett svenskt felmeddelande i samma stil som övriga (`"<filnamn>: fältet "<nyckel>" har inte ett giltigt fältnamn"` eller liknande)
+   - Värden lämnas friforma — validate garanterar redan att filen är giltig JSON
+   - Filer att ändra: `scripts/validate.js` (`validatePartyRegistry()`, rad ~271–346)
+
+### Fas 3: Tester
+
+1. Pass-through-tester i `scripts/parti.test.js`
+   - Ett handtillagt fält (t.ex. `grundad: "1988-02-04"`) i en partifil överlever `runParti()` — acceptanskriteriets kärna
+   - Om-import-sekvensen uttryckligen: importera ett år, lägg till fältet för hand, importera samma år igen — fältet finns kvar
+   - Ombyggnad två gånger med ett handtillagt fält: första körningen normaliserar formateringen, andra körningen ger byte-identiskt träd (`snapshot()`-jämförelse mellan körning 1 och 2)
+   - Utökningsnyckeln hamnar efter de kända nycklarna och flera utökningsnycklar sorteras alfabetiskt (jämför `Object.keys()` på den skrivna filen)
+   - Tabelltest över värdetyper: `null`, `false`, `0`, `""`, `[]`, `{}` och ett nästlat objekt bevaras alla JSON-djuplikt
+   - `data/parti/index.json` tar inte upp utökningsfältet
+   - Ett handredigerat värde i ett valdata-härlett fält (t.ex. `forkortning`) byggs fortsatt om från årsfilerna — hanteringsgränsen är kvar
+   - Ett utökningsfält följer med vid partibyte av filnamn (rename-fallet)
+   - En ogiltig nyckel (t.ex. `Grundad`): `runParti()` och `runImport()` avslutas med felkod och `snapshot()` visar att inget skrivits
+   - Filer att ändra: `scripts/parti.test.js`
+2. Bevarande genom symbolskripten
+   - En liten bevarandekontroll i vardera testfil: ett utökningsfält överlever symbolimporten respektive mätningen (båda går genom samma kedja, men testet låser att ingen av ingångarna regredierar)
+   - Filer att ändra: `scripts/import-partisymboler.test.js`, `scripts/measure-partisymboler.test.js`
+3. Valideringstester i `scripts/validate.test.js`
+   - Ett utökningsfält med giltigt namn passerar valideringen
+   - En nyckel som bryter mot mönstret (t.ex. `Grundad` eller `founded-date`) fälls med begripligt fel
+   - Filer att ändra: `scripts/validate.test.js`
+
+### Fas 4: Dokumentation
+
+1. README-not om utökningskontraktet
+   - I avsnittet `parti/<filnamn>/index.json`, efter fälttabellen: ytterligare fält med snake_case-namn bevaras vid ombyggnad och import men tas inte upp i `parti/index.json`
+   - Filer att ändra: `README.md` (avsnittet vid rad ~32)
+
+### Fas 5: Verifiering
+
+1. Bekräfta först att `git status --porcelain -- data/parti` är tomt, kör sedan `node scripts/parti.js` och bekräfta att det fortfarande är tomt (fångar även otrackade filer; ingen datafil ändras av pass-through-koden)
+2. Kör `npm run validate:data`, `npm test` och till sist `npm run precommit`
+
+## Filöversikt
+
+| Fil | Åtgärd | Syfte |
+|-----|--------|-------|
+| `scripts/parti.js` | Ändra | `loadParties()` behåller och granskar okända nycklar, `buildParties()`/`_orderKeys()` skriver dem stabilt, docblock beskriver ägarskapet och `PARTY_KEY_ORDER`-kontraktet |
+| `scripts/validate.js` | Ändra | Utökningsfält accepteras med nyckelnamnskrav; mönster och känd fältlista importeras från `parti.js` |
+| `scripts/parti.test.js` | Ändra | Tester för överlevnad, normalisering + byte-stabilitet, placering, värdetyper, indexprojektion, hanteringsgräns, rename och ogiltig nyckel |
+| `scripts/import-partisymboler.test.js` | Ändra | Bevarandekontroll: utökningsfält överlever symbolimporten |
+| `scripts/measure-partisymboler.test.js` | Ändra | Bevarandekontroll: utökningsfält överlever symbolmätningen |
+| `scripts/validate.test.js` | Ändra | Tester för giltiga och ogiltiga utökningsnycklar |
+| `README.md` | Ändra | Dokumenterar att extrafält bevaras men inte projiceras till indexet |
+
+## Berörda kodområden
+
+Lista de primära kataloger/områden som planen berör (för konfliktdetektering):
+- `scripts/` (`parti.js`, `validate.js` och deras tester)
+- `README.md` (dataavsnittet)
+- `data/parti/` berörs inte i denna PR (inga datafiler ändras — verifieras i fas 5), men skrivbeteendet för katalogen ändras
+
+## Designbeslut
+
+> Icke-triviala val gjorda under planeringen. Feedback välkommen; annars implementeras enligt dessa.
+
+### 1. Pass-through, inte fail-loudly
+**Alternativ:** Okända nycklar bevaras och skrivs tillbaka vs importen felar högt på okänd nyckel
+**Beslut:** Pass-through
+**Motivering:** Issuet ställer upp båda men som huvudspår respektive reservspår ("Alternatively, if pass-through is not wanted"), och #78 förutsätter att ett handtillagt fält kan bo i partifilen — fail-loudly hade gjort #78 omöjligt utan att först bygga ut `PARTY_KEY_ORDER` för varje nytt fält. Proveniens: användarbeslut (issue #79:s "What to change" i kombination med #78).
+
+### 2. Okända nycklar sist, i alfabetisk ordning, JSON-djuplikt bevarade
+**Alternativ:** (a) Bevara filens ursprungliga position per nyckel, (b) alfabetiskt efter de kända nycklarna
+**Beslut:** (b)
+**Motivering:** Kanonisk ordning är oberoende av var i filen redigeraren råkade lägga fältet, vilket ger en enda giltig utskrift per innehåll — samma egenskap som `PARTY_KEY_ORDER` redan ger de kända fälten, och det som håller idempotens-testerna meningsfulla. Kontraktet är JSON-djuplikhet, inte byte-ordagrannhet: `JSON.parse`/`JSON.stringify` normaliserar formateringen vid första ombyggnaden (nästlade objekts nyckelordning bevaras), därefter är utskriften byte-stabil. Ingen tomhetsrensning görs på utökningsfält, eftersom skripten inte äger dem och inte ska döma dem. Proveniens: agentens egen bedömning — öppen att ifrågasätta; issuet kräver bara "a stable position".
+
+### 3. Nyckelnamnskrav i både skrivväg och validering, friforma värden
+**Alternativ:** Helt friform vs nyckelnamnsmönster enbart i `validate.js` vs mönster i både skrivväg och validering vs fullt schema för deklarerade extrafält
+**Beslut:** Mönstret `^[a-z][a-z0-9_]*$` upprätthålls i `loadParties()` (stoppar körningen innan något skrivs) och i `scripts/validate.js` (granskar committad data); värden friforma; mönstret definieras en gång i `parti.js`
+**Motivering:** Issuet delegerar frågan till `scripts/validate.js` utan att avgöra den, men enbart validering i efterhand låter `node scripts/parti.js` skriva en ogiltig nyckel som först en senare `npm run validate:data` fäller — silent-loss-problemets spegelbild. Kontrollen i skrivvägen ger allt-eller-inget som registrets övriga fel, och neutraliserar `__proto__` innan nyckeln tilldelas. Ett fullt schema i förväg låser fältformer som #78 avgör senare. Mönstret fångar malformade namn (versaler, bindestreck, blanksteg, inledande understreck) — inte felstavningar av giltiga namn; utökningsnamnrymden är medvetet friform, och det dokumenteras som en egenskap, inte döljs. Namnmönstret matchar samtliga befintliga fältnamn. Proveniens: agentens egen bedömning — öppen att ifrågasätta.
+
+### 4. `data/parti/index.json` förblir utan utökningsfält
+**Alternativ:** Projicera utökningsfält till indexet vs hålla indexet vid sina sju kända fält
+**Beslut:** Indexet hålls oförändrat
+**Motivering:** Indexet är en genererad projektion (befintlig konvention, bekräftad i issue #80:s beskrivning), och `INDEX_KEYS_FROM_PARTY` i `scripts/validate.js` definierar exakt vilka fält den bär. Konsumenter som behöver ett utökningsfält läser partifilen. Proveniens: befintlig konvention (`scripts/validate.js:11`, issue #80).
+
+## Verifieringschecklista
+
+- [ ] Ett fält som lagts till för hand i en partifil överlever `node scripts/parti.js` (acceptanskriterium)
+- [ ] Samma fält överlever en om-import via `npm run import-val` (acceptanskriterium)
+- [ ] Två ombyggnader i rad ger byte-identiska filer, även med utökningsfält (acceptanskriterium)
+- [ ] Test täcker att ett handtillagt fält överlever en ombyggnad (acceptanskriterium)
+- [ ] Docblocken vid `loadParties()` beskriver vad koden gör (acceptanskriterium)
+- [ ] `node scripts/parti.js` mot committad data: `git diff --exit-code -- data/parti` går igenom
+- [ ] Alla JSON-värdetyper (inkl. `null`, `false`, `0`, `""`, `[]`, `{}`) bevaras djuplikt
+- [ ] Utökningsfält följer med vid filnamnsbyte (rename-fallet)
+- [ ] Ett handredigerat värde i ett valdata-härlett fält byggs fortfarande om — gränsen är testad
+- [ ] En ogiltig nyckel stoppar `runParti()`/`runImport()` utan att något skrivs
+- [ ] `npm run validate:data` accepterar giltiga utökningsfält och fäller ogiltiga nyckelnamn
+- [ ] README beskriver utökningskontraktet
+- [ ] `npm run precommit` grönt

--- a/agent-docs/issue/79-party-files-silently-lose-fields/progress.md
+++ b/agent-docs/issue/79-party-files-silently-lose-fields/progress.md
@@ -1,0 +1,44 @@
+# Framsteg: Issue #79 — Party files silently lose fields they are not expected to have
+
+**Påbörjad:** 2026-08-28
+**Senast uppdaterad:** 2026-08-28
+**Status:** Klar
+
+## Genomförda steg
+
+- [x] Fas 1, steg 1: Exportera `EXTRA_KEY_PATTERN` och utöka `PARTY_KEY_ORDER`-docblocken med ansvarskontraktet
+- [x] Fas 1, steg 2: `loadParties()` samlar och granskar okända nycklar (`_extraKeys()`)
+- [x] Fas 1, steg 3: `buildParties()` skriver tillbaka utökningsnycklarna
+- [x] Fas 1, steg 4: `_orderKeys()` placerar utökningsnycklar alfabetiskt sist, utan tomhetsrensning
+- [x] Fas 1, steg 5: `loadParties()`-docblocken beskriver ägarskapet
+- [x] Fas 2, steg 1: `validate.js` kräver giltigt nyckelnamn för utökningsfält
+- [x] Fas 3, steg 1: Pass-through-tester i `scripts/parti.test.js` (10 nya tester)
+- [x] Fas 3, steg 2: Bevarandekontroller i symbolskriptens tester
+- [x] Fas 3, steg 3: Valideringstester i `scripts/validate.test.js` (3 nya tester)
+- [x] Fas 4, steg 1: README-not om utökningskontraktet
+- [x] Fas 5: Verifiering (no-diff, `validate:data`, `npm test`, `npm run precommit`)
+
+## Verifieringschecklista
+
+- [x] Ett handtillagt fält överlever `node scripts/parti.js`
+- [x] Samma fält överlever en om-import
+- [x] Två ombyggnader i rad ger byte-identiska filer, även med utökningsfält
+- [x] Test täcker att ett handtillagt fält överlever en ombyggnad
+- [x] Docblocken vid `loadParties()` beskriver vad koden gör
+- [x] `node scripts/parti.js` mot committad data ger noll diff i `data/parti`
+- [x] Alla JSON-värdetyper (inkl. `null`, `false`, `0`, `""`, `[]`, `{}`) bevaras djuplikt
+- [x] Utökningsfält följer med vid filnamnsbyte
+- [x] Ett handredigerat värde i ett valdata-härlett fält byggs fortfarande om
+- [x] En ogiltig nyckel stoppar `runParti()`/`runImport()` utan att något skrivs
+- [x] `npm run validate:data` accepterar giltiga utökningsfält och fäller ogiltiga nyckelnamn
+- [x] README beskriver utökningskontraktet
+- [x] `npm run precommit` grönt
+
+## Anteckningar
+
+- Utökningsvärdena passerar oförändrade från `readJson()` till `writeFiles()`, som redan
+  serialiserar med `JSON.stringify` — bevarandekontraktet (JSON-djuplikhet, normaliserad
+  formatering) faller därmed ut av befintlig kod utan extra kopiering.
+- `_extraKeys()` granskar samtliga nycklar innan någon tilldelas, så `__proto__` fälls av
+  mönstret innan den kan nå ett objekt.
+- `npm run precommit` grönt: 151 tester, ingen fil under `data/` ändrad av implementationen.

--- a/scripts/import-partisymboler.test.js
+++ b/scripts/import-partisymboler.test.js
@@ -163,3 +163,15 @@ test('a changed code or name filename replaces the previous symbol file', t => {
   assert.equal(fs.existsSync(path.join(partyDir, oldName)), false);
   assert.deepEqual(fs.readFileSync(path.join(partyDir, '9001-testpartiet.png')), PNG_A);
 });
+
+test('a hand-added field survives the symbol import', t => {
+  const dir = makeTree();
+  t.after(() => removeTree(dir));
+  const zip = writeZip(dir, { '9001_Val 2026.png': PNG_A });
+  const file = path.join(dir, 'data/parti/testpartiet/index.json');
+  fs.writeFileSync(file, JSON.stringify({ ...readJson(file), grundad: '1988-02-04' }, null, 2) + '\n');
+
+  const result = runSymbolImport(dir, '2026', zip);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(readJson(file).grundad, '1988-02-04');
+});

--- a/scripts/measure-partisymboler.test.js
+++ b/scripts/measure-partisymboler.test.js
@@ -90,3 +90,24 @@ test('the script writes measurements into the committed registry', t => {
   const indexEntry = readJson(dir, 'data/parti/index.json').find(entry => entry.filnamn === 'testpartiet');
   assert.deepEqual(indexEntry.partisymbol, measured);
 });
+
+test('a hand-added field survives the symbol measurement', t => {
+  const dir = makeTree();
+  t.after(() => removeTree(dir));
+  const partyDir = path.join(dir, 'data/parti/testpartiet');
+  fs.writeFileSync(path.join(partyDir, '9001-testpartiet.png'), SYMBOL);
+  const party = readJson(partyDir, 'index.json');
+  party.partisymbol = {
+    filnamn: '9001-testpartiet.png',
+    kalla: 'Valmyndigheten',
+    kallurl: 'https://data.val.se/filer/val2026/parti/partisymboler.zip',
+    valar: 2026,
+    partikod: '9001'
+  };
+  party.grundad = '1988-02-04';
+  fs.writeFileSync(path.join(partyDir, 'index.json'), JSON.stringify(party, null, 2) + '\n');
+
+  const result = runMeasureSymbols(dir);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(readJson(partyDir, 'index.json').grundad, '1988-02-04');
+});

--- a/scripts/parti.js
+++ b/scripts/parti.js
@@ -7,6 +7,12 @@ const { ROOT, dataPath, toFileName, newUuid } = require('./utils.js');
  * PARTY_KEY_ORDER
  * Fixed key order for data/parti/<filnamn>/index.json so generated files are
  * byte-stable regardless of how the values were derived.
+ *
+ * The list is also exactly the set of keys the scripts take responsibility for:
+ * a key listed here must be read in loadParties() and written in
+ * buildParties(), or the value is dropped on the next rebuild. Every other key
+ * found in a party file is an extension field, carried through untouched and
+ * written after these, in alphabetical order.
  * @type {String[]}
  */
 const PARTY_KEY_ORDER = [
@@ -26,6 +32,16 @@ const PARTY_KEY_ORDER = [
 ];
 
 /**
+ * EXTRA_KEY_PATTERN
+ * The name an extension field must have: snake_case, opening on a letter. The
+ * pattern catches malformed names (capitals, hyphens, spaces, a leading
+ * underscore, __proto__) rather than misspellings of valid ones — the extension
+ * namespace is deliberately free-form.
+ * @type {RegExp}
+ */
+const EXTRA_KEY_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+/**
  * readJson
  * @param  {String} file
  * @return {*} Parsed content, or null when the file does not exist
@@ -39,8 +55,16 @@ function readJson (file) {
 
 /**
  * loadParties
- * Reads the party files, which are the source of truth; data/parti/index.json
- * is derived from them.
+ * Reads the party files. They are the source of truth for identity (uuid,
+ * filnamn, tidigare_filnamn), for the fields kept as read
+ * (valmyndigheten_registreringsdatum, partisymbol) and for every extension
+ * field, which is carried through to the rebuilt file. The fields derived from
+ * the election data — kod, beteckning, omrade, deltagande and their history —
+ * are rebuilt from the year files on every build, so what the file holds for
+ * them is a starting point, not a value that survives.
+ *
+ * An extension key that fails EXTRA_KEY_PATTERN throws here, before anything is
+ * built, moved or written, so an invalid key leaves the data untouched.
  * @return {{ parties: Object[], kodbyten: Object }}
  */
 function loadParties () {
@@ -68,13 +92,37 @@ function loadParties () {
       forkortning: data.forkortning,
       registrerad_partibeteckning: data.registrerad_partibeteckning,
       valmyndigheten_registreringsdatum: data.valmyndigheten_registreringsdatum,
-      partisymbol: data.partisymbol
+      partisymbol: data.partisymbol,
+      extra: _extraKeys(data, file)
     };
   });
   return {
     parties,
     kodbyten: readJson(dataPath('parti', 'kodbyten.json')) || {}
   };
+}
+
+/**
+ * _extraKeys
+ * Collects the entries of a party file the scripts do not manage, so they
+ * survive the rebuild. Every key is checked before any is kept, so a file with
+ * an invalid key contributes nothing.
+ * @param  {Object} data Parsed party file
+ * @param  {String} file Path, for the error message
+ * @return {Object} Extension key to value
+ */
+function _extraKeys (data, file) {
+  const keys = Object.keys(data).filter(key => !PARTY_KEY_ORDER.includes(key));
+  for (const key of keys) {
+    if (!EXTRA_KEY_PATTERN.test(key)) {
+      throw new Error(`Party file ${file} has field "${key}", which is not a valid field name`);
+    }
+  }
+  const extra = {};
+  for (const key of keys) {
+    extra[key] = data[key];
+  }
+  return extra;
 }
 
 /**
@@ -482,6 +530,7 @@ function buildParties (registry, yearFiles, areas = loadAreas()) {
       tidigare_filnamn: party.tidigare_filnamn || [],
       koder,
       data: _orderKeys({
+        ...(party.extra || {}),
         uuid: party.uuid,
         kod,
         tidigare_koder: koder.filter(other => other !== kod).sort(),
@@ -525,7 +574,11 @@ function buildParties (registry, yearFiles, areas = loadAreas()) {
 
 /**
  * _orderKeys
- * Applies PARTY_KEY_ORDER and drops empty optional values.
+ * Applies PARTY_KEY_ORDER and drops empty optional values. Keys outside the
+ * list follow the managed ones in alphabetical order, which gives one canonical
+ * output per content regardless of where in the file the field was added. They
+ * keep their value as it stands: the scripts do not own them and do not judge
+ * an empty one.
  */
 function _orderKeys (data) {
   const ordered = {};
@@ -541,6 +594,11 @@ function _orderKeys (data) {
       continue;
     }
     ordered[key] = value;
+  }
+  for (const key of Object.keys(data).filter(other => !PARTY_KEY_ORDER.includes(other)).sort()) {
+    if (data[key] !== undefined) {
+      ordered[key] = data[key];
+    }
   }
   return ordered;
 }
@@ -742,6 +800,7 @@ function writeFiles (writeSet) {
  * Exports
  */
 exports.PARTY_KEY_ORDER = PARTY_KEY_ORDER;
+exports.EXTRA_KEY_PATTERN = EXTRA_KEY_PATTERN;
 exports.loadParties = loadParties;
 exports.loadYearFiles = loadYearFiles;
 exports.loadAreas = loadAreas;

--- a/scripts/parti.test.js
+++ b/scripts/parti.test.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { test } = require('node:test');
 
 const {
+  PARTY_KEY_ORDER,
   buildParties,
   deriveArea,
   normalisePartyName,
@@ -35,6 +36,19 @@ const CSV_TVETYDIG = fixture('val-2026-tvetydig.csv');
  */
 function parti (dir, filnamn) {
   return readJson(dir, 'data/parti', filnamn, 'index.json');
+}
+
+/**
+ * editParti
+ * Edits a party file the way a contributor would, by hand.
+ * @param  {String} dir
+ * @param  {String} filnamn
+ * @param  {Object} fields Fields to add or replace
+ */
+function editParti (dir, filnamn, fields) {
+  const file = path.join(dir, 'data/parti', filnamn, 'index.json');
+  const data = { ...readJson(file), ...fields };
+  fs.writeFileSync(file, JSON.stringify(data, null, 2) + '\n');
 }
 
 /**
@@ -559,4 +573,140 @@ test('a duplicate kod in the registry stops the import', t => {
   const result = runImport(dir, '2022', CSV_2022);
   assert.equal(result.status, 1);
   assert.match(result.stderr, /Duplicate kod "9001"/);
+});
+
+test('a hand-added field survives a rebuild', t => {
+  const dir = makeTree();
+  t.after(() => removeTree(dir));
+  assert.equal(runImport(dir, '2022', CSV_2022).status, 0);
+  editParti(dir, 'testpartiet', { grundad: '1988-02-04' });
+
+  const result = runParti(dir);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(parti(dir, 'testpartiet').grundad, '1988-02-04');
+});
+
+test('a hand-added field survives a re-import of the same year', t => {
+  const dir = makeTree();
+  t.after(() => removeTree(dir));
+  assert.equal(runImport(dir, '2022', CSV_2022).status, 0);
+  editParti(dir, 'testpartiet', { grundad: '1988-02-04' });
+
+  const result = runImport(dir, '2022', CSV_2022);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(parti(dir, 'testpartiet').grundad, '1988-02-04');
+});
+
+test('the first rebuild normalises a hand-added field and the next is byte-identical', t => {
+  const dir = makeTree();
+  t.after(() => removeTree(dir));
+  assert.equal(runImport(dir, '2022', CSV_2022).status, 0);
+  const file = path.join(dir, 'data/parti/testpartiet/index.json');
+  const handWritten = JSON.stringify({ ...readJson(file), grundad: '1988-02-04' }, null, 4) + '\n';
+  fs.writeFileSync(file, handWritten);
+
+  assert.equal(runParti(dir).status, 0);
+  const normalised = snapshot(dir);
+  assert.notEqual(normalised['parti/testpartiet/index.json'], handWritten);
+  assert.match(normalised['parti/testpartiet/index.json'], /^ {2}"grundad": "1988-02-04"$/m);
+
+  assert.equal(runParti(dir).status, 0);
+  assert.deepEqual(snapshot(dir), normalised);
+});
+
+test('hand-added fields are written after the managed ones, in alphabetical order', t => {
+  const dir = makeTree();
+  t.after(() => removeTree(dir));
+  assert.equal(runImport(dir, '2022', CSV_2022).status, 0);
+  editParti(dir, 'testpartiet', { wikidata: 'Q123', grundad: '1988-02-04', arkiv_id: 'A7' });
+
+  assert.equal(runParti(dir).status, 0);
+  const keys = Object.keys(parti(dir, 'testpartiet'));
+  const managed = keys.filter(key => PARTY_KEY_ORDER.includes(key));
+  assert.deepEqual(keys.slice(managed.length), ['arkiv_id', 'grundad', 'wikidata']);
+});
+
+test('every JSON value type is preserved in a hand-added field', t => {
+  const dir = makeTree();
+  t.after(() => removeTree(dir));
+  assert.equal(runImport(dir, '2022', CSV_2022).status, 0);
+  const values = {
+    v_null: null,
+    v_false: false,
+    v_zero: 0,
+    v_tom_strang: '',
+    v_tom_array: [],
+    v_tomt_objekt: {},
+    v_nastlat: { b: [1, { c: 'två' }], a: null }
+  };
+  editParti(dir, 'testpartiet', values);
+
+  assert.equal(runParti(dir).status, 0);
+  const data = parti(dir, 'testpartiet');
+  for (const [key, value] of Object.entries(values)) {
+    assert.deepEqual(data[key], value, `${key} bevaras inte`);
+  }
+  assert.deepEqual(Object.keys(data.v_nastlat), ['b', 'a']);
+});
+
+test('index.json does not take up hand-added fields', t => {
+  const dir = makeTree();
+  t.after(() => removeTree(dir));
+  assert.equal(runImport(dir, '2022', CSV_2022).status, 0);
+  editParti(dir, 'testpartiet', { grundad: '1988-02-04' });
+
+  assert.equal(runParti(dir).status, 0);
+  const entry = readJson(dir, 'data/parti/index.json').find(party => party.filnamn === 'testpartiet');
+  assert.equal('grundad' in entry, false);
+});
+
+test('a hand-edited value in a derived field is still rebuilt from the year files', t => {
+  const dir = makeTree();
+  t.after(() => removeTree(dir));
+  assert.equal(runImport(dir, '2022', CSV_2022).status, 0);
+  editParti(dir, 'testpartiet', { forkortning: 'XX', grundad: '1988-02-04' });
+
+  assert.equal(runParti(dir).status, 0);
+  const data = parti(dir, 'testpartiet');
+  assert.equal(data.forkortning, 'TP');
+  assert.equal(data.grundad, '1988-02-04');
+});
+
+test('a hand-added field follows the party to its new filnamn', t => {
+  const dir = makeTree();
+  t.after(() => removeTree(dir));
+  assert.equal(runImport(dir, '2022', CSV_2022).status, 0);
+  editParti(dir, 'testpartiet', { grundad: '1988-02-04' });
+
+  const result = runImport(dir, '2026', CSV_2026);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(path.join(dir, 'data/parti/testpartiet')), false);
+  assert.equal(parti(dir, 'nya-testpartiet').grundad, '1988-02-04');
+});
+
+test('an invalid field name stops the rebuild and writes nothing', t => {
+  const dir = makeTree();
+  t.after(() => removeTree(dir));
+  assert.equal(runImport(dir, '2022', CSV_2022).status, 0);
+  editParti(dir, 'testpartiet', { Grundad: '1988-02-04' });
+  const before = snapshot(dir);
+
+  const result = runParti(dir);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /has field "Grundad", which is not a valid field name/);
+  assert.deepEqual(snapshot(dir), before);
+});
+
+test('an invalid field name stops the import and writes nothing', t => {
+  const parties = PARTIER.map(party => (party.filnamn === 'testpartiet'
+    ? { ...party, 'founded-date': '1988-02-04' }
+    : party));
+  const dir = makeTree({ parties });
+  t.after(() => removeTree(dir));
+  const before = snapshot(dir);
+
+  const result = runImport(dir, '2022', CSV_2022);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /has field "founded-date", which is not a valid field name/);
+  assert.deepEqual(snapshot(dir), before);
 });

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -3,6 +3,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { checkPartyProfileParliamentView } = require('./build-derived-data.js');
+const { EXTRA_KEY_PATTERN, PARTY_KEY_ORDER } = require('./parti.js');
 const { readHeader } = require('./png.js');
 const { ROOT, toFileName } = require('./utils.js');
 
@@ -308,6 +309,10 @@ function validatePartyRegistry (dataDirectory) {
     requireString(party.kod, `${entry.filnamn}.kod`);
     if (party.omrade !== undefined) requireString(party.omrade, `${entry.filnamn}.omrade`);
     assert.equal(party.filnamn, entry.filnamn, `${entry.filnamn}: filnamn ska matcha katalogen`);
+
+    for (const key of Object.keys(party).filter(other => !PARTY_KEY_ORDER.includes(other))) {
+      assert.match(key, EXTRA_KEY_PATTERN, `${entry.filnamn}: fältet "${key}" har inte ett giltigt fältnamn`);
+    }
 
     for (const [key, value] of Object.entries(entry)) {
       assert.deepEqual(value, party[key], `${entry.filnamn}: ${key} skiljer sig mellan index och partifil`);

--- a/scripts/validate.test.js
+++ b/scripts/validate.test.js
@@ -108,6 +108,14 @@ test('validateData accepts a consistent data tree', t => {
   });
 });
 
+test('validateData accepts an extension field with a snake_case name', t => {
+  const root = makeData();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  writeJson(root, 'parti/testpartiet/index.json', { ...PARTY, grundad: '1988-02-04', wikidata_id: 'Q123' });
+
+  assert.equal(validateData(root).parties, 1);
+});
+
 test('validateData rejects inconsistencies with useful errors', async t => {
   await t.test('missing party files', t => {
     const root = makeData();
@@ -149,6 +157,20 @@ test('validateData rejects inconsistencies with useful errors', async t => {
     t.after(() => fs.rmSync(root, { recursive: true, force: true }));
     writeJson(root, 'parti/testpartiet/index.json', { ...PARTY, forkortning: 'TP' });
     assert.throws(() => validateData(root), /forkortning saknas i index.json/);
+  });
+
+  await t.test('an invalid extension field name', t => {
+    const root = makeData();
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    writeJson(root, 'parti/testpartiet/index.json', { ...PARTY, 'founded-date': '1988-02-04' });
+    assert.throws(() => validateData(root), /fältet "founded-date" har inte ett giltigt fältnamn/);
+  });
+
+  await t.test('an extension field name with a capital', t => {
+    const root = makeData();
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    writeJson(root, 'parti/testpartiet/index.json', { ...PARTY, Grundad: '1988-02-04' });
+    assert.throws(() => validateData(root), /fältet "Grundad" har inte ett giltigt fältnamn/);
   });
 
   await t.test('invalid curated party profiles', t => {


### PR DESCRIPTION
`scripts/parti.js` called the party files the source of truth and then pruned them: `loadParties()` read a fixed field set and `_orderKeys()` wrote only the keys in `PARTY_KEY_ORDER`, so a field added by hand to `data/parti/<filnamn>/index.json` disappeared at the next rebuild or import — silently, with no error and no warning before the write. That made the files uneditable in practice for a project whose whole product is data people are invited to correct through a pull request.

## What changed

- `loadParties()` collects every key outside `PARTY_KEY_ORDER` into `party.extra` and carries it through the build, so the import owns the fields it derives from Valmyndigheten and everything else passes through.
- `buildParties()` writes the extension keys back, alphabetically after the managed ones, with no emptiness pruning — the managed fields always win, so a hand edit cannot shadow imported data.
- Key names must match `EXTRA_KEY_PATTERN` (`^[a-z][a-z0-9_]*$`). The check runs in the **write path**, validating every key before keeping any, so an invalid name aborts the run before anything is built, moved or written — and `__proto__` is rejected before it could ever be assigned. `scripts/validate.js` imports the same pattern and key list from `parti.js` and enforces it on committed data.
- The docblocks now describe the actual ownership contract instead of the old one.
- `README.md` documents the extension contract after the field table.

## Verification

- `git status --porcelain -- data/parti` is empty both before and after `node scripts/parti.js` (671 files, 670 parties) — no committed data file is touched by this change.
- `npm run precommit` green end to end, including the release build and the HTTP smoke.
- 151 tests pass. New coverage: survival through a rebuild and through a re-import, normalise-then-byte-stable output, alphabetical placement, all JSON value types including nested key order, the index projection staying clean, the derived-field boundary still rebuilding, carry-over across a rename, and an invalid key aborting both `runParti` and `runImport` with an unchanged snapshot — plus preservation checks through both symbol scripts and three validation cases.

## Open to challenge

Two decisions come from the plan's own judgment rather than from the issue: extension keys are placed alphabetically after the managed fields rather than at their original position in the file, and the key-name pattern is enforced in the write path as well as in validation while values stay free-form. Both are small, localised changes if either should differ.

This unblocks #78, which needs the party file to hold a founding date from Wikidata.

Closes #79
