### PR TITLE
Document the linking procedure and warn when a founding date disagrees with the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Tabellen är de fält skripten hanterar. Ytterligare fält får läggas till fö
 
 `deltagande` har ett uppslag per valår: `{ riksdag: bool, region: [länskod], kommun: [kommunkod] }`. Från 2022 listas alla val partiet deltar i, även deltagande som följer av anmälan på högre nivå. 2018 års data är insamlad på annat sätt och speglar därför årets filer, där ett riksdagsparti inte har några region- eller kommunposter alls.
 
-`wikidata` är ett sådant fält, och håller partiets post på Wikidata tillsammans med det som lästs ur den. Sektionen har tre delar: `id`, `grundat` och `hamtad`. `id` är Q-id:t för partiets post på Wikidata, till exempel `Q504069`, och käll-URL:en `https://www.wikidata.org/wiki/<id>` härleds ur det. Fältet ägs av människor: det läggs till genom en granskad pull request, först när någon har bekräftat att posten avser samma parti — etikett, beskrivning och officiell webbplats mot partiets kända uppgifter. Ingen automatisk namnmatchning kopplar ett parti till Wikidata.
+`wikidata` är ett sådant fält, och håller partiets post på Wikidata tillsammans med det som lästs ur den. Sektionen har tre delar: `id`, `grundat` och `hamtad`. `id` är Q-id:t för partiets post på Wikidata, till exempel `Q504069`, och käll-URL:en `https://www.wikidata.org/wiki/<id>` härleds ur det. Fältet ägs av människor: det läggs till genom en granskad pull request, först när någon har bekräftat att posten avser samma parti — etikett, beskrivning och officiell webbplats mot partiets kända uppgifter. Ingen automatisk namnmatchning kopplar ett parti till Wikidata. Stegen för att lägga till en koppling står under [npm run import-wikidata](#npm-run-import-wikidata----parti-filnamn).
 
 `grundat` och `hamtad` ägs av `npm run import-wikidata`. `grundat` är Wikidatas P571 i den precision källan anger — `"1988"`, `"1988-02"` eller `"1988-02-06"` — och utelämnas när posten inte anger något grundandedatum; ett tidigare värde tas då bort, eftersom en uppgift utan källa inte hör hemma i datan. `hamtad` är datumet för den senaste hämtningen.
 
@@ -146,6 +146,24 @@ Valmyndigheten ska anges som källa för symbolerna. Partisymboler kan dessutom 
 Hämtar `https://www.wikidata.org/wiki/Special:EntityData/<id>.json` för varje parti som har ett `wikidata.id`, läser grundandedatumet (P571) och skriver `wikidata.grundat` och `wikidata.hamtad` i partifilen. Med `--parti` hämtas ett enda parti. Partier utan Q-id rörs inte, och skriptet lägger aldrig till ett Q-id självt.
 
 Datumet lagras i källans precision. Har posten flera P571-påståenden gäller preferred-rank framför normal, och deprecated läses aldrig; anger posten två olika datum på samma rang avbryts körningen — vilket som gäller avgörs på Wikidata, med rangmarkering, inte här. Ett värde i en annan kalendermodell än den proleptiskt gregorianska, ett osäkerhetsintervall eller en precision grövre än år avbryter också körningen, liksom ett Q-id som har omdirigerats eller tagits bort. Allt hämtas och valideras innan något skrivs, så en misslyckad körning lämnar `data/` orört.
+
+#### Koppla ett parti till Wikidata
+
+1. Leta upp partiets post på Wikidata och kontrollera att den avser samma parti — etikett, beskrivning och officiell webbplats mot partiets kända uppgifter, och för lokalpartier den kommun posten anger mot kommunerna i partiets `deltagande`. Flera partier delar beteckning, så namnlikhet räcker inte.
+2. Lägg till Q-id:t för hand i partiets `index.json`:
+
+   ```json
+   "wikidata": { "id": "Q504069" }
+   ```
+
+3. Kör `npm run import-wikidata -- --parti <filnamn>`. Skriptet hämtar P571 och fyller `grundat` och `hamtad`.
+4. Committa partifilen med alla tre fälten. En sektion med bara `id` underkänns av `npm run validate:data`, eftersom `hamtad` saknas.
+
+Detsamma gäller när ett Q-id ändras: hämtningen sker aldrig av sig själv, så `grundat` ligger kvar från den förra posten tills importen körts om. Valideringen kontrollerar formen, inte att datumet kommer från det id som står i filen.
+
+En körning utan `--parti` hämtar om samtliga kopplade partier och sätter deras `hamtad` till dagens datum, även för de partier vars datum är oförändrat. Då ändras alltså filer som inte har med den koppling man arbetar med att göra, och rättningar som gjorts på Wikidata sedan förra körningen följer med in. Använd `--parti` när en enskild koppling läggs till eller ändras, och en fullständig körning när avsikten är att uppdatera allt.
+
+Skriptet skriver ut `Att kontrollera:` när ett hämtat datum inte rimmar med partiets egen post — grundat efter att beteckningen registrerades, eller ett parti utan registrerad beteckning som grundades långt före det första val vi har det i. Det är en varning, inte ett fel: datumet är hämtat och skrivet, och den som kopplat partiet får avgöra om posten avser rätt parti.
 
 ### npm run import-riksdagsval -- \<år\> --hamtad \<datum\> --file \<käll-id\>=\<sökväg\>
 

--- a/scripts/import-wikidata.js
+++ b/scripts/import-wikidata.js
@@ -278,6 +278,54 @@ function applyWikidata (parties, entities, today) {
 }
 
 /**
+ * FOUNDED_BEFORE_FIRST_ELECTION_YEARS
+ * How far a founding date may precede the first election we have the party in
+ * before the pairing is worth a second look. Parties that carried their
+ * designation for a decade before our election data begins are ordinary; a
+ * gap much wider than that, with nothing registered in between, is the shape
+ * a reused party name makes.
+ * @type {Number}
+ */
+const FOUNDED_BEFORE_FIRST_ELECTION_YEARS = 10;
+
+/**
+ * sanityWarnings
+ * Reads the founding date against what the party's own record says about it.
+ * Neither check can prove a mismatch, so both only warn: the registry is the
+ * one source that knows this party rather than the name it shares with
+ * others, and a Wikidata entity about a different party of the same name
+ * tends to disagree with it.
+ * @param  {Object} party The built party file, which carries deltagande
+ * @param  {String|undefined} grundat
+ * @return {String[]}
+ */
+function sanityWarnings (party, grundat) {
+  if (!grundat) {
+    return [];
+  }
+  const warnings = [];
+  const foundedYear = Number(grundat.slice(0, 4));
+  const registered = party.valmyndigheten_registreringsdatum;
+
+  if (registered && foundedYear > Number(registered.slice(0, 4))) {
+    warnings.push(`grundat ${grundat} är efter registreringen ${registered}`);
+  }
+
+  const years = Object.keys(party.deltagande ?? {}).map(Number).filter(Number.isFinite);
+  if (!registered && years.length > 0) {
+    const firstElection = Math.min(...years);
+    const gap = firstElection - foundedYear;
+    if (gap > FOUNDED_BEFORE_FIRST_ELECTION_YEARS) {
+      warnings.push(
+        `grundat ${grundat} men ingen registrerad beteckning och första valet ${firstElection}, ${gap} år senare`
+      );
+    }
+  }
+
+  return warnings;
+}
+
+/**
  * main
  */
 async function main () {
@@ -316,6 +364,19 @@ async function main () {
     console.log(`  ${marker} ${change.id} ${change.beteckning}: ${before} → ${after}`);
   }
   console.log(`Skrivna filer: ${written.length}`);
+
+  const built = new Map(build.parties.map(party => [party.filnamn, party.data]));
+  const warnings = changes.flatMap(change =>
+    sanityWarnings(built.get(change.filnamn), change.efter)
+      .map(warning => `${change.beteckning} (${change.id}): ${warning}`)
+  );
+  if (warnings.length > 0) {
+    console.log('\nAtt kontrollera:');
+    for (const warning of warnings) {
+      console.log(`  ! ${warning}`);
+    }
+    console.log('Datumet är hämtat och skrivet. Stämmer posten inte med partiet, ta bort wikidata-sektionen.');
+  }
 }
 
 /**
@@ -327,6 +388,7 @@ exports.fetchEntity = fetchEntity;
 exports.foundingDateFromEntity = foundingDateFromEntity;
 exports.wikidataTargets = wikidataTargets;
 exports.applyWikidata = applyWikidata;
+exports.sanityWarnings = sanityWarnings;
 
 if (require.main === module) {
   main().catch(error => {

--- a/scripts/import-wikidata.test.js
+++ b/scripts/import-wikidata.test.js
@@ -7,6 +7,7 @@ const {
   fetchEntity,
   foundingDateFromEntity,
   parseArgs,
+  sanityWarnings,
   wikidataTargets
 } = require('./import-wikidata.js');
 
@@ -297,4 +298,39 @@ test('applyWikidata stops on a value it must not interpret', () => {
   ]);
   assert.throws(() => applyWikidata(parties, entities, '2026-08-29'), /kalendermodellen/);
   assert.equal(parties[1].extra.wikidata.grundat, '1917');
+});
+
+test('sanityWarnings passes a party whose founding date fits its own record', () => {
+  const party = {
+    valmyndigheten_registreringsdatum: '1979-05-15',
+    deltagande: { 2018: {}, 2022: {} }
+  };
+  assert.deepEqual(sanityWarnings(party, '1979-03-24'), []);
+});
+
+test('sanityWarnings reports a founding date later than the registration', () => {
+  const party = { valmyndigheten_registreringsdatum: '2018-02-23', deltagande: { 2018: {} } };
+  const warnings = sanityWarnings(party, '2021');
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /grundat 2021 är efter registreringen 2018-02-23/);
+});
+
+test('sanityWarnings reports a long-founded party with no designation and one late election', () => {
+  const party = { valmyndigheten_registreringsdatum: undefined, deltagande: { 2018: {} } };
+  const warnings = sanityWarnings(party, '1998');
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /ingen registrerad beteckning och första valet 2018, 20 år senare/);
+});
+
+test('sanityWarnings leaves an old party alone once it has a registered designation', () => {
+  const party = {
+    valmyndigheten_registreringsdatum: '2018-03-16',
+    deltagande: { 2018: {}, 2026: {} }
+  };
+  assert.deepEqual(sanityWarnings(party, '1970'), []);
+});
+
+test('sanityWarnings says nothing when the entity states no founding date', () => {
+  const party = { deltagande: { 2022: {} } };
+  assert.deepEqual(sanityWarnings(party, undefined), []);
 });

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -326,6 +326,10 @@ function validateWikidataSection (value, context) {
   }
   requireString(value.id, `${context}.id`);
   assert.match(value.id, WIKIDATA_ID_PATTERN, `${context}.id ska vara ett Wikidata-id (Q…)`);
+  assert.ok(
+    value.hamtad !== undefined,
+    `${context}.hamtad saknas. Q-id:t läggs till för hand, resten hämtas: kör npm run import-wikidata -- --parti <filnamn>`
+  );
   requireWikidataDate(value.hamtad, `${context}.hamtad`, true);
   if (value.grundat !== undefined) {
     requireWikidataDate(value.grundat, `${context}.grundat`);

--- a/scripts/validate.test.js
+++ b/scripts/validate.test.js
@@ -5,7 +5,7 @@ const path = require('node:path');
 const test = require('node:test');
 
 const { writePartyProfileParliamentView } = require('./build-derived-data.js');
-const { validateData } = require('./validate.js');
+const { validateData, validateWikidataSection } = require('./validate.js');
 
 const PARTY = {
   uuid: '11111111-1111-4111-8111-111111111111',
@@ -277,7 +277,7 @@ test('validateData rejects a malformed wikidata section', async t => {
     ['a Q-id that is not one', { id: 'Q01', hamtad: '2026-08-29' }, /wikidata\.id ska vara ett Wikidata-id/],
     ['an empty Q-id', { id: '', hamtad: '2026-08-29' }, /wikidata\.id får inte vara tom/],
     ['a missing Q-id', { hamtad: '2026-08-29' }, /wikidata\.id ska vara en sträng/],
-    ['a missing hamtad', { id: 'Q1' }, /wikidata\.hamtad ska vara en sträng/],
+    ['a missing hamtad', { id: 'Q1' }, /wikidata\.hamtad saknas/],
     ['a hamtad without day precision', { id: 'Q1', hamtad: '2026-08' }, /wikidata\.hamtad ska vara ÅÅÅÅ-MM-DD/],
     ['a day that month does not have', { id: 'Q1', grundat: '1988-02-30', hamtad: '2026-08-29' }, /wikidata\.grundat är inte ett verkligt datum: 1988-02-30/],
     ['month zero', { id: 'Q1', grundat: '1988-00', hamtad: '2026-08-29' }, /wikidata\.grundat är inte ett verkligt datum: 1988-00/],
@@ -326,3 +326,10 @@ test('validateData rejects a Q-id claimed by two parties', t => {
 function readJson (root, relativePath) {
   return JSON.parse(fs.readFileSync(path.join(root, relativePath), 'utf8'));
 }
+
+test('validateWikidataSection points at the import when only the Q-id is there', () => {
+  assert.throws(
+    () => validateWikidataSection({ id: 'Q504069' }, 'sverigedemokraterna.wikidata'),
+    /hamtad saknas.*npm run import-wikidata/s
+  );
+});


### PR DESCRIPTION
Three small gaps around linking a party to Wikidata, found by asking what the next person to add a Q-id actually runs into.

## The procedure was never written down

README documents who owns which field — `id` by people through a reviewed PR, `grundat` and `hamtad` by the import — but never the order of steps. Someone who adds only the Q-id and commits gets a validation error about `hamtad`, a field the same README tells them the script owns. The new section under `npm run import-wikidata` gives the four steps, and the field documentation links to it.

It also writes down two things the script's behaviour implies but never stated: nothing is fetched automatically, so a changed Q-id leaves `grundat` from the previous entity until the import runs again — validation checks the form, not that the date came from the id now in the file. And a run without `--parti` refreshes every linked party and stamps today's `hamtad` on all of them, so unrelated files land in the diff and upstream corrections to other parties come along with them. Use `--parti` for a single link; a full run is for deliberately refreshing everything.

## The validation error pointed at the wrong thing

A `wikidata` section with only an `id` failed with `wikidata.hamtad ska vara en sträng`. It now names the actual missing step:

```
wikidata.hamtad saknas. Q-id:t läggs till för hand, resten hämtas: kör npm run import-wikidata -- --parti <filnamn>
```

## The import now flags a date that disagrees with the party's own record

Two checks, both warnings — neither can prove a mismatch, and the run still writes the date:

- the founding date falls after the party registered its designation;
- the party has no registered designation and was founded more than ten years before the first election we have it in.

The registry is the one source that knows *this* party rather than the name it shares with others, so a Wikidata entity about a different party of the same name tends to disagree with it. The second check is the Det nya partiet case from #84: founded 1998 per Wikidata, no registered designation, nothing before the 2018 election. It also fires on the Ny Demokrati candidate rejected in the same round. Both are regression tests.

Against the 34 currently linked parties the checks produce exactly one warning, Sverigepartiet — founded 1986, no registered designation, first stood in 2018 — which is the one remaining link a reviewer called murky. That count says something about noise but nothing about detection: the rules were derived from the mismatches rejected in #84, and those records are no longer in the tree to be caught. The regression tests are what pin the detection.

A third rule was measured and dropped: warning when the founding date long precedes the registration date fires on eleven of the thirty-four, including every parliamentary party, because Valmyndigheten's registration dates cluster in 2017–2018 regardless of when the party was founded.

## Verification

`npm run precommit` green, 192 tests. `npm run import-wikidata -- --parti sverigepartiet` was run end to end against Wikidata: the warning prints, and `data/` is unchanged.
