### PR TITLE
Start page filters are lost after opening a party and going back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ Open data about Swedish political parties. Swedish copy.
   behind nginx. `next/image` optimisation remains disabled.
 - Party pages use `getServerSideProps` and read JSON through
   `src/server/party-data.ts`. Previous slugs return HTTP 308, unknown slugs 404.
+- The start page carries its filters in the query string (`valar`, `valtyp`,
+  `lan`, `kommun`, `q`, `sortering`), with the defaults left out so the
+  unfiltered page stays `/`. `src/components/home/query.ts` translates between
+  the query and the state in both directions.
 - `npm run build:release` packages `.release/`; `npm run test:http` starts that
   exact artifact and verifies the public routes locally.
 - Styling: Tailwind 3 + Bootstrap 5 tables via sass. `src/styles/base.scss` is

--- a/agent-docs/issue/86-start-page-filters-lost-back/index.md
+++ b/agent-docs/issue/86-start-page-filters-lost-back/index.md
@@ -1,0 +1,30 @@
+# Issue #86: Start page filters are lost after opening a party and going back
+
+**Baserad på:** main
+
+## Sammanfattning
+
+Startsidan håller sökterm, valår, län, kommun, valtyp och sortering enbart i `useState` i `src/components/home/HomeContent.tsx`, så en läsare som öppnar ett parti och går tillbaka börjar om från förvalen. Planen flyttar tillståndet till URL:ens query string (`valar`, `valtyp`, `lan`, `kommun`, `q`, `sortering`) med förvalen utelämnade så att `/` förblir kanonisk ("Alla valår" får token `valar=alla`, eftersom förvalet är det senaste året): en ny ren modul `src/components/home/query.ts` översätter query ⇄ tillstånd och testas med `node:test`, `getServerSideProps` tolkar `context.query` och seedar komponenten så att en delad länk renderas filtrerad redan på servern (verifierat i `http-smoke`), och `HomeContent` skriver URL:en i varje händelsehanterare med shallow `router.replace` utan scroll — omedelbart, så en ändring följd av ett partiklick överlever bakåtnavigeringen. En riktig navigering till `/` (t.ex. via logotypen) börjar om från URL:en genom en `key` som räknas upp på icke-shallow `routeChangeComplete`. "Rensa filter" lämnar sorteringen som i dag; antalet utfällda partier lämnas utanför scope, med förslag om uppföljningsissue tillsammans med scrollåterställning. Klientnavigeringen har ingen automatisk täckning och verifieras manuellt som obligatoriskt steg.
+
+## Triageringsstatus
+
+| Fält | Värde |
+|------|-------|
+| **Redo att arbeta** | Ja |
+| **Risk** | Medel |
+| **Säker för junior** | Ja, med granskning |
+
+## Plangranskning
+
+**Status:** Granskad
+**Granskad:** 2026-08-29
+**Feedback:** Tre granskningsrundor. Första rundan: fördröjda URL-skrivningar kunde tappa en ändring vid omedelbart partiklick, återställningens effekt på sorteringen var oklar (nu ett explicit beslut: sorteringen lämnas, designbeslut 9), URL-jämförelsen var ospecificerad, smoke-testet kontrollerade bara kontrollerna och inte resultatet, och flera kantfall (`valar=[]`, blanksteg i `q`, kommun med ogiltigt län, rundtur bara för kanoniska tillstånd) saknades. Andra rundan: fördröjningen slopades helt — varje ändring skrivs i sin egen händelse med omförsök när webbläsaren vägrar — hash läses ur `window.location` i stället för routern, skrivningen hoppas över när den normaliserade söksträngen redan är URL:ens, sök-/sorteringsscenariot i smoke-testet jämför hela gridet, och triageringen fick faktiska issue-metadata. Tredje rundan: `valar=alla`-assertionen rättades — utan år släpper `matchesParticipation()` igenom alla 670 partier, inte bara de 639 med deltagande. Avböjt: att införa Playwright för klientnavigeringen — bedöms oproportionerligt, i stället obligatoriska manuella kontroller i fas 3 och en öppen fråga till användaren.
+
+## Relaterade filer
+
+- [plan.md](plan.md) — Fullständig implementationsplan
+- [progress.md](progress.md) — Implementationsframsteg
+
+## Relaterade issues
+
+- Inga öppna issues refererar #86

--- a/agent-docs/issue/86-start-page-filters-lost-back/plan.md
+++ b/agent-docs/issue/86-start-page-filters-lost-back/plan.md
@@ -1,0 +1,219 @@
+# Plan: Issue #86 — Start page filters are lost after opening a party and going back
+
+## Mål
+
+Låt startsidans filtertillstånd — sökterm, valår, län, kommun, valtyp och sortering — leva i URL:ens query string, med förvalen utelämnade så att den ofiltrerade startsidan förblir `/`. Då överlever tillståndet att en läsare öppnar ett parti och går tillbaka (historiken bär URL:en), och en filtrerad vy blir länkbar: samma URL öppnad direkt ger samma lista, server-renderad. Antalet partier som fällts ut med "Visa fler" lämnas utanför (se designbeslut 6).
+
+## Triagering
+
+> Beslutsunderlag för detta issue.
+
+| Fält | Värde |
+|------|-------|
+| **Blockeras av** | Inget |
+| **Blockerar** | Inget |
+| **Relaterade issues** | Inga (ingen öppen issue refererar #86; #57 rör Tailwind och berör inte startsidans logik) |
+| **Omfattning** | 6 filer: `src/components/home/query.ts` (ny), `src/components/home/HomeContent.tsx`, `src/pages/index.tsx`, `scripts/home-query.test.js` (ny), `scripts/http-smoke.js`, `CLAUDE.md` |
+| **Risk** | Medel (klientsidig routerkoppling i en komponent som i dag är ren React-state, och navigeringsbeteendet kan bara verifieras manuellt i webbläsare; hålls nere av att filter-/sorteringslogiken inte ändras och av att URL-tolkningen är en ren, testad modul) |
+| **Komplexitet** | Medel |
+| **Säker för junior** | Ja, med granskning — designbeslut 3–5 förklarar varför URL:en skrivs från state och inte tvärtom, och de manuella navigeringskontrollerna i fas 3 är obligatoriska |
+| **Konfliktrisk** | Låg — samtliga befintliga planmappar hör till stängda issues; ingen öppen plan berör `src/components/home/` eller `src/pages/index.tsx` |
+
+### Triagemässiga noteringar
+
+- Inget projektbräde är konfigurerat (`agent-docs/github/project.json` saknas) och `agent-docs/github/info.json` finns inte, så ingen board-status eller release-gren att stämma av. Inga `release/*`-grenar finns; planen utgår från `main`.
+- Issuet (öppet, inga etiketter, ingen tilldelad, inga kommentarer per 2026-08-29) anger uttryckligen att URL-riktningen är "the agent's suggestion, open to challenge". Acceptanskriterierna kräver dock en URL som återskapar vyn, vilket i praktiken avgör riktningen (se designbeslut 1).
+- Ingen webbläsartestning finns i repot. Klientnavigeringen (bakåt, logotyp, omedelbart partiklick) verifieras därför manuellt som obligatorisk del av fas 3; att införa Playwright bedöms oproportionerligt för det här issuet och lämnas som en öppen fråga till användaren, inte som ett tyst beslut.
+
+## Angreppssätt
+
+I dag håller `HomeContent` (`src/components/home/HomeContent.tsx:29–31`) hela tillståndet i `useState`: `filters` seedas från `defaultFilters(valar)`, `order` från `defaultOrder`, `visible` från `PAGE_SIZE`. `update()` (rad 42) kör `pruneFilters` och nollställer `visible`. Startsidan (`src/pages/index.tsx:41`) renderas med `getServerSideProps` som bara läser `partyData.readHomeData()` och ignorerar `context.query`. När läsaren navigerar till `/parti/<filnamn>` och tillbaka monteras sidan om och allt börjar från förvalen.
+
+Filter- och sorteringslogiken (`filtering.ts`, `sorting.ts`, `summary.ts`) är redan rena moduler med `node:test`-tester som `require`:ar `.ts`-filerna direkt (Node 24 type-stripping). URL-kodningen får samma form: en ny ren modul `query.ts` som översätter mellan query-parametrar och `{ filters, order }`, testad på samma sätt. Modulen får inte importera `next/router` eller något via `src/...`-baseUrl (Node löser inte det), och relativa runtime-importer måste bära `.ts`-ändelse — samma konvention som `sorting.ts` redan följer med `./summary.ts`.
+
+Tre kopplingar behövs runt den modulen:
+
+1. **Server → initialt tillstånd.** `getServerSideProps` tolkar `context.query` mot datans `valar`/`lan`/`kommuner` och skickar med `initial: { filters, order }` som prop. `HomeContent` seedar sina `useState` från `initial` i stället för från förvalen. Eftersom seeden kommer från props blir server-HTML och första klientrendering identiska, och en delad länk renderas filtrerad redan på servern — det är det som gör acceptanskriteriet "reproduces it when opened directly" mätbart i `http-smoke`.
+
+2. **State → URL.** Lokalt state förblir sanningskällan (se designbeslut 3). Varje användaråtgärd som ändrar tillståndet — `update()`, sorteringsbytet och återställningen — serialiserar det nya tillståndet med förvalen utelämnade och skriver det omedelbart, i samma händelse, med `router.replace({ pathname: '/', query, hash }, undefined, { shallow: true, scroll: false })`. `shallow: true` hindrar att `getServerSideProps` körs om (hela partiregistret läses annars per tangenttryck), `scroll: false` hindrar att sidan hoppar till toppen vid varje filterändring, och `hash` läses ur `window.location.hash` i skrivögonblicket (sidhuvudets "Om tjänsten" är en vanlig fragmentlänk som routern inte ser) så `#om-tjansten` överlever. Skrivningen hoppas över när den normaliserade söksträngen redan är `window.location.search`; annars ersätts hela query stringen, så okända parametrar försvinner avsiktligt vid första användaråtgärden. Ingen fördröjning: URL:en är skriven innan nästa händelse kan inträffa, vilket är det som gör att en filterändring omedelbart följd av ett partiklick överlever bakåtnavigeringen (designbeslut 5). Ingen skrivning sker vid mount: en icke-kanonisk länk (`/?valar=2026`, okända parametrar) lämnas som den är tills läsaren rör något.
+
+3. **Riktig navigering till `/` → nytt tillstånd.** Tillbaka-navigering från partisidan monterar `HomePage` på nytt, så seeden från props räcker där. Men en navigering från `/?valar=2018` till `/` via sidhuvudets logotyp (`Header.tsx:18`, `Link href="/"`) byter *inte* komponent — Next kör `getServerSideProps` igen och uppdaterar props, medan `useState` behåller det gamla tillståndet. Lösningen är att `HomePage` lyssnar på `router.events` `routeChangeComplete` och räknar upp en `generation` för varje icke-shallow ändring, som blir `key` på `HomeContent`; en riktig navigering till startsidan börjar då om från URL:en (designbeslut 4).
+
+Tolkningen måste vara tolerant: okända eller ogiltiga värden (ett år datan saknar, en länskod som inte finns, `valtyp=eu`) faller tyst tillbaka till förvalet, arrayvärden (`?valar=2022&valar=2018`) behandlas som första värdet, och `pruneFilters` körs på resultatet så att `?valtyp=riksdag&lan=01` ger samma tillstånd som UI:t hade gett. Ingen redirect till kanonisk form görs — nästa filterändring skriver ändå om URL:en.
+
+En kodningsdetalj som är lätt att missa: förvalet för valår är det *senaste* året, inte "alla". `valar: ''` (Alla valår) är alltså ett icke-förval och kan inte kodas som "parametern saknas". Därför får `valar` tre lägen: saknas → senaste året, `alla` → alla år, `<år>` → det året.
+
+## Steg
+
+### Fas 1: Ren URL-modul med tester
+
+1. Skapa `src/components/home/query.ts`
+   - `export interface HomeState { filters: HomeFilters; order: SortOrder }`
+   - `export type HomeQuery = Record<string, string | string[] | undefined>` (formen `context.query`/`router.query` har, utan att importera `querystring`)
+   - `export const ALL_YEARS = 'alla'` — token för "Alla valår"
+   - `export function stateFromQuery (query: HomeQuery, data: Pick<HomeData, 'valar' | 'lan' | 'kommuner'>): HomeState`
+     - `valar`: saknas eller ogiltigt → `defaultFilters(data.valar).valar`; `alla` → `''`; ett år i `data.valar` → det året
+     - `valtyp`: `riksdag` | `region` | `kommun` (nycklarna i `electionKindLabels`), annars `''`
+     - `lan`: kod som finns i `data.lan`, annars `''`; `kommun`: kod som finns i `data.kommuner`, annars `''`. Om `kommun` är giltig och `lan` saknas eller är ogiltig sätts `lan` till kommunens `HomeMunicipality.lan` (samma effekt som kommunväljarens `onChange` i `PartyFilters.tsx`, men från datan i stället för `kod.slice(0, 2)`); en giltig `lan` som inte är kommunens län lämnas åt `pruneFilters`, som då släpper kommunen
+     - `q`: strängen som den är (ingen trimning; `normalise()` trimmar vid matchning), tom om den saknas
+     - `sortering`: via `isSortOrder`, annars `defaultOrder`
+     - Arrayvärden → första elementet; okända parametrar och hash ignoreras; slutligen `pruneFilters` på filtren
+   - `export function queryFromState (state: HomeState, valar: string[]): Record<string, string>`
+     - Fast nyckelordning `valar, valtyp, lan, kommun, q, sortering` så URL:en blir stabil
+     - Regeln är "utelämna det som är lika med förvalet": `valar` utelämnas när det är `defaultFilters(valar).valar` (senaste året, eller `''` när datan saknar år — då skrivs aldrig `alla`), tomma strängar utelämnas, `sortering` utelämnas när den är `defaultOrder`; `valar=alla` skrivs för `''` bara när förvalet är ett år
+     - `q` skrivs bara när `query.trim() !== ''`, och då som den är
+   - Importera `./filtering.ts` och `./sorting.ts` med `.ts`-ändelse; `HomeData` bara som `import type`
+   - Filer att skapa: `src/components/home/query.ts`
+2. Skriv `scripts/home-query.test.js` i samma stil som `home-filtering.test.js`
+   - Tom query → `{ filters: defaultFilters(valar), order: 'namn' }`
+   - `valar=alla` → `valar: ''`; `valar=1900` (saknas i datan) → senaste året; `valar=2018` → `2018`
+   - Ogiltig `lan`/`kommun`/`valtyp`/`sortering` faller tillbaka; giltiga går igenom
+   - `kommun=1280` utan `lan` → `lan: '12'` (från `HomeMunicipality.lan`); `kommun=1280&lan=99` (ogiltigt län) → `lan: '12'`; `kommun=1280&lan=01` → kommunen prunas (läns­missmatch)
+   - `valtyp=riksdag&lan=01` → `lan: ''` (pruning)
+   - Arrayvärde tar första elementet; okända parametrar (`utm_source=x`) påverkar inget
+   - `queryFromState` med förvalen ger `{}`; `valar: ''` ger `{ valar: 'alla' }` när datan har år men `{}` när `valar` är `[]`; `sortering` skrivs bara när den avviker; `q` av bara blanksteg skrivs inte, `q` med inre blanksteg skrivs som det är
+   - Rundtur: för ett antal *kanoniska* tillstånd (kommun med sitt län, trimmad sökterm) gäller `stateFromQuery(queryFromState(s)) deepEqual s`; icke-kanoniska tillstånd (sökterm av bara blanksteg) testas som "serialiseras till `{}`" i stället
+   - Filer att skapa: `scripts/home-query.test.js`
+
+### Fas 2: Servern tolkar URL:en
+
+1. Utöka `getServerSideProps` i `src/pages/index.tsx`
+   - `const data = await partyData.readHomeData(); return { props: { ...data, initial: stateFromQuery(context.query, data) } }`
+   - Ny typ `HomePageProps = HomeData & { initial: HomeState }`; `NextPage<HomePageProps>` och `GetServerSideProps<HomePageProps>`
+   - `<link rel="canonical" href="https://www.partidata.se/">` lämnas oförändrad (designbeslut 8)
+   - Filer att ändra: `src/pages/index.tsx` (rad ~10, ~41–43)
+
+### Fas 3: Klienten seedar från och skriver till URL:en
+
+1. Seed från props i `HomeContent`
+   - Ta emot `initial` i props; `useState(initial.filters)` och `useState(initial.order)`
+   - Behåll `defaultFilters(valar)` som `defaults` för "Rensa filter" — återställning ska gå till förvalen, inte till URL:ens startläge
+   - Filer att ändra: `src/components/home/HomeContent.tsx` (rad ~27–31, ~59, ~71)
+2. Skriv URL:en från state, i händelsehanterarna
+   - `const router = useRouter()` (`next/router`); en `useRef<HomeState>` med senast begärda tillstånd och en `useRef` för en eventuell omförsökstimer
+   - Hjälpfunktion `write (state: HomeState)`: spara `state` i ref:en; `search = new URLSearchParams(queryFromState(state, valar)).toString()`; om `search === new URLSearchParams(window.location.search).toString()` → returnera (ingen onödig routerhändelse); annars `router.replace({ pathname: '/', query: queryFromState(state, valar), hash: window.location.hash || undefined }, undefined, { shallow: true, scroll: false })`. Rejection: `error.cancelled` (routerns eget avbrott) ignoreras; annat fel loggas med `console.error` och en omförsökstimer (~1 s) skriver ref:ens senaste tillstånd — det är vad som händer när Safari vägrar `replaceState` (designbeslut 5)
+   - `update(patch)`: beräkna `next = pruneFilters({ ...filters, ...patch })` från renderat state (händelserna är diskreta, så `filters` är aktuellt), `setFilters(next)`, `setVisible(PAGE_SIZE)`, `write({ filters: next, order })`
+   - Sorteringsbytet: `setOrder(next)` följt av `write({ filters, order: next })`
+   - Återställning: `update(defaults)` som i dag (sorteringen lämnas, designbeslut 9)
+   - `useEffect` med enbart cleanup som rensar omförsökstimern vid unmount
+   - Kommentaren vid omförsöket anger det tekniska skälet (webbläsares gräns för `history.replaceState`-anrop per tidsenhet) — inte produktresonemang
+   - Filer att ändra: `src/components/home/HomeContent.tsx`
+3. Börja om vid riktig navigering till startsidan
+   - I `HomePage`: `useRouter()`, `const [generation, setGeneration] = useState(0)`, `useEffect` som registrerar `routeChangeComplete`-lyssnare `(url, { shallow }) => { if (!shallow) setGeneration(g => g + 1) }` och avregistrerar i cleanup; `<HomeContent key={generation} {...props} />`
+   - Filer att ändra: `src/pages/index.tsx`
+4. Manuell navigeringskontroll i `npm run dev` (obligatorisk — det finns ingen webbläsartestning i repot, och att införa Playwright för det här är oproportionerligt; kontrollerna är därför del av fasen, inte en efterhandsbonus)
+   - Filter + sortering + sökterm, öppna parti, bakåt → allt står kvar
+   - Byt ett select-/chip-värde och klicka på ett parti *omedelbart*, bakåt → ändringen står kvar
+   - Skriv i sökfältet och klicka på första träffen *omedelbart* efter sista tangenttrycket, bakåt → hela söktermen står kvar (varje tangenttryck skrivs i sin egen händelse)
+   - Från `/` välj 2018, klicka logotypen → listan står på senaste året och URL:en är `/`
+   - Nätverksfliken: filterändringar ger inga `_next/data`-anrop; bakåtnavigering ger ett, som i dag
+   - Sökfältet: markören hoppar inte, sidan scrollar inte vid ändring; `#om-tjansten` i URL:en överlever en filterändring
+   - Verktyg: `run`-skillen eller chrome-devtools-MCP:n kan driva kontrollerna, men resultatet ska ändå läsas av en människa
+
+### Fas 4: HTTP-smoke och dokumentation
+
+1. Utöka `scripts/http-smoke.js`
+   - Låt `standingParties()` returnera listan över år som har `partideltagande/partier.json` (inte bara katalognamn), och `assert.ok` att det finns minst två sådana år innan ett tidigare år (`years.at(-2)`) används
+   - Läs varje partis `deltagande` ur `data/parti/<filnamn>/index.json` (samma källa som `readHomeData()`, via `facet()`-formen `riksdag`/`region`/`kommun`) så förväntade resultat kan räknas ut
+   - Hämta `/?valar=<tidigare år>&valtyp=riksdag` och asserta resultatet, inte bara kontrollerna: `partyGridLinks` är lika med partierna vars `deltagande[<år>].riksdag` är sant, i svensk namnordning, första 48; rubriken räknar `>N av M<` med det antalet; `<option value="<år>" selected="">`; den tryckta chipen är just riksdagsvalet (`aria-pressed="true"[^>]*>Riksdagsval<`); `<link rel="canonical" href="https://www.partidata.se/">` finns kvar
+   - Hämta `/?valar=<tidigare år>&sortering=kommuner&q=parti` och asserta: `<option value="kommuner" selected="">`, sökfältet renderas med `value="parti"`, rubriken räknar träffarna, och `partyGridLinks` är lika med de första 48 av träffarna (namn/förkortning/område innehåller "parti", normaliserat som i `normalise()` — diakritiska tecken bort, gemener) rangordnade på antal kommuner det året i fallande ordning, med stabil svensk namnordning (`comparePartyOrder`) inom lika antal; räkna fram listan i testet med samma regler, inte genom att importera `filtering.ts`/`sorting.ts` (smoke-testet ska vara oberoende av den kod det kontrollerar)
+   - Hämta `/?valar=alla` och asserta `<option value="" selected="">Alla valår</option>` och att rubriken räknar `>M av M<` — utan år och utan andra filter släpper `matchesParticipation()` (`filtering.ts:104`) igenom alla partier, även de 31 utan registrerat deltagande — samt att `partyGridLinks` är de första 48 av hela registret i `comparePartyOrder`-ordning
+   - Hämta `/?valar=1900&valtyp=eu` och asserta att senaste året är valt och ingen chip är `aria-pressed="true"` (ogiltiga värden faller tillbaka)
+   - Hämta `/?valar=<senaste>` och asserta att `partyGridLinks` är identiska med `/`:s (förvalet i URL ger samma vy som `/`)
+   - Filer att ändra: `scripts/http-smoke.js` (`standingParties()` rad ~30–45, assertioner efter rad ~160)
+2. Notera konventionen i `CLAUDE.md`
+   - En mening under "Stack": startsidans filter bärs i query strängen (`valar`, `valtyp`, `lan`, `kommun`, `q`, `sortering`), förval utelämnas, tolkningen bor i `src/components/home/query.ts`
+   - Filer att ändra: `CLAUDE.md`
+
+### Fas 5: Verifiering
+
+1. `npm run precommit` (lint, typecheck, derived-data, validate:data, test, build:release, test:http)
+2. Manuell kontroll i webbläsare enligt verifieringschecklistan nedan, inklusive Safari om tillgängligt (replaceState-gränsen)
+
+## Filöversikt
+
+| Fil | Åtgärd | Syfte |
+|-----|--------|-------|
+| `src/components/home/query.ts` | Skapa | Ren översättning query ⇄ `{ filters, order }`, förval utelämnade, `alla`-token, validering mot datan |
+| `scripts/home-query.test.js` | Skapa | Tester för tolkning, serialisering och rundtur |
+| `src/pages/index.tsx` | Ändra | `getServerSideProps` tolkar `context.query` → `initial`; `generation`-key på `HomeContent` vid icke-shallow navigering |
+| `src/components/home/HomeContent.tsx` | Ändra | Seed från `initial`; effekt som skriver URL:en med shallow `router.replace` |
+| `scripts/http-smoke.js` | Ändra | Assertioner på filtrerade URL:er, `alla`, ogiltiga värden och kanonisk `/` |
+| `CLAUDE.md` | Ändra | En rad om URL-konventionen för startsidans filter |
+
+## Berörda kodområden
+
+- `src/components/home/`
+- `src/pages/index.tsx`
+- `scripts/http-smoke.js`, `scripts/home-*.test.js`
+
+## Designbeslut
+
+> Icke-triviala val gjorda under planeringen. Feedback välkommen; annars implementeras enligt dessa.
+
+### 1. Tillståndet bärs i URL:ens query string
+**Alternativ:** Query string vs `sessionStorage` vs Next-router-state
+**Beslut:** Query string
+**Motivering:** Acceptanskriterierna kräver en URL som återskapar en filtrerad vy när den öppnas direkt eller delas — det kan bara query stringen ge. `sessionStorage` hade löst bakåtnavigeringen men inte länkbarheten. Proveniens: användarbeslut via issuets acceptanskriterier; själva riktningen är i issuet markerad som agentförslag "open to challenge", men kriterierna låser den.
+
+### 2. Parameternamn och `alla`-token
+**Alternativ:** Parameternamn lika `HomeFilters`-nycklarna vs kortformer; "alla år" som tom parameter vs egen token
+**Beslut:** `valar`, `valtyp`, `lan`, `kommun`, `q`, `sortering`; `valar=alla` för alla år; alla förval utelämnade
+**Motivering:** Namnen följer fältnamnen i `HomeFilters` och issuets exempel (`?valar=2026&lan=…&valtyp=riksdag&q=…`), i svensk form som resten av datamodellen. `sortering` matchar väljarens `aria-label`. Förvalet för valår är det senaste året, så "alla år" är ett aktivt val som behöver ett eget värde; `alla` är läsbart och kan inte förväxlas med ett årtal. Kravet att `/` förblir kanonisk gör att förval måste utelämnas. Proveniens: `q`-namnet och principen "defaults omitted" är issuets; `sortering`-namnet och `alla`-tokenen är agentens bedömning — öppna att ifrågasätta.
+
+### 3. Lokalt state förblir sanningskällan; URL:en skrivs från det
+**Alternativ:** (a) `router.query` som enda källa och alla kontroller läser därifrån, (b) lokalt state som i dag, seedat från URL:en vid mount och skrivet till URL:en vid ändring
+**Beslut:** (b)
+**Motivering:** `router.replace` är asynkron. Med (a) blir sökfältet en kontrollerad input vars värde kommer en tick senare än tangenttrycket; React återställer då DOM-värdet till det gamla i mellantiden, vilket ger hoppande markör och tappade tecken vid redigering mitt i strängen. Med (b) svarar UI:t direkt som i dag och URL:en följer efter. Priset är att URL → state bara sker vid mount och vid riktig navigering (beslut 4), aldrig löpande — vilket är rätt, eftersom inget annat än den här komponenten skriver den URL:en. `replace` i stället för `push` så att varje tangenttryck inte blir en historikpost; bakåt från partisidan hamnar då på det senaste tillståndet. Proveniens: agentens bedömning — öppen att ifrågasätta.
+
+### 4. Riktig navigering till `/` börjar om från URL:en via `key`
+**Alternativ:** (a) Nyckla `HomeContent` på `router.asPath`, (b) nyckla på serialiserat `initial`-prop, (c) räkna upp en `generation` på icke-shallow `routeChangeComplete`
+**Beslut:** (c)
+**Motivering:** (a) monterar om vid varje egen shallow-skrivning (fokus i sökfältet försvinner per tangenttryck). (b) missar fallet där både gammalt och nytt `initial` är förvalen: `/` → shallow till `?valar=2018` → logotyp till `/` ger oförändrad key medan state fortfarande säger 2018. (c) reagerar exakt på det som ska nollställa: en navigering Next själv gjorde. Bieffekten är en renderingsram med gammalt state innan omstarten, vilket inte syns i praktiken. Proveniens: agentens bedömning — öppen att ifrågasätta.
+
+### 5. Varje ändring skrivs omedelbart; en vägrad skrivning görs om efter en sekund
+**Alternativ:** (a) Skriv i samma händelse vid varje ändring, (b) debounce på alla skrivningar, (c) debounce enbart för sökfältet
+**Beslut:** (a), med omförsök vid fel
+**Motivering:** Acceptanskriteriet kräver att historikposten är uppdaterad innan läsaren följer en partilänk. Både (b) och (c) lämnar en lucka där sista ändringen inte hunnit skrivas när partilänken klickas; med (a) finns ingen sådan lucka — `router.replace` för en shallow-ändring gör inga hämtningar och är klar långt innan nästa användarhändelse kan inträffa. Skälet att överväga en fördröjning alls är Safari, som begränsar `history.replaceState` till 100 anrop per 30 sekunder och kastar `SecurityError` däröver; det kräver ihållande skrivande i sökfältet i över 20 sekunder. När det ändå händer får `router.replace` en rejection: tillståndet i komponenten är oberört, felet loggas, och ett omförsök en sekund senare skriver det senaste tillståndet så att URL:en hinner ikapp innan läsaren rimligen har valt ett parti. Sista tangenttrycket har alltså alltid en skrivning på väg, utan att någon skrivning fördröjs i normalfallet. Proveniens: agentens bedömning — öppen att ifrågasätta; omförsöket kan strykas om Safari-gränsen bedöms försumbar.
+
+### 6. Antalet utfällda partier ("Visa fler") lämnas utanför
+**Alternativ:** `visa=<n>` i URL:en vs `sessionStorage` vs utanför scope
+**Beslut:** Utanför scope; föreslå uppföljningsissue
+**Motivering:** Issuet ställer upp `sessionStorage` och "dropped from scope" som likvärdiga. Nyttan av att återställa antalet är beroende av att även scrollpositionen återställs, vilket Nexts pages-router inte gör vid bakåtnavigering utan `experimental.scrollRestoration` — det hör ihop och bör göras i ett eget issue ("återställ utfällt antal och scrollposition vid bakåtnavigering") i stället för att halvgöras här. Acceptanskriterierna nämner inte antalet. Proveniens: användaren har gett båda alternativen; valet mellan dem är agentens bedömning.
+
+### 7. Ogiltiga värden faller tyst tillbaka, ingen redirect
+**Alternativ:** Redirect till kanonisk URL vid ogiltig/onormaliserad query vs tolerant tolkning utan redirect
+**Beslut:** Tolerant tolkning; okända parametrar ignoreras och försvinner vid nästa skrivning
+**Motivering:** En redirect på `/` för varje felformad länk kostar en rundtur och ger inget läsaren ser. Tolkningen mot datans faktiska år, län och kommuner garanterar att inget ogiltigt tillstånd når `filterParties`. Proveniens: agentens bedömning — öppen att ifrågasätta.
+
+### 8. Kanonisk länk förblir `https://www.partidata.se/`
+**Alternativ:** Kanonisk länk med query vs oförändrad
+**Beslut:** Oförändrad
+**Motivering:** Filtrerade vyer är samma sida; `/` som kanonisk är redan etablerat i `src/pages/index.tsx` och är ett acceptanskriterium. Proveniens: befintlig konvention och användarbeslut (issue #86).
+
+### 9. "Rensa filter" lämnar sorteringen som den är
+**Alternativ:** Återställningen nollställer även sorteringen vs bara filtren och söktermen, som i dag
+**Beslut:** Som i dag — sorteringen lämnas
+**Motivering:** `onReset` kallar `update(initialFilters)` och rör inte `order` (`HomeContent.tsx:59, 71`); knappen heter "Rensa filter" och sorteringen är inte ett filter. Konsekvensen är att URL:en efter en återställning blir `/` bara när sorteringen står på förvalet, annars `/?sortering=…` — vilket är korrekt, eftersom vyn då inte är den ofiltrerade förvalsvyn. Att låta återställningen även nollställa sorteringen är ett UX-beslut som inte fattats i issuet och därför inte görs här. Proveniens: befintlig konvention (`HomeContent.tsx`); huruvida den ska ändras är en öppen fråga för användaren.
+
+## Verifieringschecklista
+
+Automatiskt (`npm run precommit`):
+
+- [ ] `scripts/home-query.test.js` täcker tolkning, serialisering, pruning, `alla`, tomt `valar` och rundtur för kanoniska tillstånd
+- [ ] `http-smoke`: filtrerad URL ger filtrerat och sorterat grid i server-HTML, `alla` och ogiltiga värden faller rätt, `/?valar=<senaste>` är lika med `/`, kanonisk länk kvar (acceptanskriterium: en URL som återskapar vyn)
+- [ ] `npm run precommit` grönt (acceptanskriterium)
+
+Manuellt i webbläsare (obligatoriskt — navigeringsbeteendet har ingen automatisk täckning):
+
+- [ ] Sätt valår, län, kommun, valtyp och sökterm, öppna ett parti, gå tillbaka: allt står kvar (acceptanskriterium)
+- [ ] Ändra sortering till "Flest kommuner", öppna ett parti, gå tillbaka: sorteringen står kvar (acceptanskriterium)
+- [ ] Byt ett select-/chip-värde och klicka på ett parti omedelbart, gå tillbaka: ändringen står kvar
+- [ ] Kopiera URL:en för en filtrerad vy och öppna den i ett nytt fönster: samma lista och samma kontrollägen (acceptanskriterium)
+- [ ] Ofiltrerad startsida har URL `/` utan query string; "Rensa filter" med förvald sortering tar tillbaka URL:en till `/` (acceptanskriterium)
+- [ ] "Alla valår" ger `/?valar=alla` och återskapas från den URL:en
+- [ ] `?kommun=1280` utan län: länet härleds och kommunväljaren visar kommunen; `?valtyp=riksdag&lan=01` ger Hela landet; `?valar=1900&valtyp=eu` ger förvalen
+- [ ] Skriv i sökfältet: markören hoppar inte, inga tecken tappas, sidan scrollar inte till toppen vid filterändring; `#om-tjansten` överlever en filterändring
+- [ ] Från `/?valar=2018`, klicka logotypen i sidhuvudet: listan står på senaste året och URL:en är `/`
+- [ ] Nätverksfliken: inga `_next/data`-anrop vid filterändring; ett vid bakåtnavigering, som i dag
+- [ ] Safari om tillgängligt: ihållande skrivning i sökfältet i en halv minut ger på sin höjd loggade fel, och URL:en hinner ikapp söktermen inom någon sekund efter att skrivandet upphört

--- a/agent-docs/issue/86-start-page-filters-lost-back/progress.md
+++ b/agent-docs/issue/86-start-page-filters-lost-back/progress.md
@@ -1,0 +1,48 @@
+# Framsteg: Issue #86 — Start page filters are lost after opening a party and going back
+
+**Påbörjad:** 2026-08-29
+**Senast uppdaterad:** 2026-08-29
+**Status:** Klar
+
+## Genomförda steg
+
+- [x] Fas 1, steg 1: `src/components/home/query.ts` — ren översättning query ⇄ `{ filters, order }`
+- [x] Fas 1, steg 2: `scripts/home-query.test.js` — tolkning, serialisering, pruning, rundtur
+- [x] Fas 2, steg 1: `getServerSideProps` i `src/pages/index.tsx` tolkar `context.query` → `initial`
+- [x] Fas 3, steg 1: `HomeContent` seedar tillståndet från `initial`
+- [x] Fas 3, steg 2: `HomeContent` skriver URL:en i händelsehanterarna
+- [x] Fas 3, steg 3: `generation`-key på `HomeContent` vid icke-shallow navigering
+- [x] Fas 3, steg 4: Manuell navigeringskontroll i webbläsare
+- [x] Fas 4, steg 1: `scripts/http-smoke.js` — assertioner på filtrerade URL:er
+- [x] Fas 4, steg 2: `CLAUDE.md` — rad om URL-konventionen
+- [x] Fas 5: `npm run precommit` och manuell verifieringschecklista
+
+## Pågående arbete
+
+Inget — implementationen följer planen.
+
+## Anteckningar
+
+Grenen skapades från `main` (5b530fb). `npm run precommit` är grönt: 220 `node:test`-tester
+och HTTP-smoken, som nu kontrollerar filtrerade URL:er mot förväntat grid räknat ur
+`data/parti/*/index.json`.
+
+Kontrollerna i webbläsare kördes mot `.release`-artefakten på port 3999, driven via
+chrome-devtools:
+
+- Valår, valtyp, län, kommun, sortering och sökterm skriver var sin URL i nyckelordningen
+  `valar, valtyp, lan, kommun, q, sortering`; bakåt från en partisida återställer alla sex.
+- Ett select-byte följt av ett partiklick i samma händelse överlever bakåtnavigeringen
+  (`valar=2022` fanns i historikposten), liksom sju tangenttryck följda av ett klick på
+  första träffen (`?q=moderat`).
+- Logotypen från `/?valar=2018&sortering=senaste` ger `/` med senaste året och förvald
+  sortering.
+- `#om-tjansten` överlever både en filterändring och "Rensa filter"; inga `_next/data`-anrop
+  vid filterändring; sidan hoppar inte till toppen.
+- Redigering mitt i söksträngen behåller fokus och markörläge, inga tecken tappas.
+- Direktlänkar: `?kommun=1280` härleder länet, `?valtyp=riksdag&lan=01` släpper länet,
+  `?kommun=1280&lan=01` släpper kommunen, `?valar=1900&valtyp=eu` faller tillbaka på
+  förvalen, `?valar=alla` ger 670 av 670.
+
+Safari-kontrollen av `history.replaceState`-gränsen (designbeslut 5) är inte körd — den
+kräver att Safari startas.

--- a/scripts/home-query.test.js
+++ b/scripts/home-query.test.js
@@ -44,6 +44,12 @@ test('unknown values fall back to the defaults', () => {
   );
 });
 
+test('an inherited property name is not an election type', () => {
+  for (const value of ['constructor', 'toString', '__proto__', 'hasOwnProperty']) {
+    assert.equal(stateFromQuery({ valtyp: value }, DATA).filters.valtyp, '', `${value} är ingen valtyp`);
+  }
+});
+
 test('known values pass through', () => {
   assert.deepEqual(
     stateFromQuery({ valar: '2018', valtyp: 'region', lan: '12', sortering: 'senaste' }, DATA),

--- a/scripts/home-query.test.js
+++ b/scripts/home-query.test.js
@@ -1,0 +1,127 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { defaultFilters, emptyFilters } = require('../src/components/home/filtering.ts');
+const { ALL_YEARS, queryFromState, stateFromQuery } = require('../src/components/home/query.ts');
+
+const DATA = {
+  valar: ['2018', '2022'],
+  lan: [
+    { kod: '01', namn: 'Stockholms län' },
+    { kod: '12', namn: 'Skåne län' }
+  ],
+  kommuner: [
+    { kod: '0114', namn: 'Upplands Väsby', lan: '01' },
+    { kod: '1280', namn: 'Malmö', lan: '12' }
+  ]
+};
+
+const YEARLESS = { valar: [], lan: DATA.lan, kommuner: DATA.kommuner };
+
+function filters (values) {
+  return { ...emptyFilters, valar: '2022', ...values };
+}
+
+function state (values, order = 'namn') {
+  return { filters: filters(values), order };
+}
+
+test('an empty query opens on the defaults', () => {
+  assert.deepEqual(stateFromQuery({}, DATA), { filters: defaultFilters(DATA.valar), order: 'namn' });
+});
+
+test('the year parameter names a year, every year or nothing', () => {
+  assert.equal(stateFromQuery({ valar: ALL_YEARS }, DATA).filters.valar, '');
+  assert.equal(stateFromQuery({ valar: '2018' }, DATA).filters.valar, '2018');
+  assert.equal(stateFromQuery({ valar: '1900' }, DATA).filters.valar, '2022', 'ett år datan saknar faller tillbaka');
+  assert.equal(stateFromQuery({ valar: '' }, DATA).filters.valar, '2022');
+});
+
+test('unknown values fall back to the defaults', () => {
+  assert.deepEqual(
+    stateFromQuery({ valtyp: 'eu', lan: '99', kommun: '9999', sortering: 'storlek' }, DATA),
+    { filters: defaultFilters(DATA.valar), order: 'namn' }
+  );
+});
+
+test('known values pass through', () => {
+  assert.deepEqual(
+    stateFromQuery({ valar: '2018', valtyp: 'region', lan: '12', sortering: 'senaste' }, DATA),
+    state({ valar: '2018', valtyp: 'region', lan: '12' }, 'senaste')
+  );
+});
+
+test('a municipality carries its county even when the link leaves it out', () => {
+  assert.deepEqual(stateFromQuery({ kommun: '1280' }, DATA).filters, filters({ lan: '12', kommun: '1280' }));
+  assert.deepEqual(
+    stateFromQuery({ kommun: '1280', lan: '99' }, DATA).filters,
+    filters({ lan: '12', kommun: '1280' }),
+    'ett ogiltigt län ersätts av kommunens'
+  );
+});
+
+test('pruning drops values the rest of the filters leave without meaning', () => {
+  assert.deepEqual(
+    stateFromQuery({ kommun: '1280', lan: '01' }, DATA).filters,
+    filters({ lan: '01' }),
+    'en kommun utanför det valda länet släpps'
+  );
+  assert.deepEqual(
+    stateFromQuery({ valtyp: 'riksdag', lan: '01' }, DATA).filters,
+    filters({ valtyp: 'riksdag' }),
+    'riksdagsvalet är rikstäckande och har inget län'
+  );
+});
+
+test('a repeated parameter takes its first value and unknown ones are ignored', () => {
+  assert.equal(stateFromQuery({ valar: ['2018', '2022'] }, DATA).filters.valar, '2018');
+  assert.deepEqual(stateFromQuery({ utm_source: 'x', sida: '3' }, DATA), {
+    filters: defaultFilters(DATA.valar),
+    order: 'namn'
+  });
+});
+
+test('the search term is kept as written', () => {
+  assert.equal(stateFromQuery({ q: '  nya  partiet ' }, DATA).filters.query, '  nya  partiet ');
+});
+
+test('the defaults serialise to no query at all', () => {
+  assert.deepEqual(queryFromState({ filters: defaultFilters(DATA.valar), order: 'namn' }, DATA.valar), {});
+  assert.deepEqual(queryFromState({ filters: emptyFilters, order: 'namn' }, YEARLESS.valar), {});
+});
+
+test('every year is an active choice only where the data has years', () => {
+  assert.deepEqual(queryFromState(state({ valar: '' }), DATA.valar), { valar: ALL_YEARS });
+  assert.deepEqual(queryFromState({ filters: emptyFilters, order: 'namn' }, YEARLESS.valar), {});
+});
+
+test('the sort order is written only when it differs from the default', () => {
+  assert.deepEqual(queryFromState(state({}, 'namn'), DATA.valar), {});
+  assert.deepEqual(queryFromState(state({}, 'kommuner'), DATA.valar), { sortering: 'kommuner' });
+});
+
+test('a search term of nothing but whitespace is left out', () => {
+  assert.deepEqual(queryFromState(state({ query: '   ' }), DATA.valar), {});
+  assert.deepEqual(queryFromState(state({ query: 'nya partiet' }), DATA.valar), { q: 'nya partiet' });
+});
+
+test('the keys come out in a fixed order', () => {
+  assert.deepEqual(
+    Object.keys(queryFromState(state({ valar: '', valtyp: 'kommun', lan: '12', kommun: '1280', query: 'p' }, 'kommuner'), DATA.valar)),
+    ['valar', 'valtyp', 'lan', 'kommun', 'q', 'sortering']
+  );
+});
+
+test('a canonical state survives the round trip', () => {
+  const canonical = [
+    { filters: defaultFilters(DATA.valar), order: 'namn' },
+    state({ valar: '' }, 'kommuner'),
+    state({ valar: '2018', valtyp: 'riksdag' }),
+    state({ valtyp: 'kommun', lan: '12', kommun: '1280' }, 'senaste'),
+    state({ lan: '01' }),
+    state({ query: 'nya partiet' })
+  ];
+  for (const original of canonical) {
+    assert.deepEqual(stateFromQuery(queryFromState(original, DATA.valar), DATA), original);
+  }
+});

--- a/scripts/http-smoke.js
+++ b/scripts/http-smoke.js
@@ -25,23 +25,60 @@ function comparePartyOrder (a, b) {
   return collator.compare(a.beteckning, b.beteckning) || collator.compare(a.filnamn, b.filnamn);
 }
 
-/**
- * The parties the start page opens on: the ones standing in the latest election
- * the data carries, which is the year the filters default to.
- */
-function standingParties (projectRoot, parties) {
+/** The election years the registry carries participation for, oldest first. */
+function electionYears (projectRoot) {
   const electionRoot = path.join(projectRoot, 'data', 'val');
-  const years = fs.readdirSync(electionRoot, { withFileTypes: true })
+  return fs.readdirSync(electionRoot, { withFileTypes: true })
     .filter(entry => entry.isDirectory() && /^\d{4}$/.test(entry.name))
     .map(entry => entry.name)
+    .filter(year => fs.existsSync(path.join(electionRoot, year, 'partideltagande', 'partier.json')))
     .toSorted();
-  const latest = years.findLast(year =>
-    fs.existsSync(path.join(electionRoot, year, 'partideltagande', 'partier.json')));
-  assert.ok(latest, 'ett valår med partideltagande hittades');
-  const participating = new Set(JSON.parse(
-    fs.readFileSync(path.join(electionRoot, latest, 'partideltagande', 'partier.json'), 'utf8')
-  ).map(party => party.uuid));
-  return { latest, standing: parties.filter(party => participating.has(party.uuid)) };
+}
+
+/** The parties standing in one election, which is what a chosen year narrows to. */
+function standingParties (projectRoot, parties, year) {
+  const participating = new Set(JSON.parse(fs.readFileSync(
+    path.join(projectRoot, 'data', 'val', year, 'partideltagande', 'partier.json'), 'utf8'
+  )).map(party => party.uuid));
+  return parties.filter(party => participating.has(party.uuid));
+}
+
+/**
+ * Every party's registered participation, read from the same files the site
+ * reads, so the expected result of a filtered URL can be worked out here.
+ */
+function participationByParty (projectRoot, parties) {
+  return new Map(parties.map(party => [party.filnamn, JSON.parse(fs.readFileSync(
+    path.join(projectRoot, 'data', 'parti', party.filnamn, 'index.json'), 'utf8'
+  )).deltagande ?? {}]));
+}
+
+/**
+ * The search comparison, written out here rather than imported, so the smoke
+ * test does not check the site against the very code it renders with.
+ */
+function normalise (value) {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function matchesQuery (party, query) {
+  const haystack = normalise(`${party.beteckning} ${party.forkortning ?? ''} ${party.omrade ?? ''}`);
+  return normalise(query).split(' ').every(term => haystack.includes(term));
+}
+
+/** The slugs the first page of the grid is expected to link to. */
+function expectedGrid (parties) {
+  return parties.slice(0, homePageSize).map(party => party.filnamn);
+}
+
+/** The "N av M" the results heading carries, whichever way React split the text. */
+function countPattern (matched, total) {
+  return new RegExp(`>${matched}(<!-- -->)? av (<!-- -->)?${total}</span>`);
 }
 
 /** Extracts the party links of the "Alla partier" grid in document order. */
@@ -87,8 +124,14 @@ async function main () {
   const current = parties.find(party => party.filnamn === 'miljopartiet-de-grona') ?? parties[0];
   const duplicate = parties.find(party => party.filnamn === 'kommunens-val-0503');
   const withoutParticipation = parties.find(party => party.filnamn === 'angfarjepartiet');
-  const { latest, standing } = standingParties(projectRoot, parties);
-  const expectedOrder = standing.toSorted(comparePartyOrder).slice(0, homePageSize).map(party => party.filnamn);
+  const years = electionYears(projectRoot);
+  assert.ok(years.length >= 2, 'minst två valår har partideltagande');
+  const latest = years.at(-1);
+  const earlier = years.at(-2);
+  const standing = standingParties(projectRoot, parties, latest);
+  const deltagande = participationByParty(projectRoot, parties);
+  const inNameOrder = parties.toSorted(comparePartyOrder);
+  const expectedOrder = expectedGrid(standing.toSorted(comparePartyOrder));
   const [first] = expectedOrder;
   const previous = parties.find(party => party.tidigare_filnamn?.length > 0);
   const cleanedSlug = parties.find(party =>
@@ -129,7 +172,7 @@ async function main () {
     assert.match(homeBody, /Alla partier/, 'partilistan har en rubrik');
     assert.match(
       homeBody,
-      new RegExp(`>${standing.length}(<!-- -->)? av (<!-- -->)?${parties.length}</span>`),
+      countPattern(standing.length, parties.length),
       'rubriken räknar partierna i det förvalda valåret mot hela registret'
     );
     assert.match(homeBody, new RegExp(`<option value="${latest}" selected="">${latest}</option>`), 'valårsfiltret står på det senaste valet');
@@ -152,6 +195,53 @@ async function main () {
 
     const riksdagCards = homeBody.split('party-card--large').length - 1;
     assert.equal(riksdagCards, chamber.partier.length, 'riksdagspartierna renderas som stora partikort');
+
+    const parliamentary = inNameOrder.filter(party => deltagande.get(party.filnamn)[earlier]?.riksdag);
+    assert.ok(parliamentary.length > 0, `partier anmälda till riksdagsvalet ${earlier} hittades`);
+    const filtered = await fetch(`${baseUrl}/?valar=${earlier}&valtyp=riksdag`);
+    assert.equal(filtered.status, 200);
+    const filteredBody = await filtered.text();
+    assert.match(filteredBody, new RegExp(`<option value="${earlier}" selected="">${earlier}</option>`), 'valårsfiltret står på året i länken');
+    assert.match(filteredBody, /aria-pressed="true"[^>]*>Riksdagsval</, 'riksdagsvalet är den tryckta chipen');
+    assert.match(filteredBody, /<link rel="canonical" href="https:\/\/www\.partidata\.se\/"[^>]*>/, 'en filtrerad vy är samma kanoniska sida');
+    assert.match(filteredBody, countPattern(parliamentary.length, parties.length), 'rubriken räknar de filtrerade partierna');
+    assert.deepEqual(partyGridLinks(filteredBody), expectedGrid(parliamentary), 'gridet visar partierna länken filtrerar fram');
+
+    // The ranking is the widest municipal ballot that year, and the sort is
+    // stable, so parties on equally many keep Swedish name order.
+    const found = inNameOrder
+      .filter(party => matchesQuery(party, 'parti'))
+      .filter(party => {
+        const facet = deltagande.get(party.filnamn)[earlier];
+        return Boolean(facet) && (facet.riksdag || facet.region.length > 0 || facet.kommun.length > 0);
+      })
+      .toSorted((a, b) =>
+        deltagande.get(b.filnamn)[earlier].kommun.length - deltagande.get(a.filnamn)[earlier].kommun.length);
+    assert.ok(found.length > homePageSize, 'sökningen ger fler träffar än en sida');
+    const searched = await fetch(`${baseUrl}/?valar=${earlier}&sortering=kommuner&q=parti`);
+    assert.equal(searched.status, 200);
+    const searchedBody = await searched.text();
+    assert.match(searchedBody, /<option value="kommuner" selected="">Sorterat <!-- -->Flest kommuner<\/option>/, 'sorteringen står på länkens ordning');
+    assert.match(searchedBody, /<input[^>]*type="search"[^>]*value="parti"/, 'sökfältet står på länkens sökterm');
+    assert.match(searchedBody, countPattern(found.length, parties.length), 'rubriken räknar sökträffarna');
+    assert.deepEqual(partyGridLinks(searchedBody), expectedGrid(found), 'gridet är rangordnat på antal kommuner');
+
+    const everyYear = await fetch(`${baseUrl}/?valar=alla`);
+    assert.equal(everyYear.status, 200);
+    const everyYearBody = await everyYear.text();
+    assert.match(everyYearBody, /<option value="" selected="">Alla valår<\/option>/, 'valårsfiltret står på alla valår');
+    assert.match(everyYearBody, countPattern(parties.length, parties.length), 'utan valår och övriga filter matchar hela registret');
+    assert.deepEqual(partyGridLinks(everyYearBody), expectedGrid(inNameOrder), 'gridet är hela registret i bokstavsordning');
+
+    const invalid = await fetch(`${baseUrl}/?valar=1900&valtyp=eu`);
+    assert.equal(invalid.status, 200);
+    const invalidBody = await invalid.text();
+    assert.match(invalidBody, new RegExp(`<option value="${latest}" selected="">${latest}</option>`), 'ett valår datan saknar faller tillbaka på förvalet');
+    assert.doesNotMatch(invalidBody, /aria-pressed="true"/, 'en okänd valtyp lämnar chip-gruppen otryckt');
+
+    const canonicalYear = await fetch(`${baseUrl}/?valar=${latest}`);
+    assert.equal(canonicalYear.status, 200);
+    assert.deepEqual(partyGridLinks(await canonicalYear.text()), gridLinks, 'förvalet i länken ger samma vy som startsidan');
 
     const profile = await fetch(`${baseUrl}/parti/${current.filnamn}/`);
     assert.equal(profile.status, 200);

--- a/src/components/home/HomeContent.tsx
+++ b/src/components/home/HomeContent.tsx
@@ -1,9 +1,12 @@
-import { useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { HomeData, HomeParty } from 'src/server/party-data';
 import type { ElectionKind, HomeFilters } from './filtering';
 import { PAGE_SIZE, defaultFilters, filterParties, pruneFilters } from './filtering';
+import type { HomeState } from './query';
+import { queryFromState } from './query';
 import type { SortOrder } from './sorting';
-import { defaultOrder, sortParties } from './sorting';
+import { sortParties } from './sorting';
 import PartyFilters from './PartyFilters';
 import PartyResults from './PartyResults';
 import RiksdagSection from './RiksdagSection';
@@ -21,14 +24,21 @@ function availableKinds (parties: HomeParty[]): ElectionKind[] {
   return (['riksdag', 'region', 'kommun'] as const).filter(kind => kinds.has(kind));
 }
 
+export type HomeContentProps = HomeData & { initial: HomeState };
+
 /**
- * Owns the filter state the controls write and the result grid reads.
+ * Owns the filter state the controls write and the result grid reads, and keeps
+ * the query string in step with it so the view is linkable and survives the
+ * back button.
  */
-function HomeContent ({ parties, valar, lan, kommuner, riksdag, outsideParliament }: HomeData) {
-  const initialFilters = useMemo(() => defaultFilters(valar), [valar]);
-  const [filters, setFilters] = useState<HomeFilters>(initialFilters);
-  const [order, setOrder] = useState<SortOrder>(defaultOrder);
+function HomeContent ({ parties, valar, lan, kommuner, riksdag, outsideParliament, initial }: HomeContentProps) {
+  const router = useRouter();
+  const defaults = useMemo(() => defaultFilters(valar), [valar]);
+  const [filters, setFilters] = useState<HomeFilters>(initial.filters);
+  const [order, setOrder] = useState<SortOrder>(initial.order);
   const [visible, setVisible] = useState(PAGE_SIZE);
+  const requested = useRef<HomeState>(initial);
+  const retry = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const kinds = useMemo(() => availableKinds(parties), [parties]);
   const matches = useMemo(
@@ -36,12 +46,43 @@ function HomeContent ({ parties, valar, lan, kommuner, riksdag, outsideParliamen
     [parties, filters, order],
   );
 
+  useEffect(() => () => clearTimeout(retry.current), []);
+
+  // Shallow so the page data is not fetched again for a change the client
+  // already holds, and without scrolling so the list stays where it is read.
+  // The hash comes from the address bar because the router does not track the
+  // fragment links the header points at.
+  function write (state: HomeState) {
+    requested.current = state;
+    const query = queryFromState(state, valar);
+    if (new URLSearchParams(query).toString() === new URLSearchParams(window.location.search).toString()) return;
+
+    router
+      .replace({ pathname: '/', query, hash: window.location.hash || undefined }, undefined, { shallow: true, scroll: false })
+      .catch((error: { cancelled?: boolean }) => {
+        if (error?.cancelled) return;
+        console.error(error);
+        // Browsers cap how many times history.replaceState may be called in a
+        // window of time and throw past it, so the latest state is written
+        // again once the cap has moved on.
+        clearTimeout(retry.current);
+        retry.current = setTimeout(() => write(requested.current), 1000);
+      });
+  }
+
   // The reveal count belongs to the result set it was reached in, so every
   // change of the filters starts over at the first page. Clearing the filters
   // goes through the same path, and resets the count with them.
   function update (patch: Partial<HomeFilters>) {
-    setFilters(current => pruneFilters({ ...current, ...patch }));
+    const next = pruneFilters({ ...filters, ...patch });
+    setFilters(next);
     setVisible(PAGE_SIZE);
+    write({ filters: next, order });
+  }
+
+  function changeOrder (next: SortOrder) {
+    setOrder(next);
+    write({ filters, order: next });
   }
 
   return (
@@ -56,7 +97,7 @@ function HomeContent ({ parties, valar, lan, kommuner, riksdag, outsideParliamen
         kommuner={kommuner}
         kinds={kinds}
         onChange={update}
-        onReset={() => update(initialFilters)}
+        onReset={() => update(defaults)}
       />
 
       <PartyResults
@@ -66,9 +107,9 @@ function HomeContent ({ parties, valar, lan, kommuner, riksdag, outsideParliamen
         query={filters.query}
         valar={filters.valar}
         order={order}
-        onOrderChange={setOrder}
+        onOrderChange={changeOrder}
         onShowMore={() => setVisible(current => current + PAGE_SIZE)}
-        onReset={() => update(initialFilters)}
+        onReset={() => update(defaults)}
       />
     </>
   );

--- a/src/components/home/query.ts
+++ b/src/components/home/query.ts
@@ -1,0 +1,82 @@
+import type { HomeData } from 'src/server/party-data';
+import type { ElectionKind, HomeFilters } from './filtering.ts';
+import { defaultFilters, electionKindLabels, pruneFilters } from './filtering.ts';
+import type { SortOrder } from './sorting.ts';
+import { defaultOrder, isSortOrder } from './sorting.ts';
+
+export interface HomeState {
+  filters: HomeFilters;
+  order: SortOrder;
+}
+
+export type HomeQuery = Record<string, string | string[] | undefined>;
+
+/** The value the year parameter takes for "every election year". */
+export const ALL_YEARS = 'alla';
+
+export type HomeQueryData = Pick<HomeData, 'valar' | 'lan' | 'kommuner'>;
+
+/** A repeated parameter names one value, so the first one is the answer. */
+function single (value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return value[0] ?? '';
+  return value ?? '';
+}
+
+function readYear (value: string, valar: string[], fallback: string): string {
+  if (value === ALL_YEARS) return '';
+  return valar.includes(value) ? value : fallback;
+}
+
+function readKind (value: string): HomeFilters['valtyp'] {
+  return value in electionKindLabels ? value as ElectionKind : '';
+}
+
+/**
+ * Reads a link back into the state the controls hold. Every value is checked
+ * against the data the page carries, so a year, county or municipality the
+ * registry does not know falls back to the default rather than reaching
+ * `filterParties`.
+ */
+export function stateFromQuery (query: HomeQuery, data: HomeQueryData): HomeState {
+  const defaults = defaultFilters(data.valar);
+  const kommunKod = single(query.kommun);
+  const kommun = data.kommuner.find(entry => entry.kod === kommunKod);
+  const lanKod = single(query.lan);
+  const lan = data.lan.some(entry => entry.kod === lanKod) ? lanKod : '';
+  const order = single(query.sortering);
+
+  return {
+    // A municipality names its county, so a link that carries only the
+    // municipality opens with the county selector on it as well.
+    filters: pruneFilters({
+      query: single(query.q),
+      valar: readYear(single(query.valar), data.valar, defaults.valar),
+      valtyp: readKind(single(query.valtyp)),
+      lan: kommun && !lan ? kommun.lan : lan,
+      kommun: kommun ? kommun.kod : '',
+    }),
+    order: isSortOrder(order) ? order : defaultOrder,
+  };
+}
+
+/**
+ * Writes the state as the shortest link that reproduces it: everything equal to
+ * what the page opens on is left out, so the unfiltered start page stays `/`.
+ * The keys come out in a fixed order, so the same view always has the same URL.
+ */
+export function queryFromState (state: HomeState, valar: string[]): Record<string, string> {
+  const defaults = defaultFilters(valar);
+  const { filters, order } = state;
+  const query: Record<string, string> = {};
+
+  // No year is the default when the data carries none, and an active choice
+  // when it carries some — only then does it need a value of its own.
+  if (filters.valar !== defaults.valar) query.valar = filters.valar || ALL_YEARS;
+  if (filters.valtyp) query.valtyp = filters.valtyp;
+  if (filters.lan) query.lan = filters.lan;
+  if (filters.kommun) query.kommun = filters.kommun;
+  if (filters.query.trim()) query.q = filters.query;
+  if (order !== defaultOrder) query.sortering = order;
+
+  return query;
+}

--- a/src/components/home/query.ts
+++ b/src/components/home/query.ts
@@ -28,7 +28,7 @@ function readYear (value: string, valar: string[], fallback: string): string {
 }
 
 function readKind (value: string): HomeFilters['valtyp'] {
-  return value in electionKindLabels ? value as ElectionKind : '';
+  return Object.hasOwn(electionKindLabels, value) ? value as ElectionKind : '';
 }
 
 /**

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,34 @@
 import type { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 
 import Footer from 'src/components/Footer';
 import Header from 'src/components/Header';
 import HomeContent from 'src/components/home/HomeContent';
+import type { HomeState } from 'src/components/home/query';
+import { stateFromQuery } from 'src/components/home/query';
 import { partyData } from 'src/server/party-data';
 import type { HomeData } from 'src/server/party-data';
 
-const HomePage: NextPage<HomeData> = props => {
+type HomePageProps = HomeData & { initial: HomeState };
+
+const HomePage: NextPage<HomePageProps> = props => {
+  const router = useRouter();
+  // The start page writes its own URL shallowly, which leaves the mounted
+  // component in place. A route change Next made itself brings new props that
+  // the existing state would otherwise outlive, so the counter remounts on
+  // those and only those.
+  const [generation, setGeneration] = useState(0);
+
+  useEffect(() => {
+    function onRouteChange (_url: string, { shallow }: { shallow: boolean }) {
+      if (!shallow) setGeneration(current => current + 1);
+    }
+    router.events.on('routeChangeComplete', onRouteChange);
+    return () => router.events.off('routeChangeComplete', onRouteChange);
+  }, [router.events]);
+
   return (
     <div className="page-shell">
       <Head>
@@ -28,7 +49,7 @@ const HomePage: NextPage<HomeData> = props => {
           </p>
         </div>
 
-        <HomeContent {...props} />
+        <HomeContent key={generation} {...props} />
       </main>
 
       <Footer />
@@ -38,6 +59,7 @@ const HomePage: NextPage<HomeData> = props => {
 
 export default HomePage;
 
-export const getServerSideProps: GetServerSideProps<HomeData> = async () => {
-  return { props: await partyData.readHomeData() };
+export const getServerSideProps: GetServerSideProps<HomePageProps> = async context => {
+  const data = await partyData.readHomeData();
+  return { props: { ...data, initial: stateFromQuery(context.query, data) } };
 };


### PR DESCRIPTION
The start page kept its filters, search term and sort order in component state only, so opening a party and going back reset the list to the defaults. The filters now live in the query string (`valar`, `valtyp`, `lan`, `kommun`, `q`, `sortering`), with the defaults left out so the unfiltered page stays `/`; `valar=alla` carries "all years", since the default is the latest year.

A pure `src/components/home/query.ts` translates between the query and the state in both directions. `getServerSideProps` parses `context.query` and seeds `HomeContent`, so a shared filtered URL renders the filtered list server-side; `HomeContent` writes the URL from each change with a shallow `router.replace`, so back navigation restores the list through ordinary history. Unknown or inconsistent values (a municipality outside the given county, an election type that does not apply to the year) fall back to the defaults rather than erroring.

Tests: `scripts/home-query.test.js` covers the query ⇄ state translation, and `scripts/http-smoke.js` asserts that filtered URLs render the expected grid. `npm run precommit` is green. Browser checks were done manually against the release artifact in Chrome; Safari was not checked, and the 1-second retry around its `history.replaceState` rate cap is untested.

Out of scope, as the plan sets out: restoring the "Visa fler" reveal count and the scroll position, which belong together and need scroll restoration to be useful.

Closes #86
