### PR TITLE
Present the election type and year filters as segmented single-choice controls

### DIFF
--- a/agent-docs/issue/91-segmented-single-choice-filters/index.md
+++ b/agent-docs/issue/91-segmented-single-choice-filters/index.md
@@ -1,0 +1,33 @@
+# Issue #91: Present the election type and year filters as segmented single-choice controls
+
+**Baserad på:** main
+
+## Sammanfattning
+
+Startsidans filterrad visar valtypen som tre lösa `aria-pressed`-chips där "alla" väljs genom att klicka av den valda chipen, och valåret som en dropdown. Båda blir en gemensam segmenterad envalsrad med ett explicit första segment för "alla" ("Alla" respektive "Alla valår"), byggd av native `<input type="radio">` i ett `<fieldset>` med visuellt dold `<legend>`, så att exakt ett segment alltid är valt och tabbstopp, piltangenter och hopp över låsta segment följer med elementen. Låsningen (län låser riksdagsval, kommun låser riksdags- och regionval) flyttar till en ren modul `segments.ts` med `node:test`, som också garanterar att den valda typen alltid har ett segment; låstexten behålls som `title` för hover och når hjälpmedel via `aria-describedby`. `toggleKind` tas bort, chip-stilarna i `_home.scss` ersätts av `.home-segments`/`.home-segment`, och smoke-testets sju markup-bundna assertions skrivs om till radio-semantik med en ny assertion för låsningen. Stegen är ordnade så att det nya läggs till och kopplas in innan det gamla tas bort. Tillstånd, URL, `query.ts`, `HomeContent.tsx`, län- och kommunväljarna och riksdagssektionen (#90) ändras inte. Piltangenter i en radio-grupp väljer per tryck och skriver URL:en varje gång, så verifieringen kör #89:s Safari-fall med nedhållen piltangent och antecknar utfallet där.
+
+## Triageringsstatus
+
+| Fält | Värde |
+|------|-------|
+| **Redo att arbeta** | Ja |
+| **Risk** | Låg |
+| **Säker för junior** | Ja |
+
+## Plangranskning
+
+**Status:** Granskad
+**Granskad:** 2026-08-30
+**Feedback:** Två granskningsrundor (codex). Första rundan: borttagningarna av `toggleKind` och chip-stilarna låg före inkopplingen och bröt bygget mellan faserna (nu fas 4, efter fas 3); #89:s retry beskrevs som säkrare än den är verifierad (nu formulerad som förväntat utfall plus ett obligatoriskt Safari-test); låstexten nådde bara mus (nu `aria-describedby` till ett dolt spann); "exakt ett valt" antogs i stället för att garanteras och `PartyFilters` behövde ett typpåstående (nu generisk `SegmentedControl<T>` och `kindSegments` som alltid tar med den valda typen); filantalet var 7, inte 8. Andra rundan pekade på att kantfallet fortfarande stred mot acceptanskriteriet, att "inom en sekund" överdrev retryn och att `title` som beskrivning är opålitlig — alla tre åtgärdade enligt ovan.
+
+## Relaterade filer
+
+- [plan.md](plan.md) — Fullständig implementationsplan
+- [progress.md](progress.md) — Implementationsframsteg
+- [research.md](research.md) — Forskningsresultat (om finns)
+
+## Relaterade issues
+
+- #90 — Två valårskontroller på startsidan ser ut som ett val; lämnas orört här, men den accessibla namngivningen behövs fortfarande
+- #86 — (stängt) Filtren i URL:en; grunden för att kontrollen kan bytas utan att tillstånd eller länkar ändras
+- #89 — `replaceState`-retryn som snabba piltangentsbyten kan slå i

--- a/agent-docs/issue/91-segmented-single-choice-filters/plan.md
+++ b/agent-docs/issue/91-segmented-single-choice-filters/plan.md
@@ -1,0 +1,244 @@
+# Plan: Issue #91 — Present the election type and year filters as segmented single-choice controls
+
+## Mål
+
+Startsidans filterrad har två envalskontroller som inte ser ut som enval: valtypen är tre lösa chips (`aria-pressed`-knappar i `src/components/home/PartyFilters.tsx`) där "alla valtyper" väljs genom att klicka av den valda chipen utan att något visar det läget, och valåret är en dropdown. Båda ska bli samma sorts kontroll: en segmenterad envalsrad med ett explicit första segment för "alla", så att exakt ett segment alltid är valt och läget syns. Segmenten byggs av native `<input type="radio">` i ett `<fieldset>` med `<legend>`, så att tabbstopp, piltangenter och semantik följer med elementen. Tillstånd, URL, `query.ts` och dess tester ändras inte; län och kommun förblir dropdowns.
+
+## Triagering
+
+> Beslutsunderlag för detta issue.
+
+| Fält | Värde |
+|------|-------|
+| **Blockeras av** | Inget |
+| **Blockerar** | Inget |
+| **Relaterade issues** | #90 (två valårskontroller ser ut som en), #86 (stängt; införde URL-tillståndet kontrollerna skriver), #89 (öppet; `replaceState`-retryn som snabba piltangentsbyten kan slå i) |
+| **Omfattning** | 8 filer i `src/components/home/`, `src/styles/`, `scripts/` |
+| **Risk** | Låg |
+| **Komplexitet** | Låg |
+| **Säker för junior** | Ja |
+| **Konfliktrisk** | Låg (ingen annan öppen plan rör `PartyFilters.tsx`/`_home.scss`; #90 saknar plan men kommer att röra `RiksdagSection.tsx` och möjligen `home-select`-stilarna i `_home.scss`) |
+
+### Triagemässiga noteringar
+
+- Issuet är öppet utan etiketter, ansvarig, milstolpe eller kommentarer, och har inga projektposter (`projectItems.totalCount: 0` via GraphQL 2026-08-30). Inga blockerare nämns i texten.
+- #86 är mergat (`77720ee`), så `valtyp: ''`/`valar: ''` i tillståndet och `valtyp`/`valar`/`valar=alla` i URL:en är den etablerade grunden. Den här planen rör inte `src/components/home/query.ts`, `scripts/home-query.test.js` eller `HomeContent.tsx`.
+- #89 är öppet: `write()` i `HomeContent.tsx` har en retry för Safaris tak på 100 `replaceState`-anrop per 30 sekunder, och den vägen har aldrig körts i Safari. Piltangenter i en radio-grupp väljer vid varje tryck, så en nedhållen piltangent ger ändringar tätare än klick. Det gör inte #89 till blockerare — felläget är ett konsolfel och en fördröjd URL-skrivning, inte förlorat tillstånd — men verifieringen här ska köra just det fallet i Safari (fas 6), och utfallet är värt att anteckna i #89.
+- #90 (valårsväljaren i riksdagssektionen) lämnas orörd här. Efter den här ändringen är filterradens valår en segmentrad och sektionens väljare fortfarande en dropdown, så de ser inte längre likadana ut — men båda heter fortfarande "Valår" för skärmläsare (filterradens `<legend>` respektive sektionens `aria-label`), så #90:s namngivning behövs fortfarande. Ordningen mellan #90 och #91 spelar ingen roll; rör de samma rader i `_home.scss` är det en trivial rebase.
+- Issuet säger att `scripts/http-smoke.js` "still passes with the same expectations". Tre av dess assertions är bundna till chip-markupen (`aria-pressed`, rad 187, 205 och 240) och fyra till valårets `<option ... selected="">` (rad 178, 204, 232 och 239); de måste skrivas om till radio-semantik. Förväntningarna på *vilken vy varje länk ger* (rubrikräkning, gridets innehåll och ordning) står kvar oförändrade — det är så planen läser "same expectations" (se designbeslut 7).
+
+## Angreppssätt
+
+I dag ligger valtypen i `PartyFilters.tsx` rad 92–112 som en `role="group"` med tre `<button aria-pressed>`; `toggleKind` i `summary.ts` gör att ett klick på den valda chipen nollställer typen. Valåret på rad 43–55 är en `<select>` med `<option value="">Alla valår</option>` följt av datans år. Låsningen — riksdagsvalet gäller inte ett valt län, region- och riksdagsval gäller inte en vald kommun — räknas inline på rad 96 och blir `disabled` plus en `title`.
+
+Planen ersätter båda med en gemensam komponent, `SegmentedControl`, som renderar
+
+```html
+<fieldset class="home-segments">
+  <legend class="sr-only">Valtyp</legend>
+  <label class="home-segment" title="…">
+    <input class="sr-only" type="radio" name="«id»" value="" checked onChange … />
+    <span class="home-segment__text">Alla</span>
+  </label>
+  …
+  <label class="home-segment" title="Riksdagsval gäller inte …">
+    <input class="sr-only" type="radio" name="«id»" value="riksdag" disabled aria-describedby="«id»-riksdag-note" … />
+    <span class="home-segment__text">Riksdagsval</span>
+  </label>
+  <span id="«id»-riksdag-note" class="sr-only">Riksdagsval gäller inte …</span>
+</fieldset>
+```
+
+Radioknapparna är styrda (`checked={value === segment.value}`) så att SSR och klient ger samma markup, och `onChange` skickar segmentets värde uppåt; `PartyFilters` mappar det till `onChange({ valtyp })` respektive `onChange({ valar })`, samma `patch`-form som i dag. Komponenten är generisk över värdetypen (`SegmentedControl<T extends string>`), så valtypens grupp får `T = HomeFilters['valtyp']` utan typpåstående. Eftersom "alla" är ett eget segment med värdet `''` finns alltid ett valt segment så länge `value` förekommer bland segmenten, och `toggleKind` har inget kvar att göra och tas bort tillsammans med sitt test.
+
+Invarianten "exakt ett valt" vilar på att `value` finns i listan, och segmentbyggarna garanterar det. För valår håller det av sig självt: `stateFromQuery` släpper bara igenom år ur `data.valar`, som är samma lista som bygger segmenten. För valtyp bygger listan på `availableKinds(parties)` i `HomeContent.tsx` medan `stateFromQuery` godtar alla tre typerna oavsett data, så med ett delregister utan t.ex. regionval kan `?valtyp=region` ge ett tillstånd som `kinds` saknar. Därför tar `kindSegments` även emot `filters.valtyp` och går igenom den kanoniska ordningen `riksdag`, `region`, `kommun` och tar med varje typ som finns i `kinds` *eller* är den valda: det valda segmentet finns alltid, i rätt position, och sidan visar ärligt att "Regionval" är valt med en tom lista. Med det committade registret finns alla tre typerna, så listan är identisk med dagens chips; kantfallet testas i fas 1. `query.ts` lämnas orörd, som issuet ber om.
+
+Native radio ger det issuet ber om utan egen tangentbordskod: gruppen är ett tabbstopp som landar på det valda segmentet, piltangenter flyttar valet inom gruppen, och `disabled`-radios hoppas över. En sak följer av det och ska vara känd: ett piltangentstryck *väljer* (det är radio-beteende, inte bara fokusflytt), så varje tryck kör `update()` i `HomeContent` och skriver URL:en — det är den serie av täta `replaceState`-anrop som #89 gäller. `write()` gör om skrivningen en sekund efter varje misslyckande och ger sig inte förrän den lyckas, men Safaris tak är 100 anrop per 30 sekunder, så under en lång nedhållen piltangent kan URL:en ligga efter tills fönstret rullat vidare — upp till ~30 sekunder efter sista ändringen. Verifieringen i fas 6 kör fallet i Safari och antecknar utfallet i #89.
+
+Låsningen flyttar från JSX-raden till en ren modul, `segments.ts`, som bygger segmentlistorna (`{ value, label, disabled?, title? }`) för valtyp och valår ur `filters`, `kinds` och `valar`. Modulen testas med `node:test` på samma sätt som `summary.ts` och `query.ts` (relativa importer med `.ts`-ändelse, inga runtime-importer via `src/...`), så regeln "riksdagsval låses av län, region- och riksdagsval låses av kommun" får en test i stället för att bara läsas ur markupen. Det är lite mer struktur än vad tre rader inline kräver; motiveringen är acceptanskriteriet om låsningen (designbeslut 4).
+
+Låstexten når två vägar: som `title` på `<label>` för hovern (som knappen i dag), och som accessible description på radion via `aria-describedby` till en visuellt dold `<span>` med samma text, placerad *efter* `<label>` i fältgruppen — inte inuti, för då blir texten del av segmentets namn. En skärmläsare som läser ett låst segment i browse-läge får då både "nedtonad" och *varför*. Piltangenter hoppar över låsta radios, så den vägen nås texten inte — det är samma begränsning som dagens `disabled` knappar har (designbeslut 10).
+
+Det visuella: segmenten ligger kant i kant i en pillformad rad (yttre hörn `999px`, inre hörn raka, `margin-left: -1.5px` så kanterna sammanfaller), valt segment i navy med papper-text som `.home-chip--on` i dag, låst segment med `opacity: 0.45` och `cursor: not-allowed` som `.home-chip:disabled`. Radion döljs med Tailwinds `sr-only` (absolut positionerad, klippt, fortfarande fokuserbar — `display: none` skulle ta den ur tabbordningen), och fokusringen ritas på hela segmentet med `.home-segment:has(> input:focus-visible)`, samma gula 3px-ring som övriga kontroller. `fieldset` behöver `min-inline-size: 0`, `border: 0`, `padding: 0`, `margin: 0` (Tailwinds preflight nollar margin/padding men inte `min-inline-size`), och `flex-wrap: wrap` så raden bryter på smala skärmar som chipsen gör i dag. Vid radbrytning får den brutna raden raka hörn där den delas — det accepteras (designbeslut 6) men ska tittas på i verifieringen.
+
+Stegen är ordnade så att bygget är grönt efter varje fas: nytt läggs till först (fas 1–2), filterraden byts (fas 3), och först därefter tas det gamla bort (fas 4).
+
+## Steg
+
+### Fas 1: Segmentmodellen med tester
+
+1. Skapa `src/components/home/segments.ts`
+   - `export interface Segment<T extends string = string> { value: T; label: string; disabled?: boolean; title?: string }`
+   - `export const ALL_KINDS_LABEL = 'Alla'` och `export const ALL_YEARS_LABEL = 'Alla valår'`
+   - `export function kindLocked (kind: ElectionKind, filters: Pick<HomeFilters, 'lan' | 'kommun'>): boolean` — samma regel som `PartyFilters.tsx` rad 96 i dag: `kind === 'riksdag' && Boolean(filters.lan)` eller `kind !== 'kommun' && Boolean(filters.kommun)`
+   - `export const lockedTitle = (kind: ElectionKind) => \`${electionKindLabels[kind]} gäller inte ett valt område — välj Hela landet och Alla kommuner först\`` — texten flyttas oförändrad från `PartyFilters.tsx` rad 104
+   - `export function kindSegments (kinds: ElectionKind[], filters: Pick<HomeFilters, 'valtyp' | 'lan' | 'kommun'>): Segment<HomeFilters['valtyp']>[]` — `{ value: '', label: 'Alla' }` först, sedan, i den kanoniska ordningen `riksdag`, `region`, `kommun`, ett segment för varje typ som finns i `kinds` eller är `filters.valtyp`, med `label: electionKindLabels[kind]`, `disabled: kindLocked(...)` och `title` bara när låst. Den valda typen är därmed alltid med (invarianten "exakt ett valt")
+   - `export function yearSegments (valar: string[]): Segment[]` — `{ value: '', label: 'Alla valår' }` först, sedan åren i den ordning datan ger dem (stigande, som `<option>`-listan i dag)
+   - Importer: `import type { ElectionKind, HomeFilters } from './filtering.ts'` och `import { electionKindLabels } from './filtering.ts'` — `.ts`-ändelse som i `query.ts`, så modulen går att `require` från `node:test` under Node 24
+2. Skapa `scripts/home-segments.test.js` (mönster: `scripts/home-summary.test.js`)
+   - "alla" är alltid första segmentet, aldrig låst, med värdet `''`
+   - inget låst utan område; riksdagsval låst av `lan`; riksdagsval och regionval låsta av `kommun`; kommunval aldrig låst
+   - `title` finns exakt på de låsta segmenten och nämner valtypens namn
+   - `kindSegments(['riksdag'], { valtyp: '', … })` ger bara "Alla" och "Riksdagsval" — listan följer `kinds`, inte alla tre typerna
+   - `kindSegments(['riksdag'], { valtyp: 'region', … })` ger "Alla", "Riksdagsval", "Regionval" — den valda typen finns alltid med, i kanonisk position (delregister-kantfallet i Angreppssätt)
+   - `kindSegments(['riksdag', 'region', 'kommun'], …)` ger aldrig dubbletter
+   - `yearSegments(['2018', '2022', '2026'])` ger fyra segment i ordningen "Alla valår", 2018, 2022, 2026; `yearSegments([])` ger bara "Alla valår" (gruppen visas ändå inte när `valar` är tom, se fas 3)
+
+### Fas 2: Komponenten och de nya stilarna
+
+3. Skapa `src/components/home/SegmentedControl.tsx`
+   - `function SegmentedControl<T extends string> ({ legend, value, segments, onChange }: { legend: string; value: T; segments: Segment<T>[]; onChange: (value: T) => void })`
+   - `const name = useId()` som `name` på alla radios i gruppen, så två grupper på sidan aldrig delar radio-grupp
+   - Markup enligt Angreppssätt: `<fieldset className="home-segments">`, `<legend className="sr-only">{legend}</legend>`, ett `<label className="home-segment" title={segment.title}>` per segment med `<input className="sr-only" type="radio" name={name} value={segment.value} checked={value === segment.value} disabled={segment.disabled} aria-describedby={noteId} onChange={() => onChange(segment.value)} />` följt av `<span className="home-segment__text">{segment.label}</span>`; när `segment.title` finns renderas dessutom `<span id={noteId} className="sr-only">{segment.title}</span>` som syskon *efter* `<label>` (inte inuti — då blir texten del av namnet), där `noteId = \`${name}-${segment.value || 'alla'}-note\`` och `undefined` annars, så varken `aria-describedby` eller spannet finns för olåsta segment
+   - Skriv attributen i just den ordningen (`type`, `name`, `value`, `checked`, `disabled`, `aria-describedby`) — SSR-markupen följer JSX-ordningen, och smoke-testet i fas 5 matchar med `[^>]*` mellan attributen så ordningen inte är bärande, men den ska vara stabil
+   - `key={segment.value}` på ett `<Fragment>` runt `<label>` och det eventuella spannet; `''` är ett giltigt och unikt värde i båda grupperna
+   - `title` på `<label>` är hovern; `undefined` när segmentet inte är låst, så attributet inte renderas alls
+   - Spannen påverkar inte `:first-of-type`/`:last-of-type` på `.home-segment`, som räknar `label`-element
+4. Lägg till segmentstilarna i `src/styles/_home.scss` (chip-stilarna står kvar tills fas 4)
+   - `.home-segments { display: flex; flex-wrap: wrap; min-inline-size: 0; padding: 0; border: 0; margin: 0; }`
+   - `.home-segment { position: relative; display: inline-flex; align-items: center; padding: 0.6875rem 1.25rem; border: 1.5px solid var(--partidata-chip-off-line); margin-left: -1.5px; background: var(--partidata-card); color: var(--partidata-ink); cursor: pointer; font-size: 1rem; }` (samma mått som `.home-chip`)
+   - `.home-segment:first-of-type { margin-left: 0; border-radius: 999px 0 0 999px; }` och `.home-segment:last-of-type { border-radius: 0 999px 999px 0; }` — `<legend>` är inte en `label`, så `:first-of-type` träffar första segmentet
+   - `.home-segment:hover { border-color: var(--partidata-navy); color: var(--partidata-navy); z-index: 1; }`
+   - `.home-segment:has(> input:checked) { border-color: var(--partidata-navy); background: var(--partidata-navy); color: var(--partidata-paper); z-index: 1; }`
+   - `.home-segment:has(> input:disabled) { cursor: not-allowed; opacity: 0.45; }` och `.home-segment:has(> input:disabled):hover { border-color: var(--partidata-chip-off-line); color: var(--partidata-ink); z-index: auto; }`
+   - `.home-segment:has(> input:focus-visible) { outline: 3px solid var(--partidata-yellow); outline-offset: 3px; z-index: 2; }`
+   - Den globala `input:focus-visible`-regeln i `app.scss` rad 125–128 träffar den dolda radion; det syns inte (den är klippt till 1px) och behöver ingen åtgärd
+   - `.home-search__filters` (rad 44–50) behåller `gap: 0.75rem` och `flex-wrap: wrap`; segmentgrupperna är flex-barn där som `home-select`-spannen
+
+### Fas 3: Koppla in i filterraden
+
+5. Ändra `src/components/home/PartyFilters.tsx`
+   - Byt `<span className="home-select">…<select aria-label="Valår">…</select>…</span>` (rad 43–55) mot `<SegmentedControl legend="Valår" value={filters.valar} segments={yearSegments(valar)} onChange={valar => onChange({ valar })} />`, fortfarande bakom `valar.length > 0`
+   - Byt chip-blocket (rad 92–112) mot `<SegmentedControl legend="Valtyp" value={filters.valtyp} segments={kindSegments(kinds, filters)} onChange={valtyp => onChange({ valtyp })} />`, fortfarande bakom `kinds.length > 0`. `T` härleds till `HomeFilters['valtyp']` från `value` och `segments`, så inget typpåstående behövs
+   - Behåll ordningen i raden: valår, län, kommun, valtyp, "Rensa filter" — samma som i dag
+   - Ta bort importen av `toggleKind`; `ChevronDownIcon` används fortfarande av län- och kommunväljarna
+   - `useMemo` för `municipalities` och `useId` för sökfältet står kvar
+6. Kontrollera `HomeContent.tsx`: inga ändringar. `update()` prunar filtren som förr, så ett `valtyp`-byte till `riksdag` tömmer `lan`, och `onReset` ger senaste året plus `valtyp: ''`, vilket segmentraderna visar som "2026" respektive "Alla".
+7. `npm run typecheck && npm run lint && npm run dev` — sidan renderar med de nya kontrollerna innan något gammalt tas bort.
+
+### Fas 4: Ta bort det som ersatts
+
+8. Ta bort `toggleKind` ur `src/components/home/summary.ts` (rad 59–65 inklusive docblocken) och testet på rad 70–74 i `scripts/home-summary.test.js` samt dess `require`-post på rad 10. Efter fas 3 använder inget annat funktionen (`grep -rn toggleKind src scripts` ska vara tomt).
+9. Ta bort `.home-chips` och `.home-chip*` (rad 100–137 i `src/styles/_home.scss`) och `.home-chip:focus-visible` ur den gemensamma fokusregeln på rad 139–144. `grep -rn home-chip src` ska vara tomt.
+
+### Fas 5: HTTP-smoke
+
+10. Ändra `scripts/http-smoke.js`
+    - Lägg till hjälpfunktionerna `segmentGroup(html, legend)` — klipper ut `<fieldset class="home-segments"><legend class="sr-only">{legend}</legend>…</fieldset>` för den givna legenden (klassordningen är den JSX:en skriver; matcha med `[^>]*` för säkerhets skull) — och `checkedSegment(groupHtml)` som returnerar `value` för den radio som bär `checked=""`. Assert att exakt en radio i gruppen är `checked`.
+    - Rad 178 (`<option value="${latest}" selected="">`): ersätt med `assert.equal(checkedSegment(segmentGroup(homeBody, 'Valår')), latest, 'valårsfiltret står på det senaste valet')`
+    - Rad 187 (`aria-pressed="false"`): ersätt med `assert.equal(checkedSegment(segmentGroup(homeBody, 'Valtyp')), '', 'valtypen står på alla')`
+    - Rad 204–205: `checkedSegment(... 'Valår') === earlier` och `checkedSegment(... 'Valtyp') === 'riksdag'`
+    - Rad 232: `checkedSegment(... 'Valår') === ''`
+    - Rad 239–240: `checkedSegment(... 'Valår') === latest` och `checkedSegment(... 'Valtyp') === ''`
+    - Nytt: hämta `/?valar=${earlier}&valtyp=region&lan=01` (kontrollera först att `01` finns bland länskoderna i `deltagande`-mappen, annars välj den första region-koden som förekommer) och assert att `Valtyp`-gruppens radio med `value="riksdag"` bär `disabled=""` och ett `aria-describedby` vars id finns på ett `<span class="sr-only">` i samma grupp med låstexten, och att `region` är `checked` — det är låsningen i acceptanskriterierna, renderad på servern
+    - Sorteringens `<option ... selected="">`-assertions (rad 179, 180, 224) står kvar; sorteringen är fortfarande en `<select>`
+    - Assertions på `countPattern` och `partyGridLinks` ändras inte
+
+### Fas 6: Verifiering
+
+11. `npm run precommit` (lint, typecheck, derived-data, validate:data, test, build:release, test:http)
+12. Manuell kontroll i `npm run dev`:
+    - Tab från sökfältet: ett stopp på valår (landar på valt segment), sedan län, kommun, ett stopp på valtyp, sedan "Rensa filter"; pil höger/vänster flyttar valet och hoppar över låsta segment; Shift+Tab bakåt
+    - Välj län → "Riksdagsval" låses med titeln synlig vid hover; välj kommun → "Riksdagsval" och "Regionval" låsta; "Alla" och "Kommunval" alltid valbara
+    - "Rensa filter" ger "2026" (senaste året) och "Alla"
+    - Fönster ≈ 360px brett: raderna bryter utan horisontell scroll; titta på hörnen vid brytpunkten (designbeslut 6)
+    - VoiceOver (Safari): gruppen presenteras som "Valtyp, grupp", varje segment som "Alla, radioknapp, 1 av 4, vald" och så vidare; ett låst segment, läst med VO-markören, presenteras som nedtonat *och* med låstexten som beskrivning (`aria-describedby`)
+    - Safari, #89-fallet: fokusera valårsgruppen och håll pil höger nere i mer än 30 sekunder (radion cyklar 2018 → 2022 → 2026 → Alla valår → …, långt över 100 `replaceState`-anrop). Förväntat: antingen tyst konsol, eller `SecurityError` i konsolen medan taket gäller och därefter — retryn försöker om varje sekund, så senast ~30 sekunder efter sista tangenttrycket — en URL som stämmer med det valda segmentet. Allt annat (URL som aldrig kommer ikapp, ohanterat fel) är ett fynd för #89. Anteckna utfallet i #89, som ber om just en sådan körning
+    - Bakåtknappen efter ett partiklick visar samma segment valda som innan (tillståndet kommer från URL:en, #86)
+
+## Filöversikt
+
+| Fil | Åtgärd | Syfte |
+|-----|--------|-------|
+| `src/components/home/segments.ts` | Skapa | Segmentlistor för valtyp och valår, låsregel och låstext |
+| `scripts/home-segments.test.js` | Skapa | `node:test` för segmentlistorna, låsningen och delregister-fallet |
+| `src/components/home/SegmentedControl.tsx` | Skapa | Generisk `<fieldset>`/`<legend>`/radio-komponent |
+| `src/components/home/PartyFilters.tsx` | Ändra | Valår och valtyp renderas med `SegmentedControl`; chip-blocket och `toggleKind`-importen bort |
+| `src/components/home/summary.ts` | Ändra | `toggleKind` tas bort |
+| `scripts/home-summary.test.js` | Ändra | `toggleKind`-testet tas bort |
+| `src/styles/_home.scss` | Ändra | `.home-chips`/`.home-chip*` ersätts av `.home-segments`/`.home-segment*` |
+| `scripts/http-smoke.js` | Ändra | Radio-semantik i stället för `aria-pressed`/`<option selected>` för valår och valtyp; ny assertion för låsningen |
+
+## Berörda kodområden
+
+Lista de primära kataloger/områden som planen berör (för konfliktdetektering):
+- `src/components/home/` (`PartyFilters.tsx`, `summary.ts`, nya `segments.ts` och `SegmentedControl.tsx`)
+- `src/styles/` (`_home.scss`)
+- `scripts/` (`http-smoke.js`, `home-summary.test.js`, nya `home-segments.test.js`)
+
+## Designbeslut
+
+> Icke-triviala val gjorda under planeringen. Feedback välkommen; annars implementeras enligt dessa.
+
+### 1. Native radio i `<fieldset>`/`<legend>`, inte knappar med `role="radiogroup"`
+**Alternativ:** A) `<input type="radio">` per segment, dolda visuellt, `<label>` som segment; B) `<button role="radio" aria-checked>` med egen piltangentshantering (roving tabindex).
+**Beslut:** A
+**Motivering:** Issuet anger A i scope och markerar det som agentens förslag, öppet att ifrågasätta (användarbeslut med reservation, issue #91). A ger tabbstopp, piltangenter, hopp över `disabled` och semantiken gratis; B kräver ~30 rader tangentbordskod som måste testas för hand. Priset för A är att ett piltangentstryck väljer direkt (och skriver URL:en), vilket är hur radio-grupper beter sig och vad en användare av dem förväntar sig; att det är den serie skrivningar #89 handlar om täcks av verifieringen.
+
+### 2. Legenden döljs visuellt
+**Alternativ:** A) `<legend className="sr-only">`; B) synlig legend ovanför eller före raden.
+**Beslut:** A
+**Motivering:** Ingen annan kontroll i filterraden har synlig etikett — valår, län, kommun och valtyp bär `aria-label` i dag, och första segmentets text ("Alla valår") säger vad raden väljer (befintlig konvention, `PartyFilters.tsx`). En synlig legend skulle ändra radens layout, vilket issuet inte ber om. Agentens bedömning; en synlig legend är en klassändring om designen vill ha den.
+
+### 3. Segmenttexterna "Alla" och "Alla valår"
+**Alternativ:** A) "Alla" för valtyp och "Alla valår" för valår, som issuet skriver; B) "Alla valtyper" och "Alla valår"; C) "Alla" för båda.
+**Beslut:** A
+**Motivering:** Issuets scope anger texterna (användarbeslut, issue #91). "Alla valår" behåller dropdownens nuvarande etikett, som smoke-testet också känner till. Valtypens "Alla" är kort nog att inte tränga raden; skulle "Alla" ensamt bli otydligt intill "Riksdagsval" är "Alla val" ett enords-byte i `segments.ts`.
+
+### 4. Segmentlistorna byggs i en ren, testad modul
+**Alternativ:** A) `segments.ts` med `kindSegments`/`yearSegments`/`kindLocked` och `node:test`; B) bygga listorna inline i `PartyFilters.tsx` som i dag.
+**Beslut:** A
+**Motivering:** Acceptanskriterierna nämner låsningen uttryckligen, och repot saknar komponenttester (ingen React-testmiljö; `node:test` kör `.ts`-moduler via Nodes type stripping, som `home-summary.test.js` och `home-query.test.js` gör). Att ha regeln i en ren funktion är det enda sättet att testa den automatiskt. Det ersätter samtidigt `toggleKind`-testet som försvinner. Agentens bedömning; B är helt godtagbar om man hellre håller filantalet nere.
+
+### 5. Radion döljs med `sr-only`, fokusringen ritas på segmentet via `:has()`
+**Alternativ:** A) `<input className="sr-only">` och `.home-segment:has(> input:focus-visible)`; B) `appearance: none` på radion och styla själva inputen som segmentet; C) `input:focus-visible + span` med ringen på textspannet.
+**Beslut:** A
+**Motivering:** `sr-only` finns redan (Tailwind-utility, används i `PartyResults.tsx` och profilsidan) och håller radion fokuserbar; `display: none` eller `visibility: hidden` skulle ta den ur tabbordningen. `:has()` är baseline i alla stödda webbläsare sedan 2023 och låter ringen, det valda läget och det låsta läget alla uttryckas på `<label>` utan klassväxling i React — en styrd `checked` räcker. B skulle kräva att texten ligger *i* inputen, vilket radio inte tillåter. Agentens bedömning.
+
+### 6. Sammanfogad pillrad med yttre rundade hörn; radbrytning accepteras
+**Alternativ:** A) `margin-left: -1.5px`, `999px` på första/sista segmentets ytterkanter, `flex-wrap: wrap`; B) varje segment fullt rundat med litet mellanrum (som chipsen i dag, men med "Alla"); C) förbjud radbrytning och låt raden scrolla horisontellt.
+**Beslut:** A
+**Motivering:** Issuet ber om "joined segments" som "wrap on narrow screens" (användarbeslut, issue #91). A är den läsning som ger både. Vid brytning får segmenten närmast brytpunkten raka hörn — det är ett kosmetiskt pris, inte ett funktionellt, och det inträffar bara under ~500px där valårsraden (fyra segment) bryter. C skulle strida mot issuet och B ger inte en sammanhållen rad. Agentens bedömning på hörnbehandlingen; om brytningen ser fel ut i verifieringen är B en ren SCSS-ändring utan påverkan på komponenten.
+
+### 7. Smoke-testets assertions skrivs om till radio-semantik
+**Alternativ:** A) Byt de sju markup-bundna assertions till `checkedSegment(segmentGroup(...))` och behåll alla vy-assertions; B) behåll `aria-pressed` genom att sätta attributet på `<label>` så gamla regex fortsätter matcha.
+**Beslut:** A
+**Motivering:** Issuet skriver att smoke-testet "still passes with the same expectations", men tre assertions matchar bokstavligen `aria-pressed` och fyra matchar valårets `<option selected>`; ingen av dem kan överleva att kontrollerna byts. B skulle lägga ett ARIA-attribut på ett element som inte får bära det, bara för testets skull. Planen läser "same expectations" som förväntningarna på vyn — rubrikräkningen, gridets innehåll och ordning för varje länk — och de ändras inte. Agentens tolkning; om det var meningen att smoke-testet skulle lämnas orört bör det sägas.
+
+### 8. `RiksdagSection` och #90 lämnas orörda
+**Alternativ:** A) Bara filterraden ändras; B) passa på att byta riksdagssektionens väljare eller dess namn.
+**Beslut:** A
+**Motivering:** Issuet avgränsar till filterraden och pekar på #90 för sektionens väljare (användarbeslut, issue #91). Att blanda in #90 här skulle ge två issues i en PR.
+
+### 9. Inga ändringar i `query.ts`, `HomeContent.tsx` eller URL-formatet; "exakt ett valt" garanteras i `kindSegments`
+**Alternativ:** A) Kontrollen är den enda ändringen, och `kindSegments` tar alltid med den valda typen; B) samtidigt införa t.ex. `valtyp=alla` i URL:en för symmetri med `valar=alla`; C) låta `stateFromQuery` klippa `valtyp` mot `availableKinds` så ett värde utan segment aldrig kan uppstå.
+**Beslut:** A
+**Motivering:** Issuets scope säger att tillstånd och URL är oförändrade och att `query.ts` och dess tester ska lämnas (användarbeslut, issue #91). `valtyp: ''` är redan förvalet och behöver ingen token; `valar` har sin `alla`-token för att förvalet där är senaste året. Kantfallet — ett delregister utan någon valtyp möter `?valtyp=<den typen>` — finns inte i committad data, men acceptanskriteriet "exakt ett segment valt i alla lägen" ska hålla utan förbehåll; A gör det på segmentsidan med en rad i en ren, testad funktion, medan C kräver ett `query.ts`-ingrepp. Att den valda typen då kan visas utan data är ärligt: listan är tom och rubriken räknar 0. Agentens bedömning.
+
+### 10. Låstexten som `title` på `<label>` och som `aria-describedby` på radion
+**Alternativ:** A) `title` på `<label>` (hover) plus `aria-describedby` från `<input>` till en visuellt dold `<span>` med samma text, som syskon efter `<label>`; B) bara `title` på `<label>`, som knappen i dag; C) `title` på både `<label>` och `<input>` och lita på att `title` blir accessible description.
+**Beslut:** A
+**Motivering:** Issuet ber om samma `title` som i dag (användarbeslut, issue #91), vilket B uppfyller för mus men inte för hjälpmedel: `title` på en `<label>` beskriver inte radion. C är kortast men `title`-uppläsning är inte pålitlig mellan skärmläsare, och en låst radio kan inte fokuseras med tangentbordet, så browse-läget är den enda vägen till texten — den ska då fungera. A kostar en id-koppling och ett dolt element per låst segment; texten kan inte ligga inuti `<label>`, då blir den del av namnet. Agentens bedömning.
+
+## Verifieringschecklista
+
+- [ ] Valtyp och valår är var sin segmentrad med exakt ett valt segment i alla lägen, "alla" inräknat (acceptanskriterium)
+- [ ] Tab når varje grupp en gång och landar på det valda segmentet; piltangenter flyttar inom gruppen; låsta segment hoppas över (acceptanskriterium)
+- [ ] Län låser "Riksdagsval", kommun låser "Riksdagsval" och "Regionval", med samma `title`-text som i dag (acceptanskriterium)
+- [ ] URL:en och den renderade listan är oförändrade för varje val: `/`, `/?valar=2022&valtyp=riksdag`, `/?valar=alla`, `/?valar=1900&valtyp=eu`, `/?valar=2026` ger samma grid som före ändringen (acceptanskriterium; smoke-testets `partyGridLinks`/`countPattern`)
+- [ ] `scripts/http-smoke.js` passerar med radio-assertions och den nya låsnings-assertionen
+- [ ] `npm run precommit` grönt (acceptanskriterium)
+- [ ] Bygget är grönt efter fas 3, före borttagningarna i fas 4
+- [ ] `toggleKind` finns inte kvar någonstans (`grep -rn toggleKind src scripts` tomt)
+- [ ] Inga `.home-chip`-klasser kvar i `src/`
+- [ ] Inget `as HomeFilters['valtyp']`-påstående i `PartyFilters.tsx`; `T` härleds
+- [ ] Kantfall: `valar` tom → ingen valårsgrupp renderas; `kinds` tom → ingen valtypsgrupp
+- [ ] Kantfall: `kindSegments(['riksdag'], { valtyp: '' })` ger bara "Alla" och "Riksdagsval"; `kindSegments(['riksdag'], { valtyp: 'region' })` tar med "Regionval" så den valda typen alltid har ett segment (test)
+- [ ] Kantfall: `/?valtyp=riksdag&lan=01` → `pruneFilters` släpper länet, "Riksdagsval" är valt och inte låst
+- [ ] Kantfall: "Rensa filter" med kommun vald → "Alla" valt, alla segment upplåsta, kommun- och länväljarna på "Alla kommuner"/"Hela landet"
+- [ ] Smal skärm (~360px): raderna bryter, ingen horisontell scroll; hörnen vid brytpunkten ser acceptabla ut (designbeslut 6)
+- [ ] Hover på låst segment visar titeln
+- [ ] Skärmläsare läser gruppnamn, segmenttext, "radioknapp", position och valt läge; låst segment läses som nedtonat med låstexten som beskrivning via `aria-describedby`
+- [ ] Låst radio bär `aria-describedby` till ett dolt spann med låstexten; olåst radio bär inget `aria-describedby` (smoke-testet)
+- [ ] Safari: nedhållen piltangent i valårsgruppen i >30 s — URL:en kommer ikapp senast ~30 s efter sista trycket, inget ohanterat fel; utfallet antecknat i #89
+- [ ] Bakåtnavigering från en partisida visar samma segment valda

--- a/agent-docs/issue/91-segmented-single-choice-filters/progress.md
+++ b/agent-docs/issue/91-segmented-single-choice-filters/progress.md
@@ -1,0 +1,48 @@
+# Framsteg: Issue #91 — Present the election type and year filters as segmented single-choice controls
+
+**Påbörjad:** 2026-08-30
+**Senast uppdaterad:** 2026-08-30
+**Status:** Slutförd (kod), manuell webbläsarkontroll återstår
+
+## Genomförda steg
+
+- [x] Fas 1, steg 1: `src/components/home/segments.ts`
+- [x] Fas 1, steg 2: `scripts/home-segments.test.js` — 9 tester
+- [x] Fas 2, steg 3: `src/components/home/SegmentedControl.tsx`
+- [x] Fas 2, steg 4: Segmentstilar i `src/styles/_home.scss`
+- [x] Fas 3, steg 5: `PartyFilters.tsx` använder `SegmentedControl`
+- [x] Fas 3, steg 6: `HomeContent.tsx` kontrollerad, oförändrad
+- [x] Fas 3, steg 7: typecheck + lint gröna före borttagningarna
+- [x] Fas 4, steg 8: `toggleKind` borttagen ur `summary.ts` och testet
+- [x] Fas 4, steg 9: `.home-chips`/`.home-chip*` borttagna
+- [x] Fas 5, steg 10: `scripts/http-smoke.js` med radio-assertions och låsnings-assertion
+- [x] Fas 6, steg 11: `npm run precommit` grönt
+- [ ] Fas 6, steg 12: Manuell kontroll i webbläsare
+
+## Verifierat
+
+- `npm run precommit` grönt: lint, typecheck, derived-data, validate:data, 217 tester, `build:release`, `test:http`.
+- Serverrenderad markup granskad mot den byggda artefakten:
+  - `/` — `Valår` står på senaste året, `Valtyp` på "Alla", exakt en `checked` radio per grupp.
+  - `/?valar=<tidigare>&valtyp=region&lan=01` — "Regionval" vald, "Riksdagsval" `disabled=""` med `aria-describedby` till ett `<span class="sr-only">` som bär låstexten; olåsta segment saknar `aria-describedby`.
+  - `/?valtyp=riksdag&lan=01` — `pruneFilters` släpper länet, "Riksdagsval" vald och olåst, län- och kommunväljarna på "Hela landet"/"Alla kommuner".
+- Byggd CSS innehåller `.home-segments`, `.home-segment`, `:first-of-type`/`:last-of-type`-rundningen och `:has()`-reglerna; noll träffar på `home-chip`.
+- `.sr-only` är klippt till 1px och absolut positionerad, alltså fortsatt fokuserbar.
+
+## Återstår
+
+Punkterna i planens fas 6 som kräver en webbläsare, utförda av en människa i `npm run dev`:
+
+- Tab-ordning, piltangenter och hopp över låsta segment.
+- Hover-titeln på ett låst segment.
+- "Rensa filter" ger senaste året och "Alla".
+- Smal skärm (~360px): radbrytning och hörnen vid brytpunkten (designbeslut 6).
+- VoiceOver i Safari: gruppnamn, position, valt läge och låstexten som beskrivning.
+- Safari, #89-fallet: nedhållen piltangent i valårsgruppen i >30 s; utfallet antecknas i #89.
+- Bakåtknappen efter ett partiklick visar samma segment valda.
+
+## Anteckningar
+
+Branch: `issue/91-segmented-single-choice-filters`, baserad på `main`.
+
+Planens steg 3 ber om en bestämd attributordning i JSX så SSR-markupen följer den. React ordnar om attributen själv (`class`, `type`, `disabled`, `aria-describedby`, `name`, `checked`, `value`), så ordningen är inte styrbar därifrån. Smoke-testet matchar attributoberoende, som planen förutsatte, så inget hänger på det.

--- a/scripts/home-segments.test.js
+++ b/scripts/home-segments.test.js
@@ -1,0 +1,99 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  ALL_KINDS_LABEL,
+  ALL_YEARS_LABEL,
+  kindLocked,
+  kindSegments,
+  lockedTitle,
+  yearSegments
+} = require('../src/components/home/segments.ts');
+
+const ALL_KINDS = ['riksdag', 'region', 'kommun'];
+const NO_AREA = { valtyp: '', lan: '', kommun: '' };
+
+function labels (segments) {
+  return segments.map(segment => segment.label);
+}
+
+function locked (segments) {
+  return segments.filter(segment => segment.disabled).map(segment => segment.value);
+}
+
+test('"alla" is the first segment, never locked, and carries the empty value', () => {
+  for (const filters of [NO_AREA, { valtyp: 'kommun', lan: '01', kommun: '0114' }]) {
+    const [first] = kindSegments(ALL_KINDS, filters);
+    assert.equal(first.value, '');
+    assert.equal(first.label, ALL_KINDS_LABEL);
+    assert.equal(first.disabled, undefined);
+    assert.equal(first.title, undefined);
+  }
+
+  const [firstYear] = yearSegments(['2022']);
+  assert.equal(firstYear.value, '');
+  assert.equal(firstYear.label, ALL_YEARS_LABEL);
+  assert.equal(firstYear.disabled, undefined);
+});
+
+test('nothing is locked until an area is chosen', () => {
+  assert.deepEqual(locked(kindSegments(ALL_KINDS, NO_AREA)), []);
+  assert.equal(kindLocked('riksdag', { lan: '', kommun: '' }), false);
+});
+
+test('a county locks the parliamentary election alone', () => {
+  assert.deepEqual(locked(kindSegments(ALL_KINDS, { valtyp: '', lan: '01', kommun: '' })), ['riksdag']);
+  assert.equal(kindLocked('riksdag', { lan: '01', kommun: '' }), true);
+  assert.equal(kindLocked('region', { lan: '01', kommun: '' }), false);
+  assert.equal(kindLocked('kommun', { lan: '01', kommun: '' }), false);
+});
+
+test('a municipality locks the parliamentary and the regional election', () => {
+  assert.deepEqual(
+    locked(kindSegments(ALL_KINDS, { valtyp: '', lan: '01', kommun: '0114' })),
+    ['riksdag', 'region']
+  );
+  assert.equal(kindLocked('kommun', { lan: '01', kommun: '0114' }), false);
+});
+
+test('the lock text sits on the locked segments and names the election type', () => {
+  const segments = kindSegments(ALL_KINDS, { valtyp: '', lan: '', kommun: '0114' });
+  const titled = segments.filter(segment => segment.title);
+  assert.deepEqual(titled.map(segment => segment.value), ['riksdag', 'region']);
+  assert.equal(titled[0].title, lockedTitle('riksdag'));
+  assert.match(titled[0].title, /^Riksdagsval gäller inte ett valt område/);
+  assert.match(titled[1].title, /^Regionval gäller inte ett valt område/);
+  assert.equal(segments.find(segment => segment.value === 'kommun').title, undefined);
+});
+
+test('the list follows the data, not the three types', () => {
+  assert.deepEqual(labels(kindSegments(['riksdag'], NO_AREA)), [ALL_KINDS_LABEL, 'Riksdagsval']);
+  assert.deepEqual(labels(kindSegments([], NO_AREA)), [ALL_KINDS_LABEL]);
+});
+
+test('the chosen type always has a segment, in canonical position', () => {
+  assert.deepEqual(
+    labels(kindSegments(['riksdag'], { valtyp: 'region', lan: '', kommun: '' })),
+    [ALL_KINDS_LABEL, 'Riksdagsval', 'Regionval']
+  );
+  assert.deepEqual(
+    labels(kindSegments(['kommun'], { valtyp: 'riksdag', lan: '', kommun: '' })),
+    [ALL_KINDS_LABEL, 'Riksdagsval', 'Kommunval']
+  );
+});
+
+test('a type the data and the filter both name appears once', () => {
+  const segments = kindSegments(ALL_KINDS, { valtyp: 'region', lan: '', kommun: '' });
+  assert.deepEqual(labels(segments), [ALL_KINDS_LABEL, 'Riksdagsval', 'Regionval', 'Kommunval']);
+  assert.equal(new Set(segments.map(segment => segment.value)).size, segments.length);
+});
+
+test('the year segments keep the order the data gives them', () => {
+  assert.deepEqual(yearSegments(['2018', '2022', '2026']), [
+    { value: '', label: ALL_YEARS_LABEL },
+    { value: '2018', label: '2018' },
+    { value: '2022', label: '2022' },
+    { value: '2026', label: '2026' }
+  ]);
+  assert.deepEqual(yearSegments([]), [{ value: '', label: ALL_YEARS_LABEL }]);
+});

--- a/scripts/home-summary.test.js
+++ b/scripts/home-summary.test.js
@@ -6,8 +6,7 @@ const {
   cardSub,
   participationYears,
   partyLabel,
-  queryEcho,
-  toggleKind
+  queryEcho
 } = require('../src/components/home/summary.ts');
 
 function party (deltagande) {
@@ -65,12 +64,6 @@ test('equal party names get an area suffix only when one is available', () => {
   assert.equal(partyLabel({ beteckning: 'Kommunens Väl', duplicateName: true, omrade: 'Hylte' }), 'Kommunens Väl (Hylte)');
   assert.equal(partyLabel({ beteckning: 'Kommunens Väl', duplicateName: true }), 'Kommunens Väl');
   assert.equal(partyLabel({ beteckning: 'Eget namn', duplicateName: false, omrade: 'Hylte' }), 'Eget namn');
-});
-
-test('a chip toggles its election type off when it is already the chosen one', () => {
-  assert.equal(toggleKind('', 'kommun'), 'kommun');
-  assert.equal(toggleKind('riksdag', 'kommun'), 'kommun');
-  assert.equal(toggleKind('kommun', 'kommun'), '');
 });
 
 test('the empty state echoes the search term, or the filters', () => {

--- a/scripts/http-smoke.js
+++ b/scripts/http-smoke.js
@@ -81,6 +81,31 @@ function countPattern (matched, total) {
   return new RegExp(`>${matched}(<!-- -->)? av (<!-- -->)?${total}</span>`);
 }
 
+/** The markup of one segmented control, cut out by the legend that names it. */
+function segmentGroup (html, legend) {
+  const group = html.match(new RegExp(
+    `<fieldset[^>]*class="home-segments"[^>]*><legend[^>]*>${legend}</legend>([\\s\\S]*?)</fieldset>`
+  ));
+  assert.ok(group, `segmentgruppen "${legend}" finns i markupen`);
+  return group[1];
+}
+
+/** The value of the one segment a group has selected, which is always exactly one. */
+function checkedSegment (groupHtml) {
+  const checked = [...groupHtml.matchAll(/<input[^>]*>/g)]
+    .map(match => match[0])
+    .filter(input => / checked=""/.test(input));
+  assert.equal(checked.length, 1, 'exakt ett segment i gruppen är valt');
+  return checked[0].match(/ value="([^"]*)"/)[1];
+}
+
+/** The radio of one segment, by the value it stands for. */
+function segmentInput (groupHtml, value) {
+  const input = groupHtml.match(new RegExp(`<input[^>]*value="${value}"[^>]*>`));
+  assert.ok(input, `segmentet "${value}" finns i gruppen`);
+  return input[0];
+}
+
 /** Extracts the party links of the "Alla partier" grid in document order. */
 function partyGridLinks (html) {
   const section = html.slice(html.indexOf('id="alla-partier"'));
@@ -175,7 +200,7 @@ async function main () {
       countPattern(standing.length, parties.length),
       'rubriken räknar partierna i det förvalda valåret mot hela registret'
     );
-    assert.match(homeBody, new RegExp(`<option value="${latest}" selected="">${latest}</option>`), 'valårsfiltret står på det senaste valet');
+    assert.equal(checkedSegment(segmentGroup(homeBody, 'Valår')), latest, 'valårsfiltret står på det senaste valet');
     assert.match(homeBody, /<option value="namn" selected="">Sorterat <!-- -->A–Ö<\/option>/, 'sorteringen står på bokstavsordning');
     assert.match(homeBody, /<option value="kommuner">Sorterat <!-- -->Flest kommuner<\/option>/, 'sorteringen kan rangordna på kommuner');
     assert.match(homeBody, new RegExp(`/parti/${first}`), 'partigridet länkar till en partisida');
@@ -184,7 +209,7 @@ async function main () {
     assert.match(homeBody, new RegExp(`>${outside.partier[0].rostandel.toFixed(2).replace('.', ',')}(<!-- -->)? %<`), 'utanför-rankningen visar den härledda röstandelen');
     assert.equal(homeBody.split('party-card--medium').length - 1, outside.partier.length, 'utanför-rankningen renderar alla härledda partikort');
     assert.match(homeBody, new RegExp(`valet (<!-- -->)?${chamber.valar}`), 'riksdagssektionen anger valåret');
-    assert.match(homeBody, /aria-pressed="false"/, 'valtypen renderas som en chip-grupp');
+    assert.equal(checkedSegment(segmentGroup(homeBody, 'Valtyp')), '', 'valtypen står på alla');
     assert.match(homeBody, /Visa fler partier \(/, 'visa fler anger hur många som återstår');
     assert.match(homeBody, /Alternativet \(Bromölla\)/, 'identiska partinamn får ort på korten');
     assert.match(homeBody, /Alternativet \(Ljungby\)/, 'alla synliga namndubbletter särskiljs');
@@ -201,11 +226,30 @@ async function main () {
     const filtered = await fetch(`${baseUrl}/?valar=${earlier}&valtyp=riksdag`);
     assert.equal(filtered.status, 200);
     const filteredBody = await filtered.text();
-    assert.match(filteredBody, new RegExp(`<option value="${earlier}" selected="">${earlier}</option>`), 'valårsfiltret står på året i länken');
-    assert.match(filteredBody, /aria-pressed="true"[^>]*>Riksdagsval</, 'riksdagsvalet är den tryckta chipen');
+    assert.equal(checkedSegment(segmentGroup(filteredBody, 'Valår')), earlier, 'valårsfiltret står på året i länken');
+    assert.equal(checkedSegment(segmentGroup(filteredBody, 'Valtyp')), 'riksdag', 'riksdagsvalet är det valda segmentet');
     assert.match(filteredBody, /<link rel="canonical" href="https:\/\/www\.partidata\.se\/"[^>]*>/, 'en filtrerad vy är samma kanoniska sida');
     assert.match(filteredBody, countPattern(parliamentary.length, parties.length), 'rubriken räknar de filtrerade partierna');
     assert.deepEqual(partyGridLinks(filteredBody), expectedGrid(parliamentary), 'gridet visar partierna länken filtrerar fram');
+
+    // A county rules out the nationwide election, which the server renders as a
+    // disabled segment carrying the reason as its description.
+    const regionCounties = new Set([...deltagande.values()].flatMap(facets => facets[earlier]?.region ?? []));
+    const county = regionCounties.has('01') ? '01' : [...regionCounties].toSorted().at(0);
+    assert.ok(county, `regionvalet ${earlier} har minst ett län`);
+    const inCounty = await fetch(`${baseUrl}/?valar=${earlier}&valtyp=region&lan=${county}`);
+    assert.equal(inCounty.status, 200);
+    const kindGroup = segmentGroup(await inCounty.text(), 'Valtyp');
+    assert.equal(checkedSegment(kindGroup), 'region', 'regionvalet är det valda segmentet');
+    const lockedInput = segmentInput(kindGroup, 'riksdag');
+    assert.match(lockedInput, / disabled=""/, 'ett valt län låser riksdagsvalet');
+    const noteId = lockedInput.match(/ aria-describedby="([^"]*)"/);
+    assert.ok(noteId, 'det låsta segmentet pekar ut sin beskrivning');
+    assert.ok(
+      kindGroup.includes(`<span id="${noteId[1]}" class="sr-only">Riksdagsval gäller inte ett valt område — välj Hela landet och Alla kommuner först</span>`),
+      'beskrivningen är låstexten i ett dolt spann'
+    );
+    assert.doesNotMatch(segmentInput(kindGroup, 'kommun'), / aria-describedby=/, 'ett olåst segment får ingen beskrivning');
 
     // The ranking is the widest municipal ballot that year, and the sort is
     // stable, so parties on equally many keep Swedish name order.
@@ -229,15 +273,15 @@ async function main () {
     const everyYear = await fetch(`${baseUrl}/?valar=alla`);
     assert.equal(everyYear.status, 200);
     const everyYearBody = await everyYear.text();
-    assert.match(everyYearBody, /<option value="" selected="">Alla valår<\/option>/, 'valårsfiltret står på alla valår');
+    assert.equal(checkedSegment(segmentGroup(everyYearBody, 'Valår')), '', 'valårsfiltret står på alla valår');
     assert.match(everyYearBody, countPattern(parties.length, parties.length), 'utan valår och övriga filter matchar hela registret');
     assert.deepEqual(partyGridLinks(everyYearBody), expectedGrid(inNameOrder), 'gridet är hela registret i bokstavsordning');
 
     const invalid = await fetch(`${baseUrl}/?valar=1900&valtyp=eu`);
     assert.equal(invalid.status, 200);
     const invalidBody = await invalid.text();
-    assert.match(invalidBody, new RegExp(`<option value="${latest}" selected="">${latest}</option>`), 'ett valår datan saknar faller tillbaka på förvalet');
-    assert.doesNotMatch(invalidBody, /aria-pressed="true"/, 'en okänd valtyp lämnar chip-gruppen otryckt');
+    assert.equal(checkedSegment(segmentGroup(invalidBody, 'Valår')), latest, 'ett valår datan saknar faller tillbaka på förvalet');
+    assert.equal(checkedSegment(segmentGroup(invalidBody, 'Valtyp')), '', 'en okänd valtyp faller tillbaka på alla');
 
     const canonicalYear = await fetch(`${baseUrl}/?valar=${latest}`);
     assert.equal(canonicalYear.status, 200);

--- a/src/components/home/PartyFilters.tsx
+++ b/src/components/home/PartyFilters.tsx
@@ -1,9 +1,10 @@
 import { useId, useMemo } from 'react';
 import type { HomeCounty, HomeMunicipality } from 'src/server/party-data';
 import type { ElectionKind, HomeFilters } from './filtering';
-import { countyApplies, electionKindLabels, municipalityApplies } from './filtering';
+import { countyApplies, municipalityApplies } from './filtering';
 import { ChevronDownIcon, RotateCcwIcon, SearchIcon } from './icons';
-import { toggleKind } from './summary';
+import SegmentedControl from './SegmentedControl';
+import { kindSegments, yearSegments } from './segments';
 
 export interface PartyFiltersProps {
   filters: HomeFilters;
@@ -41,17 +42,12 @@ function PartyFilters ({ filters, valar, lan, kommuner, kinds, onChange, onReset
 
       <div className="home-search__filters">
         {valar.length > 0 && (
-          <span className="home-select">
-            <select
-              aria-label="Valår"
-              value={filters.valar}
-              onChange={event => onChange({ valar: event.target.value })}
-            >
-              <option value="">Alla valår</option>
-              {valar.map(year => <option key={year} value={year}>{year}</option>)}
-            </select>
-            <ChevronDownIcon className="home-select__chevron" />
-          </span>
+          <SegmentedControl
+            legend="Valår"
+            value={filters.valar}
+            segments={yearSegments(valar)}
+            onChange={valar => onChange({ valar })}
+          />
         )}
 
         {lan.length > 0 && (
@@ -90,25 +86,12 @@ function PartyFilters ({ filters, valar, lan, kommuner, kinds, onChange, onReset
         )}
 
         {kinds.length > 0 && (
-          <div className="home-chips" role="group" aria-label="Valtyp">
-            {kinds.map(kind => {
-              const pressed = filters.valtyp === kind;
-              const locked = (kind === 'riksdag' && Boolean(filters.lan)) || (kind !== 'kommun' && Boolean(filters.kommun));
-              return (
-                <button
-                  key={kind}
-                  type="button"
-                  className={`home-chip${pressed ? ' home-chip--on' : ''}`}
-                  aria-pressed={pressed}
-                  disabled={locked}
-                  title={locked ? `${electionKindLabels[kind]} gäller inte ett valt område — välj Hela landet och Alla kommuner först` : undefined}
-                  onClick={() => onChange({ valtyp: toggleKind(filters.valtyp, kind) })}
-                >
-                  {electionKindLabels[kind]}
-                </button>
-              );
-            })}
-          </div>
+          <SegmentedControl
+            legend="Valtyp"
+            value={filters.valtyp}
+            segments={kindSegments(kinds, filters)}
+            onChange={valtyp => onChange({ valtyp })}
+          />
         )}
 
         <button type="button" className="home-reset" onClick={onReset}>

--- a/src/components/home/SegmentedControl.tsx
+++ b/src/components/home/SegmentedControl.tsx
@@ -1,0 +1,49 @@
+import { Fragment, useId } from 'react';
+import type { Segment } from './segments';
+
+export interface SegmentedControlProps<T extends string> {
+  legend: string;
+  value: T;
+  segments: Segment<T>[];
+  onChange: (value: T) => void;
+}
+
+/**
+ * A single choice shown as a joined row of segments. The radios carry the
+ * semantics — one tab stop, arrow keys within the group, disabled segments
+ * skipped — so the row needs no keyboard code of its own.
+ */
+function SegmentedControl<T extends string> ({ legend, value, segments, onChange }: SegmentedControlProps<T>) {
+  const name = useId();
+
+  return (
+    <fieldset className="home-segments">
+      <legend className="sr-only">{legend}</legend>
+      {segments.map(segment => {
+        // The description has to sit outside the label; inside it would become
+        // part of the segment's own name.
+        const noteId = segment.title ? `${name}-${segment.value || 'alla'}-note` : undefined;
+        return (
+          <Fragment key={segment.value}>
+            <label className="home-segment" title={segment.title}>
+              <input
+                className="sr-only"
+                type="radio"
+                name={name}
+                value={segment.value}
+                checked={value === segment.value}
+                disabled={segment.disabled}
+                aria-describedby={noteId}
+                onChange={() => onChange(segment.value)}
+              />
+              <span className="home-segment__text">{segment.label}</span>
+            </label>
+            {noteId && <span id={noteId} className="sr-only">{segment.title}</span>}
+          </Fragment>
+        );
+      })}
+    </fieldset>
+  );
+}
+
+export default SegmentedControl;

--- a/src/components/home/segments.ts
+++ b/src/components/home/segments.ts
@@ -1,0 +1,58 @@
+import type { ElectionKind, HomeFilters } from './filtering.ts';
+import { electionKindLabels } from './filtering.ts';
+
+export interface Segment<T extends string = string> {
+  value: T;
+  label: string;
+  disabled?: boolean;
+  title?: string;
+}
+
+export const ALL_KINDS_LABEL = 'Alla';
+export const ALL_YEARS_LABEL = 'Alla valår';
+
+/** The canonical order the election types are offered in. */
+const kindOrder: ElectionKind[] = ['riksdag', 'region', 'kommun'];
+
+/**
+ * A chosen area rules out the elections it cannot narrow: the nationwide
+ * parliamentary election has no county, and only the municipal election
+ * belongs to a single municipality.
+ */
+export function kindLocked (kind: ElectionKind, filters: Pick<HomeFilters, 'lan' | 'kommun'>): boolean {
+  return (kind === 'riksdag' && Boolean(filters.lan)) || (kind !== 'kommun' && Boolean(filters.kommun));
+}
+
+export const lockedTitle = (kind: ElectionKind): string =>
+  `${electionKindLabels[kind]} gäller inte ett valt område — välj Hela landet och Alla kommuner först`;
+
+/**
+ * The election type segments: "every type" first, then the types the data
+ * carries. The chosen type is always among them, so exactly one segment is
+ * selected even when the registry holds no ballots of that type.
+ */
+export function kindSegments (
+  kinds: ElectionKind[],
+  filters: Pick<HomeFilters, 'valtyp' | 'lan' | 'kommun'>,
+): Segment<HomeFilters['valtyp']>[] {
+  const offered = kindOrder.filter(kind => kinds.includes(kind) || filters.valtyp === kind);
+  return [
+    { value: '', label: ALL_KINDS_LABEL },
+    ...offered.map(kind => {
+      const locked = kindLocked(kind, filters);
+      return {
+        value: kind,
+        label: electionKindLabels[kind],
+        ...(locked ? { disabled: true, title: lockedTitle(kind) } : {}),
+      };
+    }),
+  ];
+}
+
+/** The election year segments: "every year" first, then the years the data carries. */
+export function yearSegments (valar: string[]): Segment[] {
+  return [
+    { value: '', label: ALL_YEARS_LABEL },
+    ...valar.map(year => ({ value: year, label: year })),
+  ];
+}

--- a/src/components/home/summary.ts
+++ b/src/components/home/summary.ts
@@ -57,14 +57,6 @@ export function partyLabel (party: Pick<HomeParty, 'beteckning' | 'duplicateName
 }
 
 /**
- * The chips are a single choice shown as a group, so pressing the active one
- * clears the election type rather than leaving it stuck on.
- */
-export function toggleKind (current: HomeFilters['valtyp'], kind: ElectionKind): HomeFilters['valtyp'] {
-  return current === kind ? '' : kind;
-}
-
-/**
  * The quoted term the empty state echoes back, or the filters when the search
  * box is empty.
  */

--- a/src/styles/_home.scss
+++ b/src/styles/_home.scss
@@ -97,46 +97,67 @@
   pointer-events: none;
 }
 
-.home-chips {
+.home-segments {
   display: flex;
-  gap: 0.5rem;
   flex-wrap: wrap;
+  min-inline-size: 0;
+  padding: 0;
+  border: 0;
+  margin: 0;
 }
 
-.home-chip {
+.home-segment {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
   padding: 0.6875rem 1.25rem;
   border: 1.5px solid var(--partidata-chip-off-line);
-  border-radius: 999px;
+  margin-left: -1.5px;
   background: var(--partidata-card);
   color: var(--partidata-ink);
   cursor: pointer;
-  font-family: inherit;
   font-size: 1rem;
 }
 
-.home-chip:disabled {
-  cursor: not-allowed;
-  opacity: 0.45;
+.home-segment:first-of-type {
+  border-radius: 999px 0 0 999px;
+  margin-left: 0;
 }
 
-.home-chip:disabled:hover {
-  border-color: var(--partidata-chip-off-line);
-  color: var(--partidata-ink);
+.home-segment:last-of-type {
+  border-radius: 0 999px 999px 0;
 }
 
-.home-chip:hover {
+.home-segment:hover {
+  z-index: 1;
   border-color: var(--partidata-navy);
   color: var(--partidata-navy);
 }
 
-.home-chip--on,
-.home-chip--on:hover {
+.home-segment:has(> input:checked) {
+  z-index: 1;
   border-color: var(--partidata-navy);
   background: var(--partidata-navy);
   color: var(--partidata-paper);
 }
 
-.home-chip:focus-visible,
+.home-segment:has(> input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.home-segment:has(> input:disabled):hover {
+  z-index: auto;
+  border-color: var(--partidata-chip-off-line);
+  color: var(--partidata-ink);
+}
+
+.home-segment:has(> input:focus-visible) {
+  z-index: 2;
+  outline: 3px solid var(--partidata-yellow);
+  outline-offset: 3px;
+}
+
 .home-reset:focus-visible,
 .home-pill:focus-visible {
   outline: 3px solid var(--partidata-yellow);


### PR DESCRIPTION
The filter bar presented two single-choice controls in ways that did not say so: the election type as three loose `aria-pressed` pills where "all" was chosen by clicking the selected pill off, and the election year as a dropdown with four options. Both are now the same segmented single-choice row with an explicit first segment for "all" ("Alla" and "Alla valår"), so exactly one segment is selected at all times and the state is visible.

`SegmentedControl<T>` is a `<fieldset>` with a visually hidden `<legend>` and native radio inputs in label segments: one tab stop per group, arrow keys within it, disabled segments skipped. The locking stays as before — a county locks Riksdagsval, a municipality locks Riksdagsval and Regionval — with the explanatory text as `title` on the label and as `aria-describedby` to a hidden span, so it reaches keyboard and screen-reader users as well as the mouse. `segments.ts` holds the pure helpers (`kindSegments` always includes the chosen type, so a sub-registry cannot leave a group with nothing selected), covered by `scripts/home-segments.test.js`. `toggleKind` and the chip styles are gone.

State, URL and `query.ts` are untouched: `valtyp: ''` and `valar: ''` still mean "all". County and municipality stay dropdowns. The smoke test's seven markup-bound assertions are rewritten to radio semantics and a new one checks the locked state's `disabled` and `aria-describedby`; every view assertion is unchanged. `npm run precommit` is green.

Not done here: the manual browser checks the plan lists in phase 6 — keyboard behaviour, wrapping at narrow widths, VoiceOver, and the Safari `replaceState` run that #89 tracks.

Closes #91
