### PR TITLE
Two year controls on the start page look like one choice but select different things

### DIFF
--- a/scripts/http-smoke.js
+++ b/scripts/http-smoke.js
@@ -209,6 +209,8 @@ async function main () {
     assert.match(homeBody, new RegExp(`>${outside.partier[0].rostandel.toFixed(2).replace('.', ',')}(<!-- -->)? %<`), 'utanför-rankningen visar den härledda röstandelen');
     assert.equal(homeBody.split('party-card--medium').length - 1, outside.partier.length, 'utanför-rankningen renderar alla härledda partikort');
     assert.match(homeBody, new RegExp(`valet (<!-- -->)?${chamber.valar}`), 'riksdagssektionen anger valåret');
+    assert.match(homeBody, /<select aria-label="Mandatfördelning efter val"/, 'riksdagssektionens val har ett eget tillgängligt namn');
+    assert.ok(!homeBody.includes('aria-label="Valår"'), 'Valår namnger bara listfiltret');
     assert.equal(checkedSegment(segmentGroup(homeBody, 'Valtyp')), '', 'valtypen står på alla');
     assert.match(homeBody, /Visa fler partier \(/, 'visa fler anger hur många som återstår');
     assert.match(homeBody, /Alternativet \(Bromölla\)/, 'identiska partinamn får ort på korten');

--- a/src/components/home/RiksdagSection.tsx
+++ b/src/components/home/RiksdagSection.tsx
@@ -16,7 +16,7 @@ function RiksdagSection ({ years }: { years: ParliamentYear[] }) {
         <h2 id={`${fieldId}-heading`}>Riksdagspartier</h2>
         {years.length > 1 ? (
           <span className="home-select">
-            <select aria-label="Valår" value={year.valar} onChange={event => setValar(Number(event.target.value))}>
+            <select aria-label="Mandatfördelning efter val" value={year.valar} onChange={event => setValar(Number(event.target.value))}>
               {years.map(entry => <option key={entry.valar} value={entry.valar}>Mandat efter valet {entry.valar}</option>)}
             </select>
             <ChevronDownIcon className="home-select__chevron" />


### PR DESCRIPTION
The Riksdag section's seat-distribution picker and the filter bar's election year both carried the accessible name "Valår", although they select different things: the year picker chooses which election's seat distribution the section shows, the filter chooses which election's participation the party list shows. The picker is now named "Mandatfördelning efter val"; "Valår" names only the filter bar's control.

The visible distinction the issue asks for is already in place since #91: the filter bar's year is a segmented row in the filter panel, the section's picker is a dropdown in the section header whose closed text reads "Mandat efter valet 2022". The two states stay independent; the section's year never reaches the query string.

Two smoke-test assertions guard the change: the section's `<select>` carries its own accessible name, and `aria-label="Valår"` appears nowhere in the start page markup. `npm run precommit` is green.

Closes #90
