### PR TITLE
Derive the party page's election results from the imported results

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Tre kodsystem möts i `data/val/`, och `R` och `K` betyder olika saker i två av
 
 ### val/\<år\>/valresultat/riksdag.json
 
-Slutligt riksdagsresultat 1994–2022 i en gemensam, källoberoende modell: giltiga röster, röster och andel per parti, mandat, stabilt parti-uuid samt källreferenser med SHA-256. Historiska rader som inte kan identitetskopplas säkert och aggregerade `Övriga partier` redovisas uttryckligen utan gissade uuid:n. Se [modell, källor och rankingmetod](docs/riksdagsvalresultat.md).
+Slutligt riksdagsresultat 1994–2022 i en gemensam, källoberoende modell: giltiga röster, röster och andel per parti, mandat, stabilt parti-uuid samt källreferenser med SHA-256. Historiska rader som inte kan identitetskopplas säkert och aggregerade `Övriga partier` redovisas uttryckligen utan gissade uuid:n. Partisidans valresultat härleds ur den här filen, enligt [reglerna för partisidan](docs/riksdagsvalresultat.md#partisidan). Se [modell, källor och rankingmetod](docs/riksdagsvalresultat.md).
 
 ### derived/
 

--- a/agent-docs/issue/76-derive-party-page-election-results/index.md
+++ b/agent-docs/issue/76-derive-party-page-election-results/index.md
@@ -1,0 +1,35 @@
+# Issue #76: Derive the party page's election results from the imported results
+
+**Baserad på:** main
+
+## Sammanfattning
+
+Partisidans valresultat (hero-blocken, sektionen "Vad partiet har fått i val" och valdeltagandesektionen) läses i dag ur det handkurerade `profil.valresultat`, som bara två partier har, medan samma siffror redan finns validerade och källspårade i `data/val/<år>/valresultat/riksdag.json` för 106 partier 1994–2022. Planen härleder resultaten vid request i `src/server/party-data.ts` — samma filer, samma memoiserade läsning som startsidans riksdagssektion — som en ny `PartiValresultat` på `PartyPageData`, med `mandat` (0 utan mandatrad), `forandring` mot föregående importerade val, källa per rad och ett `kammare`-fält som bara finns när partiet har mandat i det senaste valet med mandatfördelning. Komponenterna byter till den typen: mandatblocket i heron och kammarblocket i sektionen visas bara för kammarpartier, källraderna står per valår (SCB för 1994–1998), och underrubriken klarar ett enda valår. `profil.valresultat` tas bort ur typ, validering (som nu avvisar nyckeln) och de två profilfilerna — de kurerade värdena stämmer siffra för siffra med importen, så inget går förlorat. Smoke-testet knyter partisidans mandat till `data/derived/riksdag.json` och kontrollerar att ett parti utan resultat får ingen sektion; `docs/riksdagsvalresultat.md` får härledningsreglerna.
+
+## Triageringsstatus
+
+| Fält | Värde |
+|------|-------|
+| **Redo att arbeta** | Ja |
+| **Risk** | Låg–Medel |
+| **Säker för junior** | Ja |
+
+## Plangranskning
+
+**Status:** Granskad
+**Granskad:** 2026-08-30
+**Feedback:** Två granskningsrundor (codex). Första rundan: planen antog att preliminära resultatfiler utan mandatfördelning kunde förekomma, men `validate.js` kräver `status: "slutligt"` och 349 mandat per fil (statusfältet och kantfallet togs bort, kammaråret är det senaste importerade valet); testfixturen `makeHomeData()` gör 2026 till kammarår så det föreslagna Alfapartiet-testet var omöjligt (testerna skrevs om: `betapartiet` via store, kantfallen direkt mot `partyElectionResults()` i minnet); det valda indexet i resultatsektionen kan bli stale vid klientnavigering (`key={slug}`); två hårdkodade "Valmyndigheten · slutlig rösträkning" var fel för SCB-åren (seriens källnamn, efter `turnoutSourceNames`-mönstret); stigande/fallande sortering mellan den delade läsningen och startsidans projektion gjordes explicit; smoke-testet fick valdeltagande-assertions, en datakontroll av partiet utan resultat och en avgränsad mandatregex; villkorad spridning och `toSorted()` som implementationskrav; konfliktrisken höjdes till Medel om #21/#77 startar parallellt. Andra rundan: tom fil-lista kraschade kammarårsuppslaget (guard), navigeringstestet gick via startsidan och bevisade inget (fallet är inte nåbart i dagens UI, noterat), och en oanvänd `latestResult` på sidan (borttagen).
+
+## Relaterade filer
+
+- [plan.md](plan.md) — Fullständig implementationsplan
+- [progress.md](progress.md) — Implementationsframsteg
+- [research.md](research.md) — Forskningsresultat (om finns)
+
+## Relaterade issues
+
+- #68 — Paraplyet "Fill the party profile modules with sourced content"; #76 är dess resultatmodul ("Part of")
+- #21 — Historiskt deltagande per valår på partisidan; samma sida, annan data, ingen plan ännu
+- #35 — Omkörning av 2026-importen; härledningen ska ta ett nytt valår (och en eventuell preliminär status) utan kodändring
+- #77 — Presentationsfält i `profil.json`; rör samma typ, validering och filer, ingen plan ännu
+- #26 — Publicerat JSON-gränssnitt; `profil.json` bär inte längre `valresultat`

--- a/agent-docs/issue/76-derive-party-page-election-results/plan.md
+++ b/agent-docs/issue/76-derive-party-page-election-results/plan.md
@@ -1,0 +1,256 @@
+# Plan: Issue #76 — Derive the party page's election results from the imported results
+
+## Mål
+
+Partisidans valresultat — hero-blocken "Mandat i riksdagen" och "Riksdagsvalet ÅÅÅÅ", sektionen "Vad partiet har fått i val" och valdeltagandesektionen — ska härledas ur de importerade, validerade riksdagsresultaten i `data/val/<år>/valresultat/riksdag.json`, på samma sätt som startsidans riksdagssektion redan gör via `src/server/party-data.ts`. Det handkurerade fältet `profil.valresultat` tas bort helt: importen innehåller redan varje siffra det bär (och mer — röstetal, samt 1994 och 1998 för Liberalerna), så det finns inget kvar för fältet att uttrycka. Ett parti som saknar kopplade riksdagsresultat renderar ingen resultatsektion och inga resultatblock i heron.
+
+## Triagering
+
+> Beslutsunderlag för detta issue.
+
+| Fält | Värde |
+|------|-------|
+| **Blockeras av** | Inget |
+| **Blockerar** | Inget direkt; #26 (publicerat JSON-gränssnitt) bör känna till att `profil.json` inte längre bär `valresultat` |
+| **Relaterade issues** | #68 (paraply, "Part of"), #21 (historiskt deltagande per valår på partisidan — samma sida, annan data), #35 (omkörning av 2026-importen — härledningen ska klara ett nytt valår utan kodändring), #77 (presentationsfält i `profil.json` — samma fil och validering, ingen plan ännu), #26 (JSON-gränssnitt) |
+| **Omfattning** | ~12 kod-/dokumentfiler i `src/server/`, `src/components/party-profile/`, `src/pages/parti/`, `src/types.ts`, `scripts/`, `docs/` + `data/parti/<filnamn>/profil.json` × 2 |
+| **Risk** | Låg–Medel (rör partisidans mest synliga modul, men datan är redan validerad och de två profilerade partierna får identiska siffror; ~100 partier får en sektion de inte haft) |
+| **Komplexitet** | Medel (härledningen är enkel; kantfallen — partier utan mandat, luckor i serien, källor per rad, kammarår — kräver uttalade regler) |
+| **Säker för junior** | Ja, med planen följd — reglerna i designbeslut 2–5 är de som annars lätt gissas fel |
+| **Konfliktrisk** | Låg så länge #76 arbetas ensamt; Medel om #21 eller #77 startar parallellt. Alla befintliga planmappar hör till stängda issues. #77 (öppet, ingen plan) kommer att röra `src/types.ts` (`PartiProfil`), `scripts/validate.js` (`validatePartyProfile`) och `profil.json` — samma rader som fas 3 här. #21 (öppet, ingen plan) rör `src/pages/parti/[filnamn].tsx`. Rekommendation: låt #76 gå först |
+
+### Triagemässiga noteringar
+
+- "Part of #68" är paraply-koppling, inte blockering — samma läsning som i planen för #78. Issuet är öppet med etiketten `enhancement`, utan ansvarig, milstolpe eller kommentarer. Inget projektbräde är konfigurerat (`agent-docs/github/info.json` och `project.json` saknas), så ingen board-status har stämts av.
+- Repot har inga `release/*`-refs; planen utgår från `main` (rent working tree vid planeringen, HEAD `8f57401`).
+- **Issuets första öppna fråga är avgjord av datan.** De kurerade värdena för Liberalerna (2002–2022) och Miljöpartiet (1994–2022) stämmer siffra för siffra med `rostandel` och `mandat` i importen (kontrollerat 2026-08-30). Importen har dessutom `roster` för varje rad och Liberalernas 1994 och 1998. Det finns alltså inget "resultat importen inte kan uttrycka" att hålla ett override-fält för — fältet tas bort (designbeslut 1).
+- **Issuets andra öppna fråga får en datadriven regel.** 106 av registrets 670 partier har minst en kopplad rad i `rostresultat.partier` i något valår 1994–2022; 8 har mandat 2022; 80 har en röstrad 2022 utan mandat (från Partiet Nyans 0,44 % ned till partier med 0,00 %). Partier utan kopplad rad — de 564 övriga — får ingen sektion. Vad som visas för de 98 med rader men utan plats i kammaren styrs av designbeslut 3–4.
+- `rostresultat.ej_kopplade` och `aggregat` används inte: en historisk rad utan säkert uuid är ingen uppgift om ett visst parti, samma avgränsning som `storsta_utanfor_riksdagen` gör (`docs/riksdagsvalresultat.md`, punkt 3).
+- `scripts/validate.js` kräver att varje resultatfil har `status: "slutligt"`, en `mandatfordelning` med `antal_mandat: 349` och mandatrader som summerar till 349; importern (`scripts/riksdag-results.js`) skriver alltid `status: "slutligt"`, och `docs/riksdagsvalresultat.md` definierar modellen som slutliga resultat. Sidan får därför skriva "slutligt resultat" som fakta, och kammaråret är helt enkelt det senaste importerade valåret — samma val som `buildParliamentView()` kallar `kammare`. Preliminära resultat ligger utanför modellen och utanför detta issue (#35 får ta det om det behövs).
+- Att ta bort `valresultat` ur `profil.json` ändrar formen på en fil partisidan annonserar som maskinläsbar ("Profildata (JSON)" i `ExportSection`). Det är inte en teknisk blockering, men #26 (dokumenterat JSON-gränssnitt) ska nämna att fältet inte finns.
+
+## Angreppssätt
+
+**Datavägen.** `src/server/party-data.ts` läser redan alla `val/<år>/valresultat/riksdag.json` med `schema_version === 2` för startsidans `readParliamentYears()`. Läsningen bryts ut till en memoiserad `readParliamentResults()` (samma `??=`-mönster som `partyIndexPromise`), som både `readParliamentYears()` och den nya per-parti-härledningen använder. `ParliamentResultFile` utökas med `rostresultat` (`giltiga_roster`, `partier`) och `status`. `readCurrentParty()` slår upp partiets uuid i varje fil och bygger `valresultat`, som läggs på `PartyPageData` bredvid `candidateLists`.
+
+**Datamodellen** (`src/types.ts`; ersätter `PartiProfilValresultat`/`PartiProfilValresultatPost`):
+
+```ts
+export interface PartiValresultatPost {
+  valar: number;
+  roster: number;
+  rostandel: number;        // som lagrat i källfilen, två decimaler
+  mandat: number;           // 0 när partiet saknar mandatrad det året
+  forandring?: number;      // rostandel minus föregående importerade vals rostandel, två decimaler; se beslut 5
+  kalla: PartiProfilKalla;  // röstradens källa (kallreferens → kallor[])
+  mandatkalla?: PartiProfilKalla; // mandatradens källa, bara när den skiljer sig från röstradens (2010–2018)
+}
+
+export interface PartiValresultat {
+  valtyp: 'riksdag';
+  resultat: PartiValresultatPost[];         // stigande valår, bara år med kopplad röstrad
+  kammare?: { valar: number; mandat: number }; // finns bara när partiet har mandat i det senaste importerade valet; se beslut 3
+}
+```
+
+`kalla`/`mandatkalla` bär hela källobjektet ur filen (`id`, `titel`, `version`, `sha256` …) men typas `PartiProfilKalla`, precis som `ParliamentYear.kalla` på startsidan gör i dag. `readParliamentYears()` gör redan uppslaget `kallor.find(source => source.id === kallreferens)`; det blir en delad hjälpfunktion. Valfria fält (`forandring`, `mandatkalla`, `kammare`, `valresultat` självt) utelämnas med villkorad spridning (`...(x !== undefined ? { x } : {})`) — aldrig som explicit `undefined`, eftersom objektet blir `getServerSideProps`-props och Next serialiserar dem som JSON.
+
+**Ren härledning, testbar utan filsystem.** Själva beräkningen — rader per uuid, `mandat`, `forandring`, `kammare`, källuppslag — läggs i en exporterad ren funktion `partyElectionResults(files, uuid)` i `party-data.ts`, så att `scripts/party-data.test.js` kan testa den både via fixturer på disk (som `makeHomeData()` redan skriver) och direkt med filobjekt i minnet. Funktionen sorterar själv sin indata stigande med `toSorted()` och muterar aldrig den memoiserade listan.
+
+**Sidan.** `src/pages/parti/[filnamn].tsx` läser `valresultat` från props i stället för `profile?.valresultat`. `ProfileHero` får `results?: PartiValresultat` och renderar enligt beslut 4; `ElectionResultsSection` får `PartiValresultat` och renderar kammarblocket enligt beslut 3, källraderna per valår enligt beslut 6 och "Mot föregående val" ur `forandring`. `TurnoutSection` renderas när `valresultat` finns, som i dag.
+
+**Kurerade fältet.** `PartiProfil.valresultat` tas bort ur typen, `validatePartyProfile()` avvisar nyckeln med ett meddelande som pekar på importen, och de två `profil.json` som bär fältet får det borttaget. Sidorna för L och MP ska rendera samma siffror före och efter (kontrolleras i fas 5).
+
+**Smoke och dokumentation.** `scripts/http-smoke.js` får assertions som knyter partisidans mandat till `data/derived/riksdag.json` (samma siffra som startsidan) och som kontrollerar att ett parti utan resultat inte får någon sektion. `docs/riksdagsvalresultat.md` får ett avsnitt om partisidans härledning med samma numrerade regler som avsnittet om startsidan.
+
+### Kantfall härledningen ska klara (fas 1 förutsätter dessa)
+
+- **Röstrad utan mandatrad** → `mandat: 0`. Motsatsen (mandatrad utan röstrad) avvisas redan av `validate.js` ("mandatpartiet … saknar röstresultat") och behöver ingen hantering.
+- **Lucka i serien** (partiet ställde upp 2010 och 2022 men inte 2014/2018) → `resultat` innehåller bara 2010 och 2022; `forandring` för 2022 utelämnas eftersom föregående importerade val (2018) saknar rad för partiet. `forandring` för det första valet i serien utelämnas alltid.
+- **Senaste rad är inte kammaråret** (partiet hade mandat 2010, ingen rad sedan) → `kammare` saknas; heron visar partikoden i stället för mandatblocket, sektionen visar diagrammet men inget kammarblock.
+- **Mandat i kammaråret** → `kammare = { valar, mandat }` där `valar` är det senaste importerade valåret (validering garanterar att varje fil har en fullständig mandatfördelning, så det är samma val som `buildParliamentView()` kallar `kammare`). `kammare.mandat` är detsamma som den sista postens `mandat` när posten är kammaråret.
+- **Ett enda valår** → sektionens underrubrik blir "Riksdagsvalet ÅÅÅÅ" i stället för "Riksdagsval ÅÅÅÅ–ÅÅÅÅ"; `ElectionChart` klarar redan en punkt (`Math.max(1, results.length - 1)`).
+- **Flera källor i ett år** (2010–2018: röster från `resultat`, mandat från `mandat`) → `mandatkalla` sätts när mandatradens källobjekt (per `id`) skiljer sig från röstradens; 2006 har två källfiler men röstraden pekar ut vilken av dem som gäller.
+- **`val/<år>` utan `valresultat/`** (2026 i dag) → hoppas över, som `readParliamentYears()` gör.
+- **Klientnavigering mellan partisidor** → `ElectionResultsSection` initierar sitt valda index en gång (`useState(results.resultat.length - 1)`). Vid `next/link`-navigering från en sida med åtta poster till en med en post skulle index 7 stå kvar och sektionen returnera `null`. Sektionen monteras därför om per parti med `key={slug}` (steg 6).
+- **Inga resultatfiler alls** (testfixturen `makeData()`) → `valresultat` utelämnas ur props; sidan renderar som ett parti utan resultat.
+- **Avrundning** → `forandring` beräknas som `Number((a - b).toFixed(2))`, så att 5,08 − 4,41 inte blir 0,6699999… i props.
+
+## Steg
+
+### Fas 1: Härledningen i servern, med tester
+1. Utöka typerna i `src/types.ts`
+   - Lägg till `PartiValresultatPost` och `PartiValresultat` enligt datamodellen ovan, med docblock som anger att posterna härleds ur `val/<år>/valresultat/riksdag.json` och att `kammare` betyder mandat i det senaste val som har mandatfördelning
+   - Låt `PartiProfilValresultat`/`PartiProfilValresultatPost` och `PartiProfil.valresultat` stå kvar i detta steg — de tas bort i fas 3 när inget längre använder dem
+   - Filer att ändra: `src/types.ts`
+2. Bryt ut och memoisera läsningen av resultatfilerna i `src/server/party-data.ts`
+   - `ParliamentResultFile` får `status: string`, `rostresultat: { giltiga_roster: number; partier: Array<{ parti_uuid: string; roster: number; rostandel: number; kallreferens: string }> }`; `mandatfordelning.partier` finns redan
+   - Ny `readParliamentResults(): Promise<ParliamentResultFile[]>` — memoiserad med `parliamentResultsPromise ??=`, läser `electionYears()` och filtrerar på `schema_version === 2`, sorterad **stigande** på `valar`
+   - Ny hjälpfunktion `sourceFor(file, reference)` som gör det uppslag `readParliamentYears()` gör i dag (`kallor.find(source => source.id === reference)`), och kastar ett fel som namnger valår och referens när källan saknas (samma beteende som `sourceFor()` i `scripts/build-derived-data.js`)
+   - `readParliamentYears(byUuid)` skrivs om till att mappa över `readParliamentResults()` och sorterar sin egen projektion **fallande** (`.toSorted((a, b) => b.valar - a.valar)`, som i dag) utan att röra den delade listan; startsidans utdata ska vara byte-för-byte densamma (testet "mandate records resolve by stable uuid" förväntar `[2026, 2022]` och bevakar detta)
+   - Filer att ändra: `src/server/party-data.ts`
+3. Skriv den rena härledningen `partyElectionResults(files, uuid): PartiValresultat | undefined`
+   - Börja med `const ordered = files.toSorted((a, b) => a.valar - b.valar)`; returnera `undefined` direkt om listan är tom (inga resultatfiler — `makeData()`-fixturen); kammaråret är `ordered.at(-1).valar`
+   - För varje fil i ordning: hitta partiets röstrad; saknas den, hoppa över året. Annars bygg posten med `mandat` från mandatraden (0 om ingen), `kalla` via `sourceFor(file, rad.kallreferens)`, `mandatkalla` när mandatraden finns och dess källa har ett annat `id` än röstradens
+   - `forandring` sätts när föregående fil i listan (inte föregående post) innehåller en röstrad för partiet
+   - `kammare` sätts när partiet har en mandatrad med `mandat > 0` i kammarårets fil
+   - Returnera `undefined` när inga poster byggdes
+   - Exportera funktionen från modulen
+   - Filer att ändra: `src/server/party-data.ts`
+4. Koppla in i `readCurrentParty()` och `PartyPageData`
+   - `PartyPageData` får `valresultat?: PartiValresultat`
+   - `readCurrentParty()` läser `readParliamentResults()` parallellt med profil och kandidatlistor (utöka den befintliga `Promise.all`), anropar `partyElectionResults(files, party.uuid)` och sprider in `valresultat` bara när det finns (samma `...(x ? { x } : {})`-mönster som `profile`)
+   - Filer att ändra: `src/server/party-data.ts`
+5. Tester i `scripts/party-data.test.js`
+   - Observera att `makeHomeData()` redan skriver en 2026-fil där `betapartiet` har alla 349 mandat, så **2026 är kammaråret i den fixturen** — `alfapartiet` (rad 2022, ingen rad 2026) får därför inget `kammare`, och testet "mandate records resolve by stable uuid" (`[2026, 2022]`) ska stå orört
+   - Utöka `makeHomeData()` minimalt: låt `writeResult()` ta röstrader utan mandat (post utan `mandat`), och lägg till en röstrad för `zebrapartiet` 2022 utan mandat
+   - Nytt test (via store): `resolveParty('betapartiet').props.valresultat` deep-equals `{ valtyp: 'riksdag', resultat: [{ valar: 2026, roster: 1, rostandel: 100, mandat: 349, kalla: source }], kammare: { valar: 2026, mandat: 349 } }` — ingen `forandring` (första posten), ingen `mandatkalla`
+   - Nytt test (via store): `resolveParty('alfapartiet').props.valresultat` har en post (2022, `mandat: 200`) och inget `kammare`; `resolveParty('zebrapartiet')` har en post med `mandat: 0` och inget `kammare`
+   - Nya tester direkt mot `partyElectionResults(files, uuid)` med filobjekt i minnet (en lokal `resultFile(year, rows, sources)`-hjälpare som bygger samma form som `writeResult()`):
+     - 2018 (källor `resultat` + `mandat`, mandatrad med `kallreferens: 'mandat'`) och 2022 → `mandatkalla` 2018, `forandring` 2022 = `Number((r2022 - r2018).toFixed(2))`, `kammare` för 2022
+     - rad 2018 och 2026 men inte 2022 → två poster, ingen `forandring` på 2026
+     - rad 2018 men inte 2022 → sista posten 2018, inget `kammare`
+     - filer givna i fallande ordning → samma utdata (funktionen sorterar själv)
+     - uuid utan rad → `undefined`
+     - `kallreferens` som saknas i `kallor` → kastar med valår och referens i meddelandet
+     - inga explicita `undefined`-nycklar i utdata (`assert.ok(!('forandring' in post))` för första posten)
+   - Befintligt test för `makeData()`: assert att `valresultat` är `undefined` för båda partierna (inga resultatfiler)
+   - Befintliga tester för `home.riksdag` ska passera oförändrade
+   - Filer att ändra: `scripts/party-data.test.js`
+
+### Fas 2: Sidan och komponenterna läser den härledda datan
+6. `src/pages/parti/[filnamn].tsx`
+   - Plocka ut `valresultat` ur props; den lokala `latestResult` tas bort (heron härleder sista posten själv, företrädarsektionen använder `kammare`)
+   - `ProfileHero` får `results={valresultat}` i stället för `latestResult`
+   - `<ElectionResultsSection key={slug} results={valresultat} partyLabel={abbreviation} />` och `TurnoutSection` renderas när `valresultat` finns; `key={slug}` monterar om sektionen per parti så att det valda indexet aldrig överlever en klientnavigering till en sida med färre poster
+   - `RepresentativesSection mandateCount={valresultat?.kammare?.mandat}` (bara kammarmandat ska stå i underrubriken "partiet har N mandat")
+   - Filer att ändra: `src/pages/parti/[filnamn].tsx`
+7. `ProfileHero` i `src/components/party-profile/overview.tsx` (beslut 4)
+   - Prop `results?: PartiValresultat` ersätter `latestResult?: PartiProfilValresultatPost`
+   - Block 1: `results.kammare` → "Mandat i riksdagen · N av 349 · Valresultat ÅÅÅÅ"; annars partikodsblocket
+   - Block 2: `latest = results?.resultat.at(-1)` → "Riksdagsvalet ÅÅÅÅ · X %" med källrad `${latest.kalla.namn} · slutligt resultat` (validering garanterar att varje fil är slutlig); blocket utelämnas utan resultat
+   - `keyFactCount = (results?.kammare ? 2 : latest ? 2 : 1) + 1 + (founded ? 1 : 0)` — ett parti med röstrad men utan kammarmandat visar partikod + Riksdagsvalet, så räkningen är oförändrad i alla tre fallen; fyrspaltsläget (`profile-keyfacts--four`) täcker fortfarande maximum
+   - Filer att ändra: `src/components/party-profile/overview.tsx`
+8. `ElectionResultsSection` i `src/components/party-profile/elections.tsx` (beslut 3, 5, 6)
+   - Typer: `PartiValresultat`/`PartiValresultatPost`
+   - Underrubrik: `resultat.length > 1 ? \`Riksdagsval ${first}–${last}, …\` : \`Riksdagsvalet ${first}, …\``
+   - `sourceNames = [...new Set(results.resultat.map(post => post.kalla.namn))]` — samma mönster som `turnoutSourceNames` i `TurnoutSection`. Sektionsheaderns brand-text (`<small>valresultat · slutlig rösträkning</small>`) och introns `SourceLine` ("Valmyndigheten · slutlig rösträkning") byts till `${sourceNames.join(' och ')} · slutligt resultat`, så att 1994/1998 (SCB) inte tillskrivs Valmyndigheten; Valmyndigheten-bilden i branden står kvar (beslut 6)
+   - Vald post: "Mot föregående val" visar `forandring` med tecken när det finns, annars "—"; headerns källtext blir `${result.kalla.namn} · slutligt resultat` i stället för det hårdkodade "Valmyndigheten · slutligt resultat"
+   - Kammarblocket (`profile-results__bottom`) renderas bara när `results.kammare` finns; "Partiets N platser i kammaren" använder `kammare.mandat`
+   - Källblocket (`profile-results__sources`): en `SourceLine` per post, med valåret som prefix (`<SourceLine source={post.kalla}>Riksdagsvalet {post.valar} · </SourceLine>`), följd av en rad för `mandatkalla` när den finns ("Riksdagsvalet ÅÅÅÅ, mandat · "). Nyckel `${valar}-${kalla.url}`
+   - `chamberComposition`/`ChamberDiagram`/`TurnoutSection` oförändrade
+   - Filer att ändra: `src/components/party-profile/elections.tsx`
+9. Stil
+   - Kontrollera att `.profile-results__sources` tål 8–11 rader (MP: 8 valår + 3 mandatkällor); om raderna behöver radbrytas som en lista, justera i `src/styles/_party-profile.scss`. Sannolikt ingen ändring
+   - Filer att ändra (vid behov): `src/styles/_party-profile.scss`
+
+### Fas 3: Ta bort det kurerade fältet
+10. Typer: ta bort `PartiProfilValresultat`, `PartiProfilValresultatPost` och `PartiProfil.valresultat` ur `src/types.ts`; `npm run typecheck` ska visa att inget refererar dem längre
+    - Filer att ändra: `src/types.ts`
+11. Validering: i `validatePartyProfile()` ersätt blocket `if (profile.valresultat !== undefined) { … }` med `assert.equal(profile.valresultat, undefined, \`${context}.valresultat ska inte finnas; valresultat härleds ur val/<år>/valresultat/riksdag.json\`)`
+    - `scripts/validate.test.js`: deltestet "invalid curated election results" byts till "curated election results are rejected" och förväntar det nya meddelandet
+    - Filer att ändra: `scripts/validate.js`, `scripts/validate.test.js`
+12. Data: ta bort nyckeln `valresultat` ur `data/parti/liberalerna-tidigare-folkpartiet/profil.json` och `data/parti/miljopartiet-de-grona/profil.json`. Övriga nycklar och ordning orörda. `npm run validate:data` ska passera; `node scripts/parti.js` ska vara no-diff (skriptet rör inte `profil.json`)
+    - Filer att ändra: `data/parti/liberalerna-tidigare-folkpartiet/profil.json`, `data/parti/miljopartiet-de-grona/profil.json`
+
+### Fas 4: Smoke-test och dokumentation
+13. `scripts/http-smoke.js`
+    - `current` (Miljöpartiet) är ett kammarparti: assert att blocket `<dt>Mandat i riksdagen</dt><dd>N <span>av 349</span></dd>` finns med exakt `N = chamber.partier.find(party => party.parti_uuid === current.uuid).mandat` (regexen omfattar `<dt>` och `<dd>` tillsammans, så en annan förekomst av samma tal på sidan inte kan uppfylla den; samma värde som startsidans riksdagssektion renderar för samma år — det är acceptanskriteriet "kan inte skilja sig"), `<section class="profile-results"` och `id="deltagande"`
+    - Välj datadrivet ett parti med röstrad men utan mandat i kammaråret: läs `data/val/<chamber.valar>/valresultat/riksdag.json`, ta första (i `filnamn`-ordning) `rostresultat.partier`-uuid som saknas i `mandatfordelning.partier` och finns i registret; assert att dess sida har `profile-results` och `id="deltagande"` men varken `<dt>Mandat i riksdagen</dt>` eller "platser i kammaren"
+    - `withoutParticipation` (Ångfärjepartiet) saknar resultat: assert först, mot datan, att dess uuid inte förekommer i någon `rostresultat.partier` i `data/val/*/valresultat/riksdag.json` (så att en framtida import som ger partiet en rad felar med ett begripligt meddelande i stället för en förbryllande sidassertion); assert sedan `doesNotMatch /profile-results/`, `doesNotMatch /id="deltagande"/` och `doesNotMatch /<dt>Mandat i riksdagen<\/dt>/`, bredvid den befintliga Grundat-assertionen
+    - Filer att ändra: `scripts/http-smoke.js`
+14. `docs/riksdagsvalresultat.md`: nytt avsnitt "Partisidan" efter "Största partierna utanför riksdagen", med numrerade regler: (1) posterna är partiets uuid-kopplade röstrader per valår, (2) mandat från mandatfördelningen, 0 utan rad, (3) förändring mot föregående importerade val bara när partiet har rad i båda, (4) kammarmandat bara i det senaste valet med mandatfördelning, (5) källan står per rad; ej kopplade rader och aggregat används inte. Notera att `profil.json` inte bär valresultat
+    - Filer att ändra: `docs/riksdagsvalresultat.md`
+15. `README.md`: i avsnittet `val/<år>/valresultat/riksdag.json` (rad 115–117) lägg till en mening om att partisidan härleder sina resultat ur filen, med länk till det nya avsnittet
+    - Filer att ändra: `README.md`
+
+### Fas 5: Verifiering
+16. `npm run precommit` (lint, typecheck, check:derived-data, validate:data, test, build:release, test:http) grönt
+17. Manuell kontroll i `npm run dev`:
+    - `/parti/miljopartiet-de-grona/` och `/parti/liberalerna-tidigare-folkpartiet/`: samma procent och mandat som före ändringen, plus röstetal i "Röster" (tidigare "—") och L:s serie börjar 1994
+    - `/parti/partiet-nyans/` (röstrad 2022, inga mandat): hero med partikod + "Riksdagsvalet 2022 0,44 %", sektion med diagram, inget kammarblock, "Mot föregående val" enligt 2018-raden om den finns
+    - Ett parti med bara historiska rader (sök i `data/val/2010/…` efter ett uuid som saknas 2014–2022): sektionen visar serien, heron visar partikod, inget kammarblock
+    - `/parti/angfarjepartiet/`: ingen resultatsektion, ingen valdeltagandesektion
+    - Klientnavigering: ingen direktlänk mellan två partisidor finns i dagens UI (partisidan länkar bara till startsidan, som avmonterar sektionen), så fallet är inte nåbart manuellt; `key={slug}` behålls som billigt skydd inför framtida länkar (t.ex. #21) och verifieras genom kodläsning
+    - Startsidans riksdagssektion oförändrad
+
+## Filöversikt
+
+| Fil | Åtgärd | Syfte |
+|-----|--------|-------|
+| `src/types.ts` | Ändra | `PartiValresultat`/`PartiValresultatPost`; `PartiProfil.valresultat` och de gamla profiltyperna bort |
+| `src/server/party-data.ts` | Ändra | Memoiserad läsning av resultatfilerna, `partyElectionResults()`, `PartyPageData.valresultat` |
+| `scripts/party-data.test.js` | Ändra | Fixturer med röstrader utan mandat och två källor; tester för härledningen och kantfallen |
+| `src/pages/parti/[filnamn].tsx` | Ändra | Läser `valresultat` ur props i stället för profilen |
+| `src/components/party-profile/overview.tsx` | Ändra | Hero: mandatblock bara för kammarpartier, källrad ur posten |
+| `src/components/party-profile/elections.tsx` | Ändra | Ny typ, kammarblock villkorat, `forandring`, källrad per valår, underrubrik för ett år |
+| `src/styles/_party-profile.scss` | Ändra (vid behov) | Källistan i resultatsektionen |
+| `scripts/validate.js` | Ändra | Avvisar `profil.valresultat` med hänvisning till importen |
+| `scripts/validate.test.js` | Ändra | Deltestet för det kurerade fältet speglar avvisningen |
+| `data/parti/liberalerna-tidigare-folkpartiet/profil.json` | Ändra | `valresultat` borttaget |
+| `data/parti/miljopartiet-de-grona/profil.json` | Ändra | `valresultat` borttaget |
+| `scripts/http-smoke.js` | Ändra | Assertions: kammarparti, parti utan mandat, parti utan resultat; samma siffra som `derived/riksdag.json` |
+| `docs/riksdagsvalresultat.md` | Ändra | Avsnittet "Partisidan" med härledningsreglerna |
+| `README.md` | Ändra | Meningen om partisidan under `val/<år>/valresultat/riksdag.json` |
+
+## Berörda kodområden
+
+- `src/server/` (`party-data.ts`)
+- `src/components/party-profile/` (`overview.tsx`, `elections.tsx`)
+- `src/pages/parti/`
+- `src/types.ts`
+- `scripts/` (`validate.js`, `http-smoke.js`, tester)
+- `data/parti/<filnamn>/profil.json` (två filer)
+- `docs/`, `README.md`
+
+## Designbeslut
+
+> Icke-triviala val gjorda under planeringen. Feedback välkommen; annars implementeras enligt dessa.
+
+### 1. Det kurerade fältet tas bort, inte behålls som override
+**Alternativ:** A) ta bort `profil.valresultat` helt; B) behålla det som override för resultat importen inte kan uttrycka; C) behålla det men låta validate kräva att det stämmer med importen.
+**Beslut:** A.
+**Motivering:** Issuets kriterium för B — "only if it can carry something the imported data cannot" — är prövat mot datan och faller: varje kurerad siffra finns i importen, och importen har mer. B skulle dessutom göra "samma siffra kan inte skilja sig" till något validering måste bevaka i stället för något strukturen garanterar. C är B med extra kod för ett fält utan innehåll. Att validering aktivt *avvisar* nyckeln (steg 11) är agentens bedömning: `validatePartyProfile()` släpper i dag igenom okända nycklar tyst, och ett kvarglömt `valresultat` skulle då bli en oanvänd påstådd källa i en publicerad datafil. **Proveniens:** användarbeslut för själva riktningen (issue #76: "the work here is … to remove the duplication"); agentens bedömning för att avvisa nyckeln — öppen att ifrågasätta.
+
+### 2. Härledningen sker vid request i `party-data.ts`, inte som en ny derived-fil
+**Alternativ:** A) `partyElectionResults()` i `src/server/party-data.ts` över de memoiserade resultatfilerna; B) ett nytt `data/derived/valresultat/<filnamn>.json` (eller en per-parti-del i `derived/riksdag.json`) byggt av `scripts/build-derived-data.js`.
+**Beslut:** A.
+**Motivering:** Issuet säger uttryckligen "the way the start page already does", och startsidans mandat läses vid request ur `val/<år>/valresultat/riksdag.json` av `readParliamentYears()` — alltså samma filer, samma modul, samma cache-mönster. Acceptanskriteriet "same validated files as the start page's overviews" uppfylls bokstavligt. B skulle ge 106 committade filer (eller en stor) som `check:derived-data` måste bevaka och som avviker från hur sidan i övrigt läser partidata. Kostnaden för A är åtta små JSON-filer lästa en gång per process — samma kostnad startsidan redan betalar. **Proveniens:** befintlig konvention (`readParliamentYears()` i `src/server/party-data.ts`); valet mellan A och B är agentens bedömning.
+
+### 3. "Kammarmandat" betyder mandat i det senaste importerade valet
+**Alternativ:** A) kammarblock och "Mandat i riksdagen" visas när partiets *senaste post* har `mandat > 0`; B) bara när partiet har mandat i *kammaråret* (det senaste importerade valet — validering garanterar att varje fil har en fullständig mandatfördelning, så det är samma val som `buildParliamentView()` kallar `kammare`).
+**Beslut:** B, uttryckt som `PartiValresultat.kammare`.
+**Motivering:** Med A skulle ett parti vars senaste rad är 2010 med 3 mandat få "Partiets 3 platser i kammaren" ovanpå ett kammardiagram för 2022 — en falsk uppgift. `data/derived/riksdag.json` och startsidan definierar redan kammaren som det senaste valet; partisidan ska säga samma sak. Kammarblocket, mandatblocket i heron och `mandateCount` i företrädarsektionen styrs alla av `kammare`. **Proveniens:** befintlig konvention för definitionen (`scripts/build-derived-data.js`, `docs/riksdagsvalresultat.md` punkt 2); att koda den som ett eget fält är agentens bedömning.
+
+### 4. Partier med röstrad men utan kammarmandat får sektionen och ett hero-block
+**Alternativ:** A) sektion och "Riksdagsvalet ÅÅÅÅ X %" i heron för varje parti med minst en kopplad röstrad, partikoden kvar som första block; B) bara partier som någon gång haft mandat; C) en tröskel (t.ex. ≥ 1 % någon gång).
+**Beslut:** A.
+**Motivering:** Partidata återger Valmyndighetens siffror som de är; 0,44 % för Partiet Nyans eller 0,00 % (6 röster) för ett litet parti är sanna, källbelagda uppgifter om just det partiet, och sidan visar dem med samma källrad som riksdagspartierna. B och C är redaktionella val om vilka resultat som "räknas", vilket projektet i övrigt undviker (jfr #75, #77 i #68). Konsekvensen är att ~98 sidor får en sektion med ett diagram där mandatremsan visar nollor — det är läsbart och sant. Hero-räkningen förblir tre block (partikod, Riksdagsvalet, deltagande) plus eventuellt Grundat. **Proveniens:** agentens bedömning, öppen att ifrågasätta — särskilt 0,00 %-fallen. Om användaren vill ha en tröskel är den en enradig ändring i `partyElectionResults()` (filtrera på `roster`), inte en strukturändring.
+
+### 5. "Mot föregående val" beräknas i servern mot föregående *importerade* val
+**Alternativ:** A) komponenten jämför med föregående post i partiets serie (dagens beteende); B) servern sätter `forandring` bara när partiet har rad i det närmast föregående importerade valet.
+**Beslut:** B.
+**Motivering:** A ger för ett parti med rader 2010 och 2022 en "förändring mot föregående val" som i själva verket spänner tolv år och två val. Komponenten känner inte till vilka val som finns; servern gör det. Att räkna i servern gör regeln testbar i `node:test` utan React. Fältet utelämnas (inte 0) när jämförelsen inte finns, så komponenten renderar "—". **Proveniens:** agentens bedömning.
+
+### 6. Källan står per valår i sektionen, inte som en deduplicerad lista
+**Alternativ:** A) `PartiValresultat.kallor` som deduplicerad union av alla års källor, renderad som i dag (`results.kallor.map(SourceLine)`); B) `kalla`/`mandatkalla` per post, renderade en rad per valår med året som prefix.
+**Beslut:** B.
+**Motivering:** Källorna skiljer sig per år (SCB 1994–1998, Valmyndighetens arkivsidor 2002–2018 med separat mandatsida 2010–2018, JSON 2022) men har samma `namn` och `hamtad`, så A skulle rendera nio rader som alla lyder "Valmyndigheten · hämtat 2026-08-26" med olika länkar — oläsbart. Med B blir varje rad urskiljbar ("Riksdagsvalet 1994 · SCB · hämtat …"), och den valda postens header kan namnge sin egen källa i stället för det hårdkodade "Valmyndigheten", vilket i dag är fel för 1994 och 1998 (SCB). Samma sak gäller de två hårdkodade "Valmyndigheten · slutlig rösträkning"-texterna i sektionsheadern och intron: de byts till seriens källnamn ("SCB och Valmyndigheten · slutligt resultat" för MP), efter mönstret `turnoutSourceNames` i `TurnoutSection`. Valmyndigheten-bilden i `SectionHeader`-branden står kvar — Valmyndigheten är valmyndigheten även när SCB publicerade tabellen — men det är en bedömning värd att pröva. "Slutligt resultat" skrivs som fast text eftersom `validate.js` kräver `status: "slutligt"` i varje fil. **Proveniens:** agentens bedömning.
+
+## Verifieringschecklista
+
+- [ ] Partisidans resultat kommer ur `val/<år>/valresultat/riksdag.json` via `src/server/party-data.ts`; inget läses ur `profil.json` (acceptanskriterium 1)
+- [ ] `scripts/http-smoke.js` kontrollerar att Miljöpartiets mandat på partisidan är samma siffra som `data/derived/riksdag.json` kammare (acceptanskriterium 2)
+- [ ] Ångfärjepartiet (och varje parti utan kopplad röstrad) renderar varken resultatsektion, valdeltagandesektion eller "Mandat i riksdagen" (acceptanskriterium 3)
+- [ ] `npm run validate:data` avvisar `profil.valresultat`; `scripts/party-data.test.js` täcker härledningen inklusive kantfallen i "Angreppssätt" (acceptanskriterium 4)
+- [ ] L och MP visar samma procent och mandat som före ändringen; "Röster" är ifyllt; L:s serie börjar 1994
+- [ ] Parti med röstrad utan mandat: hero med partikod + "Riksdagsvalet ÅÅÅÅ", sektion utan kammarblock, mandatremsa med 0
+- [ ] Parti vars senaste rad inte är kammaråret: inget kammarblock, inget mandatblock i heron
+- [ ] "Mot föregående val" visar "—" för första posten och vid lucka i serien
+- [ ] Källraderna i sektionen namnger SCB för 1994/1998 och länkar mandatkällan separat 2010–2018; sektionsheader och intro namnger seriens källor, inte enbart Valmyndigheten
+- [ ] Parti med röstrad utan mandat får valdeltagandesektionen (`id="deltagande"`); parti utan resultat får den inte (smoke)
+- [ ] Klientnavigering från en sida med många poster till en med en post renderar sektionen (`key={slug}`)
+- [ ] Props innehåller inga explicita `undefined`-värden (`forandring`, `mandatkalla`, `kammare`, `valresultat` utelämnas)
+- [ ] Startsidans riksdagssektion och "största utanför riksdagen" är oförändrade (befintliga tester och smoke)
+- [ ] `node scripts/parti.js` och `npm run check:derived-data` är no-diff
+- [ ] `npm run precommit` grönt

--- a/agent-docs/issue/76-derive-party-page-election-results/progress.md
+++ b/agent-docs/issue/76-derive-party-page-election-results/progress.md
@@ -1,0 +1,37 @@
+# Framsteg: Issue #76 — Derive the party page's election results from the imported results
+
+**Påbörjad:** 2026-08-30
+**Senast uppdaterad:** 2026-08-30
+**Status:** Klar
+
+## Genomförda steg
+
+- [x] Fas 1, steg 1: `PartiValresultat`/`PartiValresultatPost` i `src/types.ts`
+- [x] Fas 1, steg 2: `readParliamentResults()` memoiserad, `sourceFor()` delad, `readParliamentYears()` läser den delade listan
+- [x] Fas 1, steg 3: `partyElectionResults(files, uuid)` som ren, exporterad funktion
+- [x] Fas 1, steg 4: `PartyPageData.valresultat` fylld i `readCurrentParty()`
+- [x] Fas 1, steg 5: fixturen tar röstrader utan mandat; tester via store och direkt mot härledningen
+- [x] Fas 2, steg 6: `src/pages/parti/[filnamn].tsx` läser `valresultat` ur props, `key={slug}`
+- [x] Fas 2, steg 7: `ProfileHero` visar mandatblocket bara för kammarpartier
+- [x] Fas 2, steg 8: `ElectionResultsSection` med villkorat kammarblock, `forandring`, källrad per valår
+- [x] Fas 2, steg 9: `.profile-results__sources` lämnad orörd — flex-wrap bär de elva raderna
+- [x] Fas 3, steg 10: de kurerade profiltyperna borttagna
+- [x] Fas 3, steg 11: `validatePartyProfile()` avvisar nyckeln; deltestet speglar avvisningen
+- [x] Fas 3, steg 12: `valresultat` borttaget ur de två `profil.json`
+- [x] Fas 4, steg 13: smoke knyter partisidans mandat till `derived/riksdag.json`
+- [x] Fas 4, steg 14: avsnittet "Partisidan" i `docs/riksdagsvalresultat.md`
+- [x] Fas 4, steg 15: meningen om partisidan i `README.md`
+- [x] Fas 5, steg 16: `npm run precommit` grönt
+- [x] Fas 5, steg 17: manuell kontroll mot `.release`
+
+## Pågående arbete
+
+Inget — alla faser är genomförda.
+
+## Anteckningar
+
+De kurerade siffrorna för Liberalerna och Miljöpartiet kontrollerades rad för rad mot importen innan fältet togs bort: varje `rostandel` och `mandat` stämde exakt. Efter härledningen visar båda sidorna samma procent och mandat som förut, med röstetal ifyllda och Liberalernas serie utökad till 1994.
+
+Kantfallet "senaste rad är inte kammaråret för ett parti som haft mandat" finns inte i datan — varje parti som någon gång haft mandat har också en röstrad 2022 — så det täcks bara av testerna mot `partyElectionResults()`.
+
+Källistan i resultatsektionen växer från två rader till elva för Miljöpartiet. `.profile-results__sources` är en `flex-wrap`-rad och bär dem strukturellt; hur tätt de elva posterna läser är värt ett ögonkast i granskningen.

--- a/data/parti/liberalerna-tidigare-folkpartiet/profil.json
+++ b/data/parti/liberalerna-tidigare-folkpartiet/profil.json
@@ -15,29 +15,6 @@
       "hamtad": "2026-08-24"
     }
   },
-  "valresultat": {
-    "valtyp": "riksdag",
-    "kallor": [
-      {
-        "namn": "Valmyndigheten – tidigare valresultat 2002–2018",
-        "url": "https://www.val.se/valresultat-och-statistik/riksdags--region--och-kommunval/tidigare-valresultat",
-        "hamtad": "2026-08-24"
-      },
-      {
-        "namn": "Valmyndigheten – valresultat 2022",
-        "url": "https://www.val.se/valresultat-och-statistik/riksdags--region--och-kommunval/valresultat-2022",
-        "hamtad": "2026-08-24"
-      }
-    ],
-    "resultat": [
-      { "valar": 2002, "rostandel": 13.39, "mandat": 48 },
-      { "valar": 2006, "rostandel": 7.54, "mandat": 28 },
-      { "valar": 2010, "rostandel": 7.06, "mandat": 24 },
-      { "valar": 2014, "rostandel": 5.42, "mandat": 19 },
-      { "valar": 2018, "rostandel": 5.49, "mandat": 20 },
-      { "valar": 2022, "rostandel": 4.61, "mandat": 16 }
-    ]
-  },
   "dokument": [
     {
       "typ": "valmanifest",

--- a/data/parti/miljopartiet-de-grona/profil.json
+++ b/data/parti/miljopartiet-de-grona/profil.json
@@ -126,24 +126,6 @@
     { "namn": "Nils Seye Larsen", "uppdrag": "Riksdagsledamot för Miljöpartiet.", "url": "https://www.mp.se/om/nils-seye-larsen/", "bild": "/img/partier/miljopartiet-de-grona/representanter/nils-seye-larsen.jpg" },
     { "namn": "Mohamed Yassin", "uppdrag": "Ledamot i kommunfullmäktige och gymnasie- och vuxenutbildningsnämnden.", "url": "https://www.mp.se/om/mohamed-yassin/", "bild": "/img/partier/miljopartiet-de-grona/representanter/mohamed-yassin.jpg" }
   ],
-  "valresultat": {
-    "valtyp": "riksdag",
-    "kallor": [
-      { "namn": "SCB – historisk valstatistik 1910–2022", "url": "https://www.scb.se/hitta-statistik/statistik-efter-amne/demokrati/allmanna-val/allmanna-val-valresultat/pong/tabell-och-diagram/historisk-valstatistik/historisk-statistik-over-valaren-19102022.-procentuell-fordelning-av-giltiga-valsedlar-efter-parti-och-typ-av-val/", "hamtad": "2026-08-25" },
-      { "namn": "Valmyndigheten – tidigare valresultat 2002–2018", "url": "https://www.val.se/valresultat-och-statistik/riksdags--region--och-kommunval/tidigare-valresultat", "hamtad": "2026-08-24" },
-      { "namn": "Valmyndigheten – valresultat 2022", "url": "https://www.val.se/valresultat-och-statistik/riksdags--region--och-kommunval/valresultat-2022", "hamtad": "2026-08-24" }
-    ],
-    "resultat": [
-      { "valar": 1994, "rostandel": 5.02, "mandat": 18 },
-      { "valar": 1998, "rostandel": 4.5, "mandat": 16 },
-      { "valar": 2002, "rostandel": 4.65, "mandat": 17 },
-      { "valar": 2006, "rostandel": 5.24, "mandat": 19 },
-      { "valar": 2010, "rostandel": 7.34, "mandat": 25 },
-      { "valar": 2014, "rostandel": 6.89, "mandat": 25 },
-      { "valar": 2018, "rostandel": 4.41, "mandat": 16 },
-      { "valar": 2022, "rostandel": 5.08, "mandat": 18 }
-    ]
-  },
   "nyheter": [
     {
       "datum": "2026-08-20",

--- a/docs/riksdagsvalresultat.md
+++ b/docs/riksdagsvalresultat.md
@@ -49,6 +49,18 @@ Startsidan använder den deterministiska härledningen i `data/derived/riksdag.j
 
 Avgränsningen i punkt 3 är viktig för de äldsta SCB-tabellerna, där mindre partier endast publicerades som ett gemensamt `Övriga partier`. Startsidan påstår därför inte att ett okänt parti i ett historiskt aggregat hade ett visst resultat.
 
+## Partisidan
+
+Partisidans valresultat härleds vid request ur samma filer, per parti:
+
+1. Posterna är partiets uuid-kopplade rader i `rostresultat.partier`, en per valår partiet har en rad i, i stigande ordning.
+2. Mandaten kommer ur `mandatfordelning.partier` samma år, och är 0 för ett år utan mandatrad.
+3. Förändringen mot föregående val sätts bara när partiet har en rad i både valet och det närmast föregående importerade valet.
+4. Kammarmandat redovisas bara för det senaste importerade valet. Ett parti vars senaste rad är äldre får diagrammet men inget kammarblock.
+5. Källan står per valår, och mandatkällan separat de år mandaten är hämtade från en annan sida än rösterna.
+
+Ej kopplade rader och aggregat används inte, av samma skäl som i punkt 3 ovan. Ett parti utan kopplad röstrad i något valår får varken resultatsektion eller valdeltagandesektion. `profil.json` bär inga valresultat.
+
 ## Import
 
 Importeraren läser lokala kopior av primärkällorna. Hämtdatum måste anges uttryckligen, så samma filer och argument alltid ger identiska JSON-byte.

--- a/scripts/http-smoke.js
+++ b/scripts/http-smoke.js
@@ -35,6 +35,17 @@ function electionYears (projectRoot) {
     .toSorted();
 }
 
+/** Every imported parliamentary result file, oldest first. */
+function parliamentResults (projectRoot) {
+  const electionRoot = path.join(projectRoot, 'data', 'val');
+  return fs.readdirSync(electionRoot, { withFileTypes: true })
+    .filter(entry => entry.isDirectory() && /^\d{4}$/.test(entry.name))
+    .map(entry => path.join(electionRoot, entry.name, 'valresultat', 'riksdag.json'))
+    .filter(file => fs.existsSync(file))
+    .map(file => JSON.parse(fs.readFileSync(file, 'utf8')))
+    .toSorted((a, b) => a.valar - b.valar);
+}
+
 /** The parties standing in one election, which is what a chosen year narrows to. */
 function standingParties (projectRoot, parties, year) {
   const participating = new Set(JSON.parse(fs.readFileSync(
@@ -79,6 +90,11 @@ function expectedGrid (parties) {
 /** The "N av M" the results heading carries, whichever way React split the text. */
 function countPattern (matched, total) {
   return new RegExp(`>${matched}(<!-- -->)? av (<!-- -->)?${total}</span>`);
+}
+
+/** The "N av 349" of the hero's seat block, whichever way React split the text. */
+function seatPattern (seats) {
+  return new RegExp(`<dt>Mandat i riksdagen</dt><dd>${seats}(<!-- -->)? <span>av 349</span></dd>`);
 }
 
 /** The markup of one segmented control, cut out by the legend that names it. */
@@ -173,6 +189,30 @@ async function main () {
   assert.ok(cleanedSlug);
   assert.ok(withSymbol);
   assert.ok(founded?.grundat, `${current.filnamn} har ett grundandedatum från Wikidata`);
+
+  const results = parliamentResults(projectRoot);
+  assert.ok(results.length > 0, 'riksdagsresultat är importerade');
+  const chamberResult = results.at(-1);
+  assert.equal(chamberResult.valar, chamber.valar, 'kammaråret är det senaste importerade valet');
+  const currentSeats = chamberResult.mandatfordelning.partier.find(party => party.parti_uuid === current.uuid);
+  assert.ok(currentSeats, `${current.filnamn} har mandat i kammaren`);
+  assert.equal(
+    currentSeats.mandat,
+    chamber.partier.find(party => party.parti_uuid === current.uuid).mandat,
+    'partisidans mandat är samma siffra som startsidans riksdagssektion'
+  );
+  const seated = new Set(chamberResult.mandatfordelning.partier.map(party => party.parti_uuid));
+  const byUuid = new Map(parties.map(party => [party.uuid, party]));
+  const withoutSeats = chamberResult.rostresultat.partier
+    .map(row => byUuid.get(row.parti_uuid))
+    .filter(party => party && !seated.has(party.uuid))
+    .toSorted((a, b) => a.filnamn < b.filnamn ? -1 : a.filnamn > b.filnamn ? 1 : 0)
+    .at(0);
+  assert.ok(withoutSeats, `valet ${chamber.valar} har ett registrerat parti utan mandat`);
+  assert.ok(
+    !results.some(result => result.rostresultat.partier.some(row => row.parti_uuid === withoutParticipation.uuid)),
+    `${withoutParticipation.filnamn} saknar röstrad i varje importerat riksdagsval`
+  );
 
   const port = await freePort();
   const baseUrl = `http://127.0.0.1:${port}`;
@@ -301,6 +341,17 @@ async function main () {
       'källraden länkar till Wikidata med Q-id:t synligt'
     );
     assert.match(profileBody, new RegExp(`hämtat <!-- -->${founded.hamtad}`), 'källraden anger hämtdatumet');
+    assert.match(profileBody, seatPattern(currentSeats.mandat), 'partisidan visar kammarmandaten från de importerade resultaten');
+    assert.match(profileBody, /<section class="profile-results"/, 'ett parti med resultat får resultatsektionen');
+    assert.match(profileBody, /id="deltagande"/, 'ett parti med resultat får valdeltagandesektionen');
+
+    const withoutSeatsProfile = await fetch(`${baseUrl}/parti/${withoutSeats.filnamn}/`);
+    assert.equal(withoutSeatsProfile.status, 200);
+    const withoutSeatsBody = await withoutSeatsProfile.text();
+    assert.match(withoutSeatsBody, /<section class="profile-results"/, 'ett parti med röstrad men utan mandat får resultatsektionen');
+    assert.match(withoutSeatsBody, /id="deltagande"/, 'ett parti med röstrad men utan mandat får valdeltagandesektionen');
+    assert.doesNotMatch(withoutSeatsBody, /<dt>Mandat i riksdagen<\/dt>/, 'ett parti utan mandat får inget mandatblock');
+    assert.doesNotMatch(withoutSeatsBody, /platser i kammaren/, 'ett parti utan mandat får inget kammarblock');
 
     const duplicateProfile = await fetch(`${baseUrl}/parti/${duplicate.filnamn}/`);
     assert.equal(duplicateProfile.status, 200);
@@ -313,6 +364,9 @@ async function main () {
     const withoutParticipationBody = await withoutParticipationProfile.text();
     assert.match(withoutParticipationBody, /Inget registrerat deltagande/);
     assert.doesNotMatch(withoutParticipationBody, /<dt>Grundat<\/dt>/, 'ett parti utan Wikidata-uppgift får ingen tom platshållare');
+    assert.doesNotMatch(withoutParticipationBody, /profile-results/, 'ett parti utan resultat får ingen resultatsektion');
+    assert.doesNotMatch(withoutParticipationBody, /id="deltagande"/, 'ett parti utan resultat får ingen valdeltagandesektion');
+    assert.doesNotMatch(withoutParticipationBody, /<dt>Mandat i riksdagen<\/dt>/, 'ett parti utan resultat får inget mandatblock');
 
     const redirect = await fetch(`${baseUrl}/parti/${previous.tidigare_filnamn[0]}/`, { redirect: 'manual' });
     assert.equal(redirect.status, 308);

--- a/scripts/party-data.test.js
+++ b/scripts/party-data.test.js
@@ -4,7 +4,7 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 
-const { createPartyDataStore } = require('../src/server/party-data.ts');
+const { createPartyDataStore, partyElectionResults } = require('../src/server/party-data.ts');
 
 function writeJson (root, relativePath, value) {
   const file = path.join(root, relativePath);
@@ -64,6 +64,7 @@ test('party data resolves current, previous and unknown slugs', async t => {
   assert.equal(current.props.profile.namn, 'Testpartiet');
   assert.deepEqual(current.props.candidateLists, { 2018: ['R', 'K'] });
   assert.equal(current.props.symbolSrc, '/partisymbol/testpartiet/9001-testpartiet.png');
+  assert.equal(current.props.valresultat, undefined, 'utan resultatfiler härleds inga valresultat');
   assert.deepEqual(await store.resolveParty('gamla-testpartiet'), {
     kind: 'redirect',
     destination: '/parti/testpartiet/'
@@ -78,6 +79,7 @@ test('optional profile and candidate lists may be absent', async t => {
   const result = await createPartyDataStore(dataRoot).resolveParty('utan-profil');
   assert.equal(result.kind, 'party');
   assert.equal(result.props.profile, undefined);
+  assert.equal(result.props.valresultat, undefined);
   assert.deepEqual(result.props.candidateLists, {});
 });
 
@@ -239,7 +241,8 @@ function makeHomeData () {
     hamtad: '2026-08-25',
     sha256: 'a'.repeat(64)
   };
-  function writeResult (year, mandates) {
+  // A row without `mandat` stood in the election without winning a seat.
+  function writeResult (year, rows) {
     writeJson(dataRoot, `val/${year}/valresultat/riksdag.json`, {
       schema_version: 2,
       valtyp: 'riksdag',
@@ -248,14 +251,14 @@ function makeHomeData () {
       kallor: [source],
       valdeltagande: { procent: 84, kallreferens: 'resultat' },
       rostresultat: {
-        giltiga_roster: mandates.length,
+        giltiga_roster: rows.length,
         kallreferenser: ['resultat'],
-        partier: mandates.map(entry => ({
+        partier: rows.map(entry => ({
           parti_uuid: entry.uuid,
           kallkod: entry.forkortning,
           partibeteckning: entry.forkortning,
           roster: 1,
-          rostandel: Number((100 / mandates.length).toFixed(2)),
+          rostandel: Number((100 / rows.length).toFixed(2)),
           kallreferens: 'resultat'
         })),
         ej_kopplade: [],
@@ -264,7 +267,7 @@ function makeHomeData () {
       mandatfordelning: {
         antal_mandat: 349,
         kallreferenser: ['resultat'],
-        partier: mandates.map(entry => ({
+        partier: rows.filter(entry => entry.mandat !== undefined).map(entry => ({
           parti_uuid: entry.uuid,
           kallkod: entry.forkortning,
           partibeteckning: entry.forkortning,
@@ -277,13 +280,14 @@ function makeHomeData () {
   writeResult(2022, [
     { uuid: parties.find(party => party.filnamn === 'alfapartiet').uuid, forkortning: 'A', mandat: 200 },
     { uuid: parties.find(party => party.filnamn === 'duplikatpartiet-ett').uuid, forkortning: 'D', mandat: 100 },
-    { uuid: '12121212-1212-4212-8212-121212121212', forkortning: 'X', mandat: 49 }
+    { uuid: '12121212-1212-4212-8212-121212121212', forkortning: 'X', mandat: 49 },
+    { uuid: parties.find(party => party.filnamn === 'zebrapartiet').uuid, forkortning: 'Z' }
   ]);
   writeResult(2026, [
     { uuid: parties.find(party => party.filnamn === 'betapartiet').uuid, forkortning: 'B', mandat: 349 }
   ]);
 
-  return { root, dataRoot };
+  return { root, dataRoot, source };
 }
 
 test('home data lists parties in Swedish alphabetical order with participation facets', async t => {
@@ -382,6 +386,119 @@ test('mandate records resolve by stable uuid and leave an unknown uuid unlinked'
     },
     { uuid: '12121212-1212-4212-8212-121212121212', forkortning: 'X', mandat: 49 }
   ]);
+});
+
+test('party pages derive their election results from the imported result files', async t => {
+  const { root, dataRoot, source } = makeHomeData();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const store = createPartyDataStore(dataRoot);
+
+  const chamberParty = await store.resolveParty('betapartiet');
+  assert.deepEqual(chamberParty.props.valresultat, {
+    valtyp: 'riksdag',
+    resultat: [{ valar: 2026, roster: 1, rostandel: 100, mandat: 349, kalla: source }],
+    kammare: { valar: 2026, mandat: 349 }
+  });
+
+  // Seats in 2022 but no row in the chamber year, so no chamber claim.
+  const former = await store.resolveParty('alfapartiet');
+  assert.deepEqual(former.props.valresultat.resultat, [
+    { valar: 2022, roster: 1, rostandel: 25, mandat: 200, kalla: source }
+  ]);
+  assert.equal(former.props.valresultat.kammare, undefined);
+
+  // A vote row without a seat row is a result of zero mandates, not a gap.
+  const withoutSeats = await store.resolveParty('zebrapartiet');
+  assert.deepEqual(withoutSeats.props.valresultat.resultat, [
+    { valar: 2022, roster: 1, rostandel: 25, mandat: 0, kalla: source }
+  ]);
+  assert.equal(withoutSeats.props.valresultat.kammare, undefined);
+
+  const withoutResults = await store.resolveParty('jarl');
+  assert.equal(withoutResults.props.valresultat, undefined);
+});
+
+const voteSource = { id: 'resultat', namn: 'Valmyndigheten', url: 'https://example.com/roster', hamtad: '2026-08-26' };
+const seatSource = { id: 'mandat', namn: 'Valmyndigheten', url: 'https://example.com/mandat', hamtad: '2026-08-26' };
+
+/** One result file in the shape `val/<år>/valresultat/riksdag.json` carries. */
+function resultFile (valar, rows, kallor = [voteSource]) {
+  return {
+    schema_version: 2,
+    valar,
+    status: 'slutligt',
+    kallor,
+    rostresultat: {
+      giltiga_roster: 1000,
+      partier: rows.map(row => ({
+        parti_uuid: row.uuid,
+        roster: row.roster,
+        rostandel: row.rostandel,
+        kallreferens: 'resultat'
+      }))
+    },
+    mandatfordelning: {
+      partier: rows.filter(row => row.mandat !== undefined).map(row => ({
+        parti_uuid: row.uuid,
+        partibeteckning: 'P',
+        mandat: row.mandat,
+        kallreferens: row.mandatreferens ?? 'resultat'
+      }))
+    }
+  };
+}
+
+const derivedUuid = '11111111-1111-4111-8111-111111111111';
+
+test('the derivation names the seat source separately and measures change against the previous election', () => {
+  const files = [
+    resultFile(2018, [{ uuid: derivedUuid, roster: 44, rostandel: 4.41, mandat: 16, mandatreferens: 'mandat' }], [voteSource, seatSource]),
+    resultFile(2022, [{ uuid: derivedUuid, roster: 51, rostandel: 5.08, mandat: 18 }])
+  ];
+
+  assert.deepEqual(partyElectionResults(files, derivedUuid), {
+    valtyp: 'riksdag',
+    resultat: [
+      { valar: 2018, roster: 44, rostandel: 4.41, mandat: 16, kalla: voteSource, mandatkalla: seatSource },
+      { valar: 2022, roster: 51, rostandel: 5.08, mandat: 18, forandring: 0.67, kalla: voteSource }
+    ],
+    kammare: { valar: 2022, mandat: 18 }
+  });
+});
+
+test('the derivation leaves out change across a gap in the series and reads the same in any file order', () => {
+  const files = [
+    resultFile(2018, [{ uuid: derivedUuid, roster: 44, rostandel: 4.41, mandat: 16 }]),
+    resultFile(2022, [{ uuid: 'abababab-abab-4bab-8bab-abababababab', roster: 1, rostandel: 0.01 }]),
+    resultFile(2026, [{ uuid: derivedUuid, roster: 51, rostandel: 5.08, mandat: 18 }])
+  ];
+
+  const derived = partyElectionResults(files, derivedUuid);
+  assert.deepEqual(derived.resultat.map(post => post.valar), [2018, 2026]);
+  assert.ok(!('forandring' in derived.resultat[0]), 'den första posten bär ingen förändring');
+  assert.ok(!('forandring' in derived.resultat[1]), 'ett överhoppat val ger ingen förändring');
+  assert.ok(!('mandatkalla' in derived.resultat[0]), 'en gemensam källa nämns inte två gånger');
+  assert.deepEqual(partyElectionResults(files.toReversed(), derivedUuid), derived);
+});
+
+test('the derivation claims no chamber seats when the last row is not the chamber year', () => {
+  const files = [
+    resultFile(2018, [{ uuid: derivedUuid, roster: 44, rostandel: 4.41, mandat: 16 }]),
+    resultFile(2022, [{ uuid: 'abababab-abab-4bab-8bab-abababababab', roster: 1, rostandel: 0.01, mandat: 349 }])
+  ];
+
+  const derived = partyElectionResults(files, derivedUuid);
+  assert.equal(derived.resultat.at(-1).valar, 2018);
+  assert.equal(derived.kammare, undefined);
+});
+
+test('the derivation skips a party without rows and rejects an unknown source reference', () => {
+  const files = [resultFile(2022, [{ uuid: derivedUuid, roster: 51, rostandel: 5.08, mandat: 18 }])];
+  assert.equal(partyElectionResults(files, 'abababab-abab-4bab-8bab-abababababab'), undefined);
+  assert.equal(partyElectionResults([], derivedUuid), undefined);
+
+  const broken = [resultFile(2022, [{ uuid: derivedUuid, roster: 51, rostandel: 5.08, mandat: 18, mandatreferens: 'saknas' }])];
+  assert.throws(() => partyElectionResults(broken, derivedUuid), /Riksdagsvalet 2022 saknar källan saknas/);
 });
 
 test('home data enriches the derived outside-parliament ranking by stable uuid', async t => {

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -182,25 +182,7 @@ function validatePartyProfile (profile, context) {
       }
     }
   }
-  if (profile.valresultat !== undefined) {
-    assert.equal(profile.valresultat.valtyp, 'riksdag', `${context}.valresultat.valtyp har ett okänt värde`);
-    requireArray(profile.valresultat.kallor, `${context}.valresultat.kallor`);
-    assert.ok(profile.valresultat.kallor.length > 0, `${context}.valresultat.kallor får inte vara tom`);
-    profile.valresultat.kallor.forEach((source, index) => {
-      validateProfileSource(source, `${context}.valresultat.kallor[${index}]`);
-    });
-    requireArray(profile.valresultat.resultat, `${context}.valresultat.resultat`);
-    assert.ok(profile.valresultat.resultat.length > 0, `${context}.valresultat.resultat får inte vara tom`);
-    requireUnique(profile.valresultat.resultat, 'valar', `${context}.valresultat.resultat`);
-    let previousYear = 0;
-    for (const result of profile.valresultat.resultat) {
-      assert.ok(Number.isInteger(result.valar) && result.valar > previousYear, `${context}.valresultat.resultat ska vara sorterat på valår`);
-      assert.ok(typeof result.rostandel === 'number' && result.rostandel >= 0 && result.rostandel <= 100, `${context}.valresultat.resultat.rostandel ska vara 0–100`);
-      assert.ok(Number.isInteger(result.mandat) && result.mandat >= 0 && result.mandat <= 349, `${context}.valresultat.resultat.mandat ska vara 0–349`);
-      if (result.roster !== undefined) assert.ok(Number.isInteger(result.roster) && result.roster >= 0, `${context}.valresultat.resultat.roster ska vara ett positivt heltal`);
-      previousYear = result.valar;
-    }
-  }
+  assert.equal(profile.valresultat, undefined, `${context}.valresultat ska inte finnas; valresultat härleds ur val/<år>/valresultat/riksdag.json`);
   if (profile.dokument !== undefined) {
     requireArray(profile.dokument, `${context}.dokument`);
     for (const [index, document] of profile.dokument.entries()) {

--- a/scripts/validate.test.js
+++ b/scripts/validate.test.js
@@ -199,7 +199,7 @@ test('validateData rejects inconsistencies with useful errors', async t => {
     assert.throws(() => validateData(root), /namn_kalla.url ska vara en giltig URL/);
   });
 
-  await t.test('invalid curated election results', t => {
+  await t.test('curated election results are rejected', t => {
     const root = makeData();
     t.after(() => fs.rmSync(root, { recursive: true, force: true }));
     writeJson(root, 'parti/testpartiet/profil.json', {
@@ -208,13 +208,10 @@ test('validateData rejects inconsistencies with useful errors', async t => {
       valresultat: {
         valtyp: 'riksdag',
         kallor: [{ namn: 'Valmyndigheten', url: 'https://www.val.se', hamtad: '2026-08-24' }],
-        resultat: [
-          { valar: 2022, rostandel: 5, mandat: 18 },
-          { valar: 2018, rostandel: 4, mandat: 14 }
-        ]
+        resultat: [{ valar: 2022, rostandel: 5, mandat: 18 }]
       }
     });
-    assert.throws(() => validateData(root), /ska vara sorterat på valår/);
+    assert.throws(() => validateData(root), /valresultat ska inte finnas; valresultat härleds ur val\/<år>\/valresultat\/riksdag\.json/);
   });
 
   await t.test('invalid parliamentary election result', t => {

--- a/src/components/party-profile/elections.tsx
+++ b/src/components/party-profile/elections.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import { useState } from 'react';
 import parliamentView from 'data/derived/riksdag.json';
-import type { PartiDeltagande, PartiProfilValresultat, PartiProfilValresultatPost } from 'src/types';
+import type { PartiDeltagande, PartiValresultat, PartiValresultatPost } from 'src/types';
 import { SectionHeader, SourceLine } from './shared';
 
 export type ElectionType = 'R' | 'L' | 'K';
@@ -37,7 +37,7 @@ const chamberSeats = (() => {
   }));
 })();
 
-function ElectionChart ({ results, selected, onSelect }: { results: PartiProfilValresultatPost[]; selected: number; onSelect: (index: number) => void }) {
+function ElectionChart ({ results, selected, onSelect }: { results: PartiValresultatPost[]; selected: number; onSelect: (index: number) => void }) {
   const highestResult = Math.max(4, ...results.map(result => result.rostandel));
   const maximum = Math.max(8, Math.ceil((highestResult * 1.15) / 2) * 2);
   const thresholdPosition = (4 / maximum) * 100;
@@ -84,11 +84,14 @@ function ChamberDiagram ({ mandates, partyLabel }: { mandates: number; partyLabe
   );
 }
 
-export function ElectionResultsSection ({ results, partyLabel }: { results: PartiProfilValresultat; partyLabel?: string }) {
+export function ElectionResultsSection ({ results, partyLabel }: { results: PartiValresultat; partyLabel?: string }) {
   const [selected, setSelected] = useState(results.resultat.length - 1);
   const result = results.resultat[selected];
-  const latestResult = results.resultat.at(-1);
-  const previousResult = selected > 0 ? results.resultat[selected - 1] : undefined;
+  const firstYear = results.resultat[0]?.valar;
+  const lastYear = results.resultat.at(-1)?.valar;
+  const sourceNames = [...new Set(results.resultat.map(post => post.kalla.namn))];
+  const seriesSource = `${sourceNames.join(' och ')} · slutligt resultat`;
+  const chamber = results.kammare;
   if (!result) return null;
 
   return (
@@ -97,28 +100,30 @@ export function ElectionResultsSection ({ results, partyLabel }: { results: Part
         <SectionHeader
           id="results-heading"
           title="Vad partiet har fått i val"
-          subtitle={`Riksdagsval ${results.resultat[0]?.valar}–${latestResult?.valar}, andel av giltiga röster i hela riket`}
-          aside={<div className="profile-authority-brand"><Image src="/img/kallor/valmyndigheten.png" alt="" width={38} height={38} /><div><strong>Valmyndigheten</strong><small>valresultat · slutlig rösträkning</small></div></div>}
+          subtitle={results.resultat.length > 1
+            ? `Riksdagsval ${firstYear}–${lastYear}, andel av giltiga röster i hela riket`
+            : `Riksdagsvalet ${firstYear}, andel av giltiga röster i hela riket`}
+          aside={<div className="profile-authority-brand"><Image src="/img/kallor/valmyndigheten.png" alt="" width={38} height={38} /><div><strong>Valmyndigheten</strong><small>{seriesSource}</small></div></div>}
         />
         <div className="profile-results__top">
-          <div className="profile-results__intro"><p>Diagrammet visar partiets andel av de giltiga rösterna och antal mandat i varje riksdagsval.</p><SourceLine>Valmyndigheten · slutlig rösträkning</SourceLine></div>
+          <div className="profile-results__intro"><p>Diagrammet visar partiets andel av de giltiga rösterna och antal mandat i varje riksdagsval.</p><SourceLine>{seriesSource}</SourceLine></div>
           <div>
             <ElectionChart results={results.resultat} selected={selected} onSelect={setSelected} />
             <div className="profile-selected-result">
-              <header><strong>Riksdagsvalet {result.valar}</strong><span>Valmyndigheten · slutligt resultat</span></header>
+              <header><strong>Riksdagsvalet {result.valar}</strong><span>{result.kalla.namn} · slutligt resultat</span></header>
               <dl>
                 <div><dt>Andel giltiga röster</dt><dd>{percentageFormatter.format(result.rostandel)} %</dd></div>
-                <div><dt>Röster</dt><dd>{result.roster !== undefined ? new Intl.NumberFormat('sv-SE').format(result.roster) : '—'}</dd></div>
+                <div><dt>Röster</dt><dd>{new Intl.NumberFormat('sv-SE').format(result.roster)}</dd></div>
                 <div><dt>Mandat</dt><dd>{result.mandat}</dd></div>
-                <div><dt>Mot föregående val</dt><dd>{previousResult ? `${result.rostandel - previousResult.rostandel > 0 ? '+' : ''}${percentageFormatter.format(result.rostandel - previousResult.rostandel)}` : '—'}</dd></div>
+                <div><dt>Mot föregående val</dt><dd>{result.forandring !== undefined ? `${result.forandring > 0 ? '+' : ''}${percentageFormatter.format(result.forandring)}` : '—'}</dd></div>
               </dl>
             </div>
           </div>
         </div>
-        {latestResult && <div className="profile-results__bottom">
+        {chamber && <div className="profile-results__bottom">
           <div>
-            <h3>Partiets {latestResult.mandat} platser i kammaren</h3>
-            <ChamberDiagram mandates={latestResult.mandat} partyLabel={partyLabel} />
+            <h3>Partiets {chamber.mandat} platser i kammaren</h3>
+            <ChamberDiagram mandates={chamber.mandat} partyLabel={partyLabel} />
             <SourceLine source={parliamentView.kammare.kalla}>349 mandat efter valet {parliamentView.kammare.valar} · </SourceLine>
           </div>
           <div className="profile-composition">
@@ -126,7 +131,12 @@ export function ElectionResultsSection ({ results, partyLabel }: { results: Part
             <ul>{parliamentComposition.map(party => <li key={party.label} className={party.label === partyLabel ? 'is-current' : undefined}><span>{party.label}</span><i><b style={{ width: `${(party.seats / parliamentComposition[0].seats) * 100}%` }} /></i><strong>{party.seats}</strong></li>)}</ul>
           </div>
         </div>}
-        <div className="profile-results__sources">{results.kallor.map(source => <SourceLine source={source} key={source.url} />)}</div>
+        <div className="profile-results__sources">
+          {results.resultat.flatMap(post => [
+            <SourceLine source={post.kalla} key={`${post.valar}-${post.kalla.url}`}>Riksdagsvalet {post.valar} · </SourceLine>,
+            ...(post.mandatkalla ? [<SourceLine source={post.mandatkalla} key={`${post.valar}-${post.mandatkalla.url}`}>Riksdagsvalet {post.valar}, mandat · </SourceLine>] : []),
+          ])}
+        </div>
       </div>
     </section>
   );

--- a/src/components/party-profile/elections.tsx
+++ b/src/components/party-profile/elections.tsx
@@ -90,7 +90,11 @@ export function ElectionResultsSection ({ results, partyLabel }: { results: Part
   const firstYear = results.resultat[0]?.valar;
   const lastYear = results.resultat.at(-1)?.valar;
   const sourceNames = [...new Set(results.resultat.map(post => post.kalla.namn))];
-  const seriesSource = `${sourceNames.join(' och ')} · slutligt resultat`;
+  const authority = sourceNames.join(' och ');
+  const seriesSource = `${authority} · slutligt resultat`;
+  // Valmyndigheten's is the only source logo the site carries, so it stands
+  // only where Valmyndigheten is the whole series.
+  const valmyndighetenOnly = sourceNames.length === 1 && sourceNames[0] === 'Valmyndigheten';
   const chamber = results.kammare;
   if (!result) return null;
 
@@ -103,7 +107,7 @@ export function ElectionResultsSection ({ results, partyLabel }: { results: Part
           subtitle={results.resultat.length > 1
             ? `Riksdagsval ${firstYear}–${lastYear}, andel av giltiga röster i hela riket`
             : `Riksdagsvalet ${firstYear}, andel av giltiga röster i hela riket`}
-          aside={<div className="profile-authority-brand"><Image src="/img/kallor/valmyndigheten.png" alt="" width={38} height={38} /><div><strong>Valmyndigheten</strong><small>{seriesSource}</small></div></div>}
+          aside={<div className="profile-authority-brand">{valmyndighetenOnly && <Image src="/img/kallor/valmyndigheten.png" alt="" width={38} height={38} />}<div><strong>{authority}</strong><small>valresultat · slutligt resultat</small></div></div>}
         />
         <div className="profile-results__top">
           <div className="profile-results__intro"><p>Diagrammet visar partiets andel av de giltiga rösterna och antal mandat i varje riksdagsval.</p><SourceLine>{seriesSource}</SourceLine></div>

--- a/src/components/party-profile/overview.tsx
+++ b/src/components/party-profile/overview.tsx
@@ -8,7 +8,7 @@ import type {
   PartiProfil,
   PartiProfilDokument,
   PartiProfilForetradare,
-  PartiProfilValresultatPost,
+  PartiValresultat,
   PartiWikidata,
 } from 'src/types';
 import { ExternalLink, SectionHeader, SourceLine, formatPrecisionDate } from './shared';
@@ -46,7 +46,7 @@ export function ProfileHero ({
   symbol,
   symbolSrc,
   symbolFrame,
-  latestResult,
+  results,
   latestParticipation,
   wikidata,
 }: {
@@ -57,13 +57,14 @@ export function ProfileHero ({
   symbol?: Parti['partisymbol'];
   symbolSrc?: string;
   symbolFrame?: SymbolFrame;
-  latestResult?: PartiProfilValresultatPost;
+  results?: PartiValresultat;
   latestParticipation?: [string, PartiDeltagande];
   wikidata?: PartiWikidata;
 }) {
   const participation = latestParticipation?.[1];
+  const latestResult = results?.resultat.at(-1);
   const founded = formatPrecisionDate(wikidata?.grundat);
-  const keyFactCount = (latestResult ? 2 : 1) + 1 + (founded ? 1 : 0);
+  const keyFactCount = (results?.kammare || latestResult ? 2 : 1) + 1 + (founded ? 1 : 0);
   const description = profile.beskrivning ?? profile.profiltext?.text ?? 'Registrerad partibeteckning och anmält valdeltagande enligt Valmyndighetens öppna data.';
   const descriptionSource = profile.profiltext?.kalla ?? profile.namn_kalla;
 
@@ -96,22 +97,24 @@ export function ProfileHero ({
       </div>
 
       <dl className={`profile-keyfacts${keyFactCount === 4 ? ' profile-keyfacts--four' : ''}`}>
-        {latestResult ? <>
+        {results?.kammare ? (
           <div>
             <dt>Mandat i riksdagen</dt>
-            <dd>{latestResult.mandat} <span>av 349</span></dd>
-            <dd className="profile-source">Valresultat {latestResult.valar}</dd>
+            <dd>{results.kammare.mandat} <span>av 349</span></dd>
+            <dd className="profile-source">Valresultat {results.kammare.valar}</dd>
           </div>
-          <div>
-            <dt>Riksdagsvalet {latestResult.valar}</dt>
-            <dd>{percentageFormatter.format(latestResult.rostandel)} <span>%</span></dd>
-            <dd className="profile-source">Valmyndigheten · slutligt resultat</dd>
-          </div>
-        </> : (
+        ) : (
           <div>
             <dt>Partikod</dt>
             <dd className="profile-mono">{code}</dd>
             <dd className="profile-source">Valmyndighetens partiregister</dd>
+          </div>
+        )}
+        {latestResult && (
+          <div>
+            <dt>Riksdagsvalet {latestResult.valar}</dt>
+            <dd>{percentageFormatter.format(latestResult.rostandel)} <span>%</span></dd>
+            <dd className="profile-source">{latestResult.kalla.namn} · slutligt resultat</dd>
           </div>
         )}
         {participation ? (

--- a/src/pages/parti/[filnamn].tsx
+++ b/src/pages/parti/[filnamn].tsx
@@ -29,6 +29,7 @@ function PartyPage ({
   profile,
   symbolSrc,
   symbolFrame,
+  valresultat,
 }: PartyPageProps) {
   const displayName = profile?.namn ?? registeredName;
   const pageName = duplicateName && area ? `${displayName} (${area})` : displayName;
@@ -39,7 +40,6 @@ function PartyPage ({
   const participationYears = Object.entries(participation ?? {})
     .filter(([, value]) => value.riksdag || value.region.length > 0 || value.kommun.length > 0)
     .sort(([a], [b]) => Number(b) - Number(a));
-  const latestResult = profile?.valresultat?.resultat.at(-1);
   const style = { '--profile-accent': profile?.accentfarg ?? '#082354' } as CSSProperties;
 
   return (
@@ -52,11 +52,11 @@ function PartyPage ({
           <link rel="icon" href="/img/partidata/mark.svg" type="image/svg+xml" />
           <link rel="canonical" href={`https://www.partidata.se/parti/${slug}/`} />
         </Head>
-        <ProfileHero code={code} abbreviation={abbreviation} profile={resolvedProfile} displayName={pageName} symbol={symbol} symbolSrc={symbolSrc} symbolFrame={symbolFrame} latestResult={latestResult} latestParticipation={participationYears[0]} wikidata={wikidata} />
+        <ProfileHero code={code} abbreviation={abbreviation} profile={resolvedProfile} displayName={pageName} symbol={symbol} symbolSrc={symbolSrc} symbolFrame={symbolFrame} results={valresultat} latestParticipation={participationYears[0]} wikidata={wikidata} />
         <DocumentsSection profile={resolvedProfile} abbreviation={abbreviation} />
-        <RepresentativesSection profile={resolvedProfile} abbreviation={abbreviation} mandateCount={latestResult?.mandat} />
-        {profile?.valresultat && <ElectionResultsSection results={profile.valresultat} partyLabel={abbreviation} />}
-        {profile?.valresultat && <TurnoutSection />}
+        <RepresentativesSection profile={resolvedProfile} abbreviation={abbreviation} mandateCount={valresultat?.kammare?.mandat} />
+        {valresultat && <ElectionResultsSection key={slug} results={valresultat} partyLabel={abbreviation} />}
+        {valresultat && <TurnoutSection />}
         {participationYears.length > 0 && <BallotSection participationYears={participationYears} candidateLists={candidateLists} slug={slug} partyName={displayName} />}
         <WikipediaSection profile={resolvedProfile} />
         <NewsSection profile={resolvedProfile} />

--- a/src/server/party-data.ts
+++ b/src/server/party-data.ts
@@ -1,7 +1,15 @@
 import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 
-import type { Parti, PartiIndexEntry, PartiProfil, PartiProfilKalla, PartiSymbol } from '../types';
+import type {
+  Parti,
+  PartiIndexEntry,
+  PartiProfil,
+  PartiProfilKalla,
+  PartiSymbol,
+  PartiValresultat,
+  PartiValresultatPost,
+} from '../types';
 import { assertSwedishCollation, compareSv } from './collation.ts';
 
 /**
@@ -19,6 +27,7 @@ export interface PartyPageData extends Parti {
   profile?: PartiProfil;
   symbolSrc?: string;
   symbolFrame?: SymbolFrame;
+  valresultat?: PartiValresultat;
 }
 
 export type PartyResolution =
@@ -134,10 +143,15 @@ interface RegionFile {
   kommuner?: Array<{ kod: string; namn: string }>;
 }
 
-interface ParliamentResultFile {
+export interface ParliamentResultFile {
   schema_version: 2;
   valar: number;
+  status: string;
   kallor: Array<PartiProfilKalla & { id: string }>;
+  rostresultat: {
+    giltiga_roster: number;
+    partier: Array<{ parti_uuid: string; roster: number; rostandel: number; kallreferens: string }>;
+  };
   mandatfordelning: {
     partier: Array<{ parti_uuid: string; kallkod?: string; partibeteckning: string; mandat: number; kallreferens: string }>;
   };
@@ -204,6 +218,55 @@ export function symbolFrame (symbol?: PartiSymbol): SymbolFrame | undefined {
   };
 }
 
+/** The source a result row cites, by the `id` the file's `kallor` list it under. */
+function sourceFor (file: ParliamentResultFile, reference: string): PartiProfilKalla & { id: string } {
+  const source = file.kallor.find(entry => entry.id === reference);
+  if (!source) throw new Error(`Riksdagsvalet ${file.valar} saknar källan ${reference}`);
+  return source;
+}
+
+/**
+ * A party's parliamentary results across the imported election files, one post
+ * per year the party has a vote row in. `mandat` is 0 for a year without a seat
+ * row, `forandring` is set only when the immediately preceding imported
+ * election also has a row for the party, and `kammare` only when the party
+ * holds seats in the most recent imported election.
+ */
+export function partyElectionResults (files: ParliamentResultFile[], uuid: string): PartiValresultat | undefined {
+  const ordered = files.toSorted((a, b) => a.valar - b.valar);
+  const chamberYear = ordered.at(-1);
+  if (!chamberYear) return undefined;
+
+  const resultat: PartiValresultatPost[] = [];
+  ordered.forEach((file, index) => {
+    const votes = file.rostresultat.partier.find(row => row.parti_uuid === uuid);
+    if (!votes) return;
+    const seats = file.mandatfordelning.partier.find(row => row.parti_uuid === uuid);
+    const kalla = sourceFor(file, votes.kallreferens);
+    const seatSource = seats ? sourceFor(file, seats.kallreferens) : undefined;
+    const previous = ordered[index - 1]?.rostresultat.partier.find(row => row.parti_uuid === uuid);
+    resultat.push({
+      valar: file.valar,
+      roster: votes.roster,
+      rostandel: votes.rostandel,
+      mandat: seats?.mandat ?? 0,
+      ...(previous ? { forandring: Number((votes.rostandel - previous.rostandel).toFixed(2)) } : {}),
+      kalla,
+      ...(seatSource && seatSource.id !== kalla.id ? { mandatkalla: seatSource } : {}),
+    });
+  });
+  if (resultat.length === 0) return undefined;
+
+  const chamberSeats = chamberYear.mandatfordelning.partier.find(row => row.parti_uuid === uuid);
+  return {
+    valtyp: 'riksdag',
+    resultat,
+    ...(chamberSeats && chamberSeats.mandat > 0
+      ? { kammare: { valar: chamberYear.valar, mandat: chamberSeats.mandat } }
+      : {}),
+  };
+}
+
 function partyNameKey (name: string): string {
   return name.trim().toLocaleLowerCase('sv-SE').replace(/\s+/g, ' ');
 }
@@ -243,6 +306,7 @@ export function createPartyDataStore (
 ) {
   let partyIndexPromise: Promise<PartyIndex> | undefined;
   let homeDataPromise: Promise<HomeData> | undefined;
+  let parliamentResultsPromise: Promise<ParliamentResultFile[]> | undefined;
 
   function getPartyIndex (): Promise<PartyIndex> {
     partyIndexPromise ??= readJson<PartiIndexEntry[]>(path.join(dataRoot, 'derived', 'parti.json')).then(parties => {
@@ -288,12 +352,14 @@ export function createPartyDataStore (
   async function readCurrentParty (slug: string, duplicateName: boolean): Promise<PartyPageData> {
     const partyRoot = path.join(dataRoot, 'parti', slug);
     const party = await readJson<Parti>(path.join(partyRoot, 'index.json'));
-    const [profile, candidateLists] = await Promise.all([
+    const [profile, candidateLists, results] = await Promise.all([
       readOptionalJson<PartiProfil>(path.join(partyRoot, 'profil.json')),
       readCandidateLists(slug),
+      readParliamentResults(),
     ]);
     const symbolSrc = symbolSource(party);
     const frame = symbolFrame(party.partisymbol);
+    const valresultat = partyElectionResults(results, party.uuid);
 
     return {
       ...party,
@@ -302,6 +368,7 @@ export function createPartyDataStore (
       ...(profile ? { profile } : {}),
       ...(symbolSrc ? { symbolSrc } : {}),
       ...(frame ? { symbolFrame: frame } : {}),
+      ...(valresultat ? { valresultat } : {}),
     };
   }
 
@@ -313,16 +380,26 @@ export function createPartyDataStore (
       .sort();
   }
 
+  /** Every imported parliamentary result file, oldest first, read once. */
+  function readParliamentResults (): Promise<ParliamentResultFile[]> {
+    parliamentResultsPromise ??= (async () => {
+      const years = await electionYears();
+      const results = await Promise.all(years.map(year =>
+        readOptionalJson<ParliamentResultFile>(path.join(dataRoot, 'val', year, 'valresultat', 'riksdag.json'))));
+      return results
+        .filter((result): result is ParliamentResultFile => result?.schema_version === 2)
+        .sort((a, b) => a.valar - b.valar);
+    })();
+    return parliamentResultsPromise;
+  }
+
   async function readParliamentYears (byUuid: Map<string, PartiIndexEntry>): Promise<ParliamentYear[]> {
-    const years = await electionYears();
-    const results = await Promise.all(years.map(year =>
-      readOptionalJson<ParliamentResultFile>(path.join(dataRoot, 'val', year, 'valresultat', 'riksdag.json'))));
+    const results = await readParliamentResults();
 
     return results
-      .filter((result): result is ParliamentResultFile => result?.schema_version === 2)
       .map(result => ({
         valar: result.valar,
-        kalla: result.kallor.find(source => source.id === result.mandatfordelning.partier[0]?.kallreferens)!,
+        kalla: sourceFor(result, result.mandatfordelning.partier[0]?.kallreferens),
         partier: result.mandatfordelning.partier.map(entry => {
           const party = byUuid.get(entry.parti_uuid);
           const symbolSrc = party ? symbolSource(party) : undefined;
@@ -337,7 +414,7 @@ export function createPartyDataStore (
           };
         }),
       }))
-      .sort((a, b) => b.valar - a.valar);
+      .toSorted((a, b) => b.valar - a.valar);
   }
 
   async function readOutsideParliament (byUuid: Map<string, PartiIndexEntry>): Promise<OutsideParliamentData | undefined> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,17 +92,33 @@ export interface PartiProfilDokument {
   delar?: PartiProfilDokumentdel[];
 }
 
-export interface PartiProfilValresultatPost {
+/**
+ * One election year of a party's parliamentary result, derived from
+ * `data/val/<år>/valresultat/riksdag.json`. A year is present only when the
+ * file carries a vote row for the party's uuid.
+ */
+export interface PartiValresultatPost {
   valar: number;
+  roster: number;
   rostandel: number;
+  /** 0 when the year's seat distribution has no row for the party. */
   mandat: number;
-  roster?: number;
+  /** Share minus the previous imported election's share, absent without one. */
+  forandring?: number;
+  kalla: PartiProfilKalla;
+  /** Only when the seat row cites another source than the vote row. */
+  mandatkalla?: PartiProfilKalla;
 }
 
-export interface PartiProfilValresultat {
+/**
+ * A party's parliamentary results across the imported election years.
+ * `kammare` means seats in the most recent election with a seat distribution,
+ * which is the chamber `data/derived/riksdag.json` describes.
+ */
+export interface PartiValresultat {
   valtyp: 'riksdag';
-  kallor: PartiProfilKalla[];
-  resultat: PartiProfilValresultatPost[];
+  resultat: PartiValresultatPost[];
+  kammare?: { valar: number; mandat: number };
 }
 
 export interface PartiProfilKanal {
@@ -171,7 +187,6 @@ export interface PartiProfil {
   foretradare?: PartiProfilForetradare[];
   nyheter?: PartiProfilNyhet[];
   wikipedia?: PartiProfilWikipedia;
-  valresultat?: PartiProfilValresultat;
   dokument?: PartiProfilDokument[];
 }
 


### PR DESCRIPTION
The party page's hero and election results section read `profil.valresultat`, a hand-curated copy of the parliamentary results that two parties carried. The imported results in `data/val/<år>/valresultat/riksdag.json` already hold the same series for every party, source-traceable and with vote counts, so the page now derives its results from them the way the start page does, and the curated field is gone.

`src/server/party-data.ts` memoises the eight result files once per process, shares the source lookup with the start page, and exposes a pure `partyElectionResults(files, uuid)` that builds the per-party series: vote share and count per election, seats and the seat source where the party sat in the chamber, and the change against the previous imported election computed server-side so a gap in the series never reads as a four-year change. `readCurrentParty()` spreads the result into the page props; `overview.tsx` shows the seat block only for chamber parties and `elections.tsx` renders one source line per election year. `validate:data` rejects `profil.valresultat` and points at the import; the two `profil.json` files that carried it are trimmed; `docs/riksdagsvalresultat.md` and the README describe the derivation.

Before the field was removed, all fourteen curated rows were checked against the import: every vote share and seat count matches, and the import adds vote counts and Liberalerna's 1994 and 1998 results. Rendered from the release build, Liberalerna and Miljöpartiet show the same figures as before; parties with votes but no seats render the results section without a chamber block; a party with no result rows renders neither. `npm run precommit` is green.

Open for review, as the plan marks it: every party with a vote row gets a results section, including 0,00 % cases such as a two-vote municipal-only party; a threshold would be a one-line filter in `partyElectionResults()`. The source row grows to eleven entries for Miljöpartiet and has not been checked visually.

Closes #76
