### PR TITLE
Publish a documented JSON interface for Partidata's data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,13 @@ Open data about Swedish political parties. Swedish copy.
   behind nginx. `next/image` optimisation remains disabled.
 - Party pages use `getServerSideProps` and read JSON through
   `src/server/party-data.ts`. Previous slugs return HTTP 308, unknown slugs 404.
+- `/data/<sökväg>` serves an allowlisted subset of `data/` byte for byte through
+  `src/pages/api/data/[...path].ts` (rewritten from `/data/:path+` in
+  `next.config.ts`). `src/server/data-resources.ts` holds the allowlist and is
+  the only place that decides what is handed out — candidate lists, `profil.json`
+  and the symbols are outside it. `/data/` itself is the documentation page,
+  whose field tables live in `src/components/data/fields.ts` and are checked
+  against real specimens by `scripts/data-fields.test.js`.
 - The start page carries its filters in the query string (`valar`, `valtyp`,
   `lan`, `kommun`, `q`, `sortering`), with the defaults left out so the
   unfiltered page stays `/`. `src/components/home/query.ts` translates between

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Tillgängliggöra data om alla Sveriges politiska partier på ett öppet och tra
 
 ## Tillgänglig data
 
+Registret, partifilerna, `val/<år>/partideltagande/`, `val/<år>/valresultat/riksdag.json`, `regioner/index.json` och `derived/` serveras som JSON på `https://www.partidata.se/data/<sökväg>` — samma sökväg som här under `data/`, och samma byte. Adresser, fält, huvuden, versioneringsprincip och licensvillkor står på https://www.partidata.se/data/. Kandidatlistorna och `profil.json` serveras inte.
+
+Gränsen för vad som publiceras går vid filen, inte vid fältet: varje fält i en partifil lämnas ut, extrafälten inräknade. Ett fält som inte tål att publiceras hör inte hemma i partifilen.
+
 ### parti/\<filnamn\>/index.json
 
 En fil per parti. `uuid` sätts en gång och ändras aldrig — det är den identitet `val/`-filerna refererar till. `filnamn` är partiets adress på sajten och följer partiets `beteckning`: byter partiet namn får det ett nytt `filnamn`, katalogen flyttas dit, och den gamla adressen läggs till i `tidigare_filnamn` och serveras som en vidarebefordran till den nya. `filnamn` skapas med `toFileName` i `scripts/utils.js`, med suffixet `-<kod>` när flera partier ger samma filnamn. Ett `filnamn` som registret en gång har burit ges aldrig till ett annat parti.

--- a/agent-docs/issue/26-documented-json-interface/index.md
+++ b/agent-docs/issue/26-documented-json-interface/index.md
@@ -1,0 +1,36 @@
+# Issue #26: Publish a documented JSON interface for Partidata's data
+
+**Baserad på:** main
+
+## Sammanfattning
+
+Sajten serverar sin egen data som JSON under en enda regel: `https://www.partidata.se/data/<sökväg>` är filen `data/<sökväg>` i repot, byte för byte, för de filer som står på en allowlist — registret, varje partis registerfil, `partideltagande/` och `valresultat/riksdag.json` per valår, `derived/riksdag.json` och SCB:s områdeskoder. Allowlisten är en ren, testad modul (`src/server/data-resources.ts`); lagret `party-data.ts` läser filen ur samma `data/`-träd som sidorna, cachar den och sätter `ETag` = SHA-256; en API-route nådd via rewrite från `/data/:path+` svarar på `GET`/`HEAD`/`OPTIONS` med `Content-Type`, `Cache-Control: public, max-age=3600`, 304 på `If-None-Match`, `X-Partidata-Version` och `Access-Control-Allow-Origin: *` på varje svar, 308 för tidigare `filnamn`, 404 för allt utanför listan (kandidatlistor, `profil.json`, PNG, `..`) och 405 för andra metoder. `/data/` är en server-renderad dokumentationssida vars adresstabell och exempel byggs ur datan så att inga länkar är döda, med avsnitt om fält, huvuden, versioneringsprincip och licens (CC0 för sammanställningen, källvillkor per ursprung). Partisidans "Registerdata (JSON)" pekar på Partidata, navigationen får "Data", sidfoten "Data som JSON", sitemapen `/data/`. HTTP-smoke prövar 200/304/404/405/OPTIONS, content-type, CORS, etag, kandidatfilen och partisidans länk. nginx ändras inte.
+
+## Triageringsstatus
+
+| Fält | Värde |
+|------|-------|
+| **Redo att arbeta** | Ja |
+| **Risk** | Medel |
+| **Säker för junior** | Ja — med ägarens granskning av allowlisten och licenstexten innan merge |
+
+## Plangranskning
+
+**Status:** Granskad
+**Granskad:** 2026-08-30
+**Feedback:** Codex (två pass). Infört: `responseLimit: false` i routen, `Vary: Accept-Encoding`, `OPTIONS` som uttalat kontrakt (204 för alla adresser, designbeslut 12), `path.relative`-inneslutning och fler traversal-fall i smoke, en egen `dataCatalogPromise` och en separat testfixtur i stället för ändrad `makeData()`, fälttabeller med typ/obligatoriskt på sidan med test mot riktiga exemplar, README-länkar under den byggda taggen, en uttalad gräns "allt i partifilen är publikt" i README, minnesbudget (60 MB, tolerans 5 MB) och cachebeslut (13), källvillkor för Valmyndigheten/SCB/Wikidata med URL och kontrolldatum, två lokala HTTP-origins för CORS-provet och automatiserad "ingen 308"-assertion. Avvisat: `PUBLIC_PARTY_KEYS`-filtrering av partifilen (bryter byte-identiska svar och #79:s syfte — gränsen dokumenteras i stället), symlänkar i hotbilden, och 404-krav på adresser Next själv normaliserar med 308 (kravet är "aldrig 200 med JSON").
+
+## Relaterade filer
+
+- [plan.md](plan.md) — Fullständig implementationsplan
+- [progress.md](progress.md) — Implementationsframsteg
+- [research.md](research.md) — Forskningsresultat (om finns)
+
+## Relaterade issues
+
+- #33 — Kandidatlistor och personuppgifter: uttryckligen utanför; allowlisten får aldrig släppa igenom `kandidatlistor/`
+- #48 — Stängt; riksdagsresultaten är importerade, så valresultat-adresserna kan publiceras nu
+- #53 / #55 — Mergat; den server-renderade appen är grunden för att servera ur samma `data/`
+- #25 — README-uppdatering; den här planen lägger bara ett stycke om adresserna, resten lämnas till #25
+- #28 / #57 — Bootstrap/Tailwind; dokumentationssidan använder egna tabellstilar, inte Bootstraps `.table`
+- #21 — Deltagande per valår på partisidan; samma filer, ingen kodöverlappning

--- a/agent-docs/issue/26-documented-json-interface/plan.md
+++ b/agent-docs/issue/26-documented-json-interface/plan.md
@@ -1,0 +1,281 @@
+# Plan: Issue #26 — Publish a documented JSON interface for Partidata's data
+
+## Mål
+
+Sajten ska själv servera sin data som JSON på stabila, dokumenterade adresser: registret, varje partis registerfil, partideltagandet per valår, riksdagsresultaten per valår, härledningen för riksdagen och SCB:s områdeskoder. Regeln är en enda: `https://www.partidata.se/data/<sökväg>` är samma fil som `data/<sökväg>` i repot, byte för byte, för de filer som står på en allowlist. Svaren kommer ur samma `data/`-träd som sajten redan läser genom `src/server/party-data.ts` — ingen kopia under `public/`. Adresserna svarar på `GET`, `HEAD` och `OPTIONS`, med `Content-Type`, cache-huvuden, `ETag` och CORS för läsning från andra webbplatser; allt annat är 404 eller 405. En sida på `/data/` dokumenterar adresserna, fälten, källorna, versioneringsprincipen, licensvillkoren och visar exempel som alltid pekar på filer som finns. Partisidans "Registerdata (JSON)" pekar på Partidatas adress i stället för på GitHub. Kandidatfiler och annat med personuppgifter exponeras inte — de avgörs i #33.
+
+## Triagering
+
+> Beslutsunderlag för detta issue.
+
+| Fält | Värde |
+|------|-------|
+| **Blockeras av** | Inget |
+| **Blockerar** | Inget |
+| **Relaterade issues** | #33 (kandidatlistor och personuppgifter — uttryckligen utanför; allowlisten får aldrig släppa igenom `kandidatlistor/`), #48 (stängt; valresultaten är importerade, så villkoret "när #48 är implementerat" är uppfyllt), #53/#55 (mergade; server-renderad app är grunden), #25 (README-uppdatering — README får ett stycke om adresserna här, resten lämnas till #25), #28/#57 (Bootstrap/Tailwind — dokumentationssidan ska inte bygga på `.table` ur Bootstrap), #21 (deltagande per valår på partisidan — samma filer, ingen kodöverlappning) |
+| **Omfattning** | ~17 filer i `src/server/`, `src/pages/`, `src/components/`, `src/styles/`, `scripts/`, `next.config.ts`, `README.md`, `CLAUDE.md` |
+| **Risk** | Medel |
+| **Komplexitet** | Medel |
+| **Säker för junior** | Ja — med ägarens granskning av allowlisten (fas 1) och licenstexten (fas 3) innan merge |
+| **Konfliktrisk** | Låg (ingen öppen plan rör dessa filer; alla 17 befintliga planmappar hör till issues som är stängda enligt `gh issue view` 2026-08-30). #25 saknar plan men äger README; den här planen lägger ett stycke där och rör inte fälttabellerna |
+
+### Triagemässiga noteringar
+
+- Issuet är öppet med etiketten `enhancement`, utan ansvarig och utan kommentarer (`gh issue view 26`, 2026-08-30); `projectItems.totalCount` är 0 via GraphQL samma dag, så det finns ingen projektstatus att läsa. Inga blockerare nämns. Läs om issuet innan arbetet börjar — planen är skriven mot det tillståndet.
+- Gränsen för vad som är publikt går vid filen, inte vid fältet: varje fält i `parti/<filnamn>/index.json` lämnas ut, inklusive handlagda extrafält (README tillåter godtyckliga snake_case-fält sedan #79). Det är samma gräns som redan gäller — repot är publikt och partisidan länkar filen på GitHub — men den ska stå uttalad i README-stycket (fas 5) så att den som lägger till ett fält vet att det publiceras. Personuppgifter hör inte hemma i partifilen; #33 avgör var sådana lagras, och planen där utesluter git.
+- Källornas villkor, kontrollerade 2026-08-30: Valmyndigheten — "all data är fri att använda, förutsatt att du anger Valmyndigheten som källa", https://www.val.se/valresultat-och-statistik/statistik-och-data/om-var-oppna-data; SCB — "Vi använder licensen CC0 för dessa data, vilket innebär att du får använda och sprida eller tillgängliggöra sådana data utan krav på att ange källa", https://www.scb.se/vara-tjanster/oppna-data/ (SCB rekommenderar ändå "Källa: SCB"). Wikidata — CC0, https://www.wikidata.org/wiki/Wikidata:Licensing. Dessa URL:er och datumet skrivs in på licenssidan (designbeslut 7).
+- Bakgrunden i issuet stämmer med `main` (`a7eff4f`): appen kör `output: 'standalone'` bakom nginx, `data/` kopieras in i `.release/` av `scripts/build-release.js` och läses vid request av `src/server/party-data.ts`. Det finns alltså redan en process som har filerna — det som saknas är en route som lämnar ut dem.
+- Risken i det här issuet är inte teknisk utan innehållslig: `data/val/2018/kandidatlistor/gotenes-framtid.json` innehåller namn, ålder och hemvist. Därför är det en allowlist (bara namngivna filmönster släpps ut), inte en denylist, och både `node:test` och HTTP-smoke kontrollerar att just den filen ger 404. Vem som helst kan läsa den på GitHub redan i dag; det ändrar inte att sajten inte ska servera den.
+- Valmyndighetens partisymboler (PNG i `data/parti/<filnamn>/`) kan vara varumärkesskyddade (`data/partisymboler/README.md`) och serveras redan på `/partisymbol/<filnamn>/<bild>`. De ligger utanför `/data/`; JSON-filens `partisymbol.filnamn` förklaras på dokumentationssidan tillsammans med adressen.
+- `profil.json` (två partier i dag) innehåller Wikipedia-utdrag under CC BY-SA 4.0 och nyhetsrubriker, och dess innehåll avgörs i #68–#75/#77. Den lämnas utanför `/data/` i den här PR:en (designbeslut 3); partisidans knapp "Profildata (JSON)" fortsätter peka på GitHub.
+- Inga wiki-länkar i issuet; ingen `wiki`-konfiguration.
+
+## Angreppssätt
+
+**Adressregeln.** `/data/<sökväg>` serverar `data/<sökväg>` ur det `data/`-träd processen startats med (`dataRoot` i `createPartyDataStore`, i drift `.release/data/`). Innehållet är filens byte, inte en omserialisering, så `sha256` på svaret är `sha256` på filen i repot vid samma tagg. Det gör "samma validerade sanningskälla" till något som går att kontrollera utifrån, och det är också vad dokumentationssidan säger: samma fil finns på `https://github.com/swedev/partidata/blob/v<version>/data/<sökväg>`.
+
+**Allowlisten** är en ren modul, `src/server/data-resources.ts`, med en funktion som tar URL-segmenten och svarar med vilken resurs de betecknar — eller ingen. Den är den enda platsen som avgör vad som lämnas ut:
+
+| Segment | Resurs |
+|---------|--------|
+| `derived/parti.json` | Registret (`PartiIndexEntry[]`) |
+| `derived/riksdag.json` | Kammaren och de största partierna utanför riksdagen |
+| `regioner/index.json` | Läns- och kommunkoder (SCB) |
+| `parti/<filnamn>/index.json` | Ett partis registerfil; `<filnamn>` ska vara ett aktuellt eller tidigare `filnamn` i registret |
+| `val/<åååå>/partideltagande/<fil>.json` | `partier`, `riksdag`, `region`, `kommun` eller `landsting` |
+| `val/<åååå>/valresultat/riksdag.json` | Riksdagsresultatet det året |
+
+Allt annat är "ingen resurs": `kandidatlistor/`, `profil.json`, PNG-filer, `parti/kodbyten.json`, `valresultat/riksdag-partikopplingar.json`, `val/<år>/valresultat/scb-tabeller.json`, kataloger, tomma segment, `..`, versaler, och varje segment som inte matchar `^[a-z0-9-]+$` (sista segmentet plus `.json`). Ordningen är avsiktlig: segmenten klassas *innan* någon sökväg byggs, sökvägen byggs ur den klassade resursen (`dataPath(resource)`) och inte ur indata, och `path.relative(path.resolve(dataRoot), path.resolve(dataRoot, ...dataPath(resource)))` kontrolleras vara en relativ sökväg utan `..` innan något läses — hängslen och livrem, som `readPartySymbol` gör med `path.basename`. Symlänkar finns inte i `data/` och ingår inte i hotbilden.
+
+**Lagret** (`src/server/party-data.ts`) får `resolveDataResource(segments)` som returnerar en diskriminerad union i samma stil som `resolveParty`: `{ kind: 'file', body, etag }`, `{ kind: 'redirect', destination }` för ett tidigare `filnamn`, eller `{ kind: 'notFound' }`. Kroppen läses en gång per sökväg och hålls i en `Map<string, Promise<…>>` som de andra cacharna i lagret — datan ändras bara när processen startas om vid deploy. Cachen är bunden av datans storlek: alla allowlistade filer tillsammans är under 28 MB (hela `data/` inklusive PNG och kandidatfiler), varav `val/2026/partideltagande/kommun.json` är den största på 6,9 MB, så värsta fallet är knappt 28 MB mer RSS efter att allt hämtats en gång — i samma storleksordning som det parsade startsidedatat som redan ligger i minnet (designbeslut 13). `etag` är filens SHA-256 som citerad sträng, `"<64 hex>"`; den är stark eftersom svaret är filens byte. Lagret får också `readDataCatalog()` för dokumentationssidan, cachad i ett eget `dataCatalogPromise`: vilka valår som finns och vilka av deras filer, antalet partier i registret, och ett exempelparti — det parti med flest mandat i senaste kammaren som har ett `filnamn`, annars registrets första — så att sidans exempel aldrig är döda länkar.
+
+**Routen** `src/pages/api/data/[...path].ts` följer `partisymbol`- och `sitemap`-routernas mönster, nådd genom en rewrite i `next.config.ts` från `/data/:path+` (ett eller flera segment; `/data/` är dokumentationssidan och matchas inte). `trailingSlash: true` lägger inte till snedstreck på adresser med filändelse — det är samma väg som `/partisymbol/<filnamn>/<bild>.png` och `/sitemap.xml` redan går, och smoke-testet hämtar dem utan avslutande snedstreck i dag. Routen:
+
+- exporterar `config = { api: { bodyParser: false, responseLimit: false } }`: Next varnar annars för svar över 4 MB (`kommun.json` är 6,9 MB), och en avvisad skrivmetod ska inte få sin kropp parsad innan 405;
+- svarar på `GET`, `HEAD` och `OPTIONS`; annan metod → 405 med `Allow: GET, HEAD, OPTIONS`;
+- sätter `Access-Control-Allow-Origin: *` på *varje* svar — 200, 304, 308, 404, 405 — utan det ser en webbläsarklient ett nätverksfel i stället för statuskoden. `OPTIONS` → 204 med `Access-Control-Allow-Methods: GET, HEAD, OPTIONS`, `Access-Control-Allow-Headers: If-None-Match` och `Access-Control-Max-Age: 86400`, *oavsett* om adressen finns: en preflight frågar om metoden får användas, inte om resursen finns, och resursens status kommer i det riktiga anropet (designbeslut 12);
+- `file` → 200 med `Content-Type: application/json; charset=utf-8`, `Content-Length`, `Cache-Control: public, max-age=3600`, `Vary: Accept-Encoding` (nginx gzippar JSON utan `gzip_vary on`, så appen säger själv att kroppen varierar med kodningen), `ETag`, `X-Partidata-Version: <process.env.PARTIDATA_VERSION>` och `Access-Control-Expose-Headers: ETag, X-Partidata-Version` (ETag är inte CORS-safelistad och syns annars inte i `fetch`). Matchar `If-None-Match` etaggen — jämför efter att `W/` och citattecken skalats av varje kommaseparerad post, eftersom nginx försvagar etaggen till `W/"…"` när den gzippar; en post utan citattecken matchar aldrig — → 304 med samma huvuden (`ETag`, `Cache-Control`, `Vary`, `X-Partidata-Version`, CORS) men ingen kropp. `HEAD` ger exakt 200-svarets huvuden inklusive `Content-Length` utan kropp;
+- `redirect` → 308 med `Location: /data/parti/<nytt filnamn>/index.json`;
+- `notFound` → 404 med `Content-Type: application/json; charset=utf-8` och kroppen `{"fel":"Okänd resurs"}`; en okänd metod på en okänd adress ger 405, metoden prövas först som i symbolrouten.
+
+Ingenting i `deploy/partidata.se.conf` behöver ändras: `gzip_types` innehåller redan `application/json`, `X-Content-Type-Options: nosniff` sätts där, `Vary` sätts i appen, och CORS sätts i appen så att `npm run test:http` prövar samma sak som produktionen skickar. Routen är också nåbar direkt på `/api/data/<sökväg>` (som `/api/partisymbol/…` och `/api/sitemap` är i dag); den adressen dokumenteras inte och räknas inte som stabil.
+
+**Dokumentationssidan** `src/pages/data/index.tsx` är en server-renderad sida med `Header`/`Footer` som de andra, `<title>Data – Partidata</title>` och canonical `https://www.partidata.se/data/`. Den läser katalogen i `getServerSideProps` och skriver, i den här ordningen: en ingress; *Adresser* — regeln och en tabell med resurserna ovan, där varje rad är en riktig länk (`/data/derived/parti.json`, `/data/parti/<exempel>/index.json`, ett block per valår med de filer som finns); *Fält* — per resurs: toppnivåformen (array eller objekt), en tabell med fält, typ, obligatoriskt/valfritt och en rad beskrivning, hur identiteterna hänger ihop (`uuid` i registret = `uuid` i partifilen = `parti_uuid` i valresultaten; `kod` = `PARTIKOD`; läns- och kommunkoder = `regioner/index.json`), 2018-filernas avvikelser (`landsting.json`, inget `partier.json`, region/kommun listar bara partier utanför `riksdag.json`), och länk till README-avsnittet på GitHub under den byggda versionens tagg för bakgrunden; *Hämta* — ett `curl`- och ett `fetch`-exempel mot exempelpartiet, vad huvudena betyder (`Cache-Control`, `ETag`/`If-None-Match` — och att etaggen kan vara `W/`-märkt när svaret är komprimerat —, `Vary`, `X-Partidata-Version`, CORS) och statuskoderna (200, 304, 308, 404, 405, 204 på `OPTIONS`); *Versionering* — principen i designbeslut 6; *Licens och villkor* — designbeslut 7; *Det som inte finns här* — kandidatlistor (#33), partisymboler (adress `/partisymbol/`, varumärkesförbehållet), `profil.json` och kopplingstabellerna (på GitHub). Sidan är statisk text plus katalogens listor; ingen klientkod. Stilen läggs i `src/styles/_data.scss` (`@use` från `app.scss`): en `.data-page`-behållare som återanvänder `.site-shell`/`.home-intro`/`.description`, egna tabell- och `<pre>`-stilar i profilens färger — inte Bootstraps `.table`, som #28 vill ta bort.
+
+**Länkarna.** `Header` får en `current`-prop (`'partier' | 'data'`) så att den aktiva understrykningen inte längre är hårdkodad på "Partier"; navigationen blir "Partier" (`/`), "Data" (`/data/`), "Om tjänsten". GitHub-länken flyttar till dokumentationssidan; sidfoten har den redan under "Öppenhet", som får "Data som JSON" (`/data/`) överst. `ExportSection` på partisidan pekar "Registerdata (JSON)" på `/data/parti/<filnamn>/index.json` och får en textlänk till `/data/`; "Profildata (JSON)" och "Projektet på GitHub" står kvar. `api/sitemap.ts` tar med `/data/`.
+
+**Tester.** Allowlisten testas som ren funktion (`scripts/data-resources.test.js`, mönster `scripts/home-segments.test.js`); lagret testas i `scripts/party-data.test.js` mot ett temporärt `data/`-träd som också innehåller en `kandidatlistor`-fil och en PNG, med assertion att båda ger `notFound`; HTTP-smoke prövar allt issuet räknar upp mot det riktiga registret. Stegen är ordnade så att bygget är grönt efter varje fas.
+
+## Steg
+
+### Fas 1: Allowlist och lager med tester
+
+1. Skapa `src/server/data-resources.ts`
+   - `export type DataResource = { kind: 'registry' } | { kind: 'derived-parliament' } | { kind: 'regions' } | { kind: 'party'; filnamn: string } | { kind: 'participation'; valar: string; fil: string } | { kind: 'results'; valar: string }`
+   - `export const PARTICIPATION_FILES = ['partier', 'riksdag', 'region', 'kommun', 'landsting'] as const`
+   - `export function classifyDataPath (segments: string[]): DataResource | undefined` — varje segment ska matcha `/^[a-z0-9-]+$/` (sista segmentet `/^[a-z0-9-]+\.json$/`), valår `/^\d{4}$/`; matcha mot tabellen i Angreppssätt; allt annat `undefined`
+   - `export function dataPath (resource: DataResource): string[]` — segmenten tillbaka från resursen, så lagret bygger sökvägen ur den klassade resursen och inte ur indata
+   - Inga importer från `src/` med alias; relativa importer med `.ts`-ändelse som `segments.ts`, så modulen går att `require` från `node:test`
+2. Skapa `scripts/data-resources.test.js`
+   - accepterar var och en av de sex resursformerna med rätt fält
+   - avvisar: `[]`, `['derived']`, `['derived', 'parti.json', 'x']`, `['parti', 'moderaterna']`, `['parti', 'moderaterna', 'profil.json']`, `['parti', 'moderaterna', '0001-moderaterna.png']`, `['parti', 'kodbyten.json']`, `['val', '2018', 'kandidatlistor', 'gotenes-framtid.json']`, `['val', '2022', 'valresultat', 'scb-tabeller.json']`, `['val', '22', 'partideltagande', 'partier.json']`, `['val', '2022', 'partideltagande', 'ovrigt.json']`, `['valresultat', 'riksdag-partikopplingar.json']`, `['..', 'package.json']`, `['parti', '..', 'kodbyten.json']`, `['Derived', 'parti.json']`, `['derived', 'parti.JSON']`, `['derived', 'parti.json/']`, `['']`
+   - `dataPath(classifyDataPath(s))` ger tillbaka `s` för varje accepterad form
+3. Ändra `src/server/party-data.ts`
+   - `export type DataResourceResolution = { kind: 'file'; body: Buffer; etag: string } | { kind: 'redirect'; destination: string } | { kind: 'notFound' }`
+   - `resolveDataResource (segments: string[]): Promise<DataResourceResolution>` i det returnerade objektet: `classifyDataPath` → `notFound` vid `undefined`; för `party`: `index.current.has(filnamn)` → läs, `index.redirects.get(filnamn)` → `redirect` till `/data/parti/<filnamn>/index.json`, annars `notFound`; för `participation`/`results`: läs; ENOENT → `notFound` (år utan den filen, t.ex. `val/2026/valresultat/riksdag.json` eller `val/2022/partideltagande/landsting.json`). Läsningen går via en `Map<string, Promise<{ body: Buffer; etag: string } | undefined>>` nycklad på sökvägen; `etag` = `'"' + createHash('sha256').update(body).digest('hex') + '"'`. Innan läsning: `const root = path.resolve(dataRoot); const file = path.resolve(root, ...dataPath(resource)); const rel = path.relative(root, file);` och kräv `rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)`, annars `notFound`
+   - `export interface DataCatalog { antalPartier: number; exempel: { filnamn: string; beteckning: string }; valar: Array<{ valar: string; partideltagande: string[]; valresultat: boolean }> }` och `readDataCatalog (): Promise<DataCatalog>`: åren från `electionYears()`; `partideltagande` = de av `PARTICIPATION_FILES` som finns i `val/<år>/partideltagande/` (samma ordning som listan); `valresultat` = `readParliamentResults()` har året; `exempel` = partiet med flest mandat i senaste kammaren (`readParliamentYears` sorterat, första året, största `mandat` med `filnamn`), annars registrets första post. Cachas i ett eget `dataCatalogPromise` bredvid `homeDataPromise` (som håller `HomeData` och inte ska återanvändas)
+   - `assertHealthy` lämnas orörd
+4. Utöka `scripts/party-data.test.js`
+   - Rör inte `makeData()` — befintliga tester förutsätter att `valresultat` är `undefined` för `testpartiet`. Lägg en hjälpare `withDataFiles(dataRoot)` som *ovanpå* `makeData()` skriver `val/2018/partideltagande/riksdag.json`, `val/2022/valresultat/riksdag.json` (minimal `schema_version: 2`-fil med en röst- och mandatrad för `testpartiet`, i samma form som `partyElectionResults`-testet bygger), `regioner/index.json` och `derived/riksdag.json`; PNG:n och `val/2018/kandidatlistor/testpartiet.json` finns redan i `makeData()`. De nya testerna anropar `withDataFiles` och skapar ett eget lager, så inget befintligt test ser de nya filerna
+   - `resolveDataResource(['derived', 'parti.json'])` ger `file` vars `body` är byte-lika med filen på disk och vars `etag` är `"` + sha256 + `"`
+   - `['parti', 'testpartiet', 'index.json']` → `file`; `['parti', 'gamla-testpartiet', 'index.json']` → `redirect` till `/data/parti/testpartiet/index.json`; `['parti', 'okant', 'index.json']` → `notFound`
+   - `['val', '2018', 'kandidatlistor', 'testpartiet.json']` → `notFound` trots att filen finns; `['parti', 'testpartiet', '9001-testpartiet.png']` → `notFound`; `['parti', 'testpartiet', 'profil.json']` → `notFound`
+   - `['val', '2022', 'partideltagande', 'landsting.json']` → `notFound` (år utan filen); `['val', '2018', 'partideltagande', 'riksdag.json']` → `file`
+   - `readDataCatalog()` listar 2018 med `['riksdag']` och `valresultat: false`, 2022 med `[]` och `valresultat: true`; `antalPartier` är 2; `exempel.filnamn` är det parti som har mandat i resultatfilen
+5. `npm test && npm run typecheck`
+
+### Fas 2: Routen och rewriten
+
+6. Skapa `src/pages/api/data/[...path].ts`
+   - `export const config = { api: { bodyParser: false, responseLimit: false } }`
+   - Sätt `Access-Control-Allow-Origin: *` först, på alla svar
+   - `OPTIONS` → 204 med `Access-Control-Allow-Methods: GET, HEAD, OPTIONS`, `Access-Control-Allow-Headers: If-None-Match`, `Access-Control-Max-Age: 86400`, `end()` — före resursuppslaget, för alla adresser (designbeslut 12)
+   - annan metod än `GET`/`HEAD` → `Allow: GET, HEAD, OPTIONS`, 405, `end()`
+   - Läs `request.query.path`; är det inte en `string[]` → 404 som nedan
+   - `partyData.resolveDataResource(path)`: `notFound` → 404, `Content-Type: application/json; charset=utf-8`, kropp `{"fel":"Okänd resurs"}` (tom vid `HEAD`); `redirect` → `Location`, 308, `end()`
+   - `file`: `Cache-Control: public, max-age=3600`, `Vary: Accept-Encoding`, `ETag`, `X-Partidata-Version` (bara när `process.env.PARTIDATA_VERSION` finns), `Access-Control-Expose-Headers: ETag, X-Partidata-Version`; om `matchesEtag(request.headers['if-none-match'], etag)` → 304, `end()`; annars `Content-Type: application/json; charset=utf-8`, `Content-Length`, 200, `end(request.method === 'HEAD' ? undefined : body)`
+   - Lägg `matchesEtag (header: string | undefined, etag: string): boolean` som exporterad funktion i `src/server/data-resources.ts` så att den får ett test (fas 2 steg 8) i stället för att ligga inline
+7. Ändra `next.config.ts`: lägg till `{ source: '/data/:path+', destination: '/api/data/:path+' }` i `rewrites()` efter `partisymbol`-raden
+8. Utöka `scripts/data-resources.test.js` med `matchesEtag(header, etag)` där `etag` är den citerade strängen: `'"abc"'` → sant; `'W/"abc"'` → sant; `'"x", "abc"'` → sant; `' "abc" '` → sant; `'*'` → sant; `undefined`, `''`, `'"abd"'`, `'abc'` (utan citattecken), `'"ab'`, `'W/abc'` → falskt
+9. `npm run build:release && npm run test:http` (befintliga assertions gröna) och `curl -i http://127.0.0.1:<port>/data/derived/parti.json` mot `.release/server.js` för att se svaret med egna ögon: 200 direkt, inte 308 med snedstreck — det är vad `trailingSlash` gör med filändelser i dag (`/sitemap.xml`, `/partisymbol/…png`), och smoke-testet i fas 6 låser det med `redirect: 'manual'`. Skulle det ändå bli 308: ta reda på varför innan något ändras (Next-versionens `trailingSlash`-regler, rewritens form), och först om orsaken är rewrite-ordningen flytta den till `beforeFiles` — och skriv orsaken i PR:en
+
+### Fas 3: Dokumentationssidan, navigationen och sitemapen
+
+10. Skapa `src/styles/_data.scss` och `@use "./data";` i `src/styles/app.scss`
+    - `.data-page` (max-bredd ~`50rem` för löptext, `.data-page table` full bredd inom `.site-shell`), tabeller med `border-top: 2px solid var(--partidata-text)` och `1px solid var(--partidata-line)` mellan rader som `.participation-list`, `th` i `var(--partidata-navy)`, `code`/`pre` i `var(--font-partidata-mono)` med bakgrund `var(--partidata-soft)` och `overflow-x: auto`, `h2` med `margin-top: clamp(2.5rem, 6vw, 4rem)`
+11. Skapa `src/pages/data/index.tsx`
+    - `getServerSideProps` → `{ props: await partyData.readDataCatalog() }`
+    - `<Head>`: `<title>Data – Partidata</title>`, `<meta name="description" content="Partidatas data som JSON: adresser, fält, källor, versionering och licens.">`, ikon och canonical som de andra sidorna
+    - `<Header current="data" />`, `<main className="container data-page">`, `<Footer />`
+    - Sektioner med `id` och `aria-labelledby` som partisidan: `#adresser`, `#falt`, `#hamta`, `#versionering`, `#licens`, `#utanfor`
+    - *Adresser*: regeln som mening + `<code>https://www.partidata.se/data/&lt;sökväg&gt;</code>`; tabell Resurs / Adress / Innehåll med riktiga `<a href>`: `/data/derived/parti.json`, `/data/derived/riksdag.json`, `/data/regioner/index.json`, `/data/parti/{exempel.filnamn}/index.json` (med "byt ut mot partiets `filnamn` ur registret"), och per år i `valar` (senaste först) en rad per fil i `partideltagande` och en för `valresultat/riksdag.json` när den finns. Nämn att ett tidigare `filnamn` svarar 308 till det nuvarande, och att `{antalPartier}` partier finns i registret
+    - *Fält*: per resurs en underrubrik (`<h3>`), toppnivåformen i en mening, en tabell Fält / Typ / Obligatoriskt / Beskrivning byggd ur `FIELD_DOCS` i `src/pages/data/fields.ts` (nästa punkt), och för `parti/<filnamn>/index.json` meningen "Fält som inte står i tabellen är handlagda extrafält (snake_case, valfritt JSON-värde) och är lika publika". Relationerna och 2018-avvikelserna enligt Angreppssätt. Bokstavskoderna (`grunder` A/R/K; `kandidatlistor` finns inte här, men `R`/`K` i `partideltagande` betyder deltagandegrund) skrivs ut. README-länkarna byggs som `https://github.com/swedev/partidata/blob/${process.env.PARTIDATA_VERSION ? \`v${version}\` : 'main'}/README.md#…` med ankarna `#partifilnamnindexjson`, `#valårpartideltagande`, `#valårvalresultatriksdagjson`, `#derivedpartijson`, `#regionerindexjson` — kontrollera ankarna mot GitHubs rendering av README (GitHub tar bort `\` och `<>` och gemenar)
+    - *Hämta*: `<pre>` med `curl -i https://www.partidata.se/data/parti/{exempel.filnamn}/index.json` och ett `fetch(...).then(r => r.json())`; en lista över huvudena med en rad var (inklusive att `ETag` är `W/`-märkt när svaret levereras komprimerat och att `If-None-Match` ändå ger 304); statuskoderna 200/304/308/404/405 och 204 på `OPTIONS`; att alla svar bär `Access-Control-Allow-Origin: *`; att bara `GET`, `HEAD` och `OPTIONS` tillåts
+    - Skapa `src/pages/data/fields.ts` med `FieldDoc = { namn: string; typ: string; obligatoriskt: boolean; beskrivning: string }` och `FIELD_DOCS` per resurs, och `scripts/data-fields.test.js` som läser ett riktigt exemplar av varje resurs ur `data/` (registret, `data/parti/moderaterna/index.json`, senaste årets `partideltagande/partier.json`, ett `valresultat/riksdag.json`, `regioner/index.json`, `derived/riksdag.json`) och kontrollerar att varje toppnivånyckel i exemplaret finns i `FIELD_DOCS` (extrafält i partifilen undantagna: nycklar som inte finns i `PARTY_KEY_ORDER` från `scripts/parti.js`) och att varje `obligatoriskt: true`-fält finns i exemplaret. Nästlade fält skrivs med punktnotation (`partisymbol.filnamn`, `rostresultat.partier[].parti_uuid`) och täcks av tabellen men inte av testet. Datan är sanningen, inte TypeScript-typerna, så testet behöver inte tolka `src/types.ts`
+    - *Versionering*: texten i designbeslut 6, inklusive länkmönstret till GitHub-taggen
+    - *Licens och villkor*: texten i designbeslut 7, med källornas URL:er och kontrolldatum utskrivna
+    - *Det som inte finns här*: kandidatlistor (länk till #33), partisymboler (`/partisymbol/<filnamn>/<partisymbol.filnamn>`, varumärkesförbehållet), `profil.json` och kopplingstabellerna med länk till `data/` på GitHub
+12. Ändra `src/components/Header.tsx`: `function Header ({ current = 'partier' }: { current?: 'partier' | 'data' })`; `<Link href="/" className={current === 'partier' ? 'site-header__active-link' : undefined}>Partier</Link>`, `<Link href="/data/" className={current === 'data' ? … }>Data</Link>`, `<a href="#om-tjansten">Om tjänsten</a>`. Ta bort "Data på GitHub". `src/pages/index.tsx` och `src/pages/parti/[filnamn].tsx` behöver inte ändras (förvalet är `partier`)
+13. Ändra `src/components/Footer.tsx`: under "Öppenhet", ny första post `<li><Link href="/data/">Data som JSON</Link></li>` (importera `Link` från `next/link`)
+14. Ändra `src/pages/api/sitemap.ts`: `new URL('/data/', baseUrl).toString()` efter startsidan
+15. `npm run dev` och läs sidan på `/data/`: varje länk i adresstabellen svarar 200; `Header` visar "Data" understruket på `/data/` och "Partier" på `/`
+
+### Fas 4: Partisidans länkar
+
+16. Ändra `ExportSection` i `src/components/party-profile/sources.tsx`
+    - `const dataUrl = \`/data/parti/${slug}/index.json\`` (encodeURIComponent på `slug` som symbolrouten gör)
+    - Texten: "Källan står vid varje uppgift på sidan. Partiets registerdata finns som JSON på Partidata; alla datafiler är versionshanterade på GitHub." och en `<Link href="/data/">Så använder du datan</Link>` efter knapparna
+    - `profileUrl` (GitHub) och "Projektet på GitHub" står kvar
+
+### Fas 5: Dokumentation i repot
+
+17. Ändra `README.md`: nytt stycke överst i "Tillgänglig data": registret, partifilerna, `partideltagande/`, `valresultat/riksdag.json`, `regioner/index.json` och `derived/` serveras som JSON på `https://www.partidata.se/data/<sökväg>` — samma sökväg som under `data/` — med länk till `https://www.partidata.se/data/` för adresser, huvuden och villkor; kandidatlistor och `profil.json` serveras inte; och att varje fält i en partifil, extrafält inräknade, publiceras där (allowlisten går vid filen, inte vid fältet). Ändra inte fälttabellerna (#25 äger resten av README)
+18. Ändra `CLAUDE.md` under "Stack": en punkt om att `/data/<sökväg>` serverar en allowlistad delmängd av `data/` genom `src/pages/api/data/[...path].ts` (rewrite från `/data/`), att allowlisten bor i `src/server/data-resources.ts` och är det enda stället som avgör vad som lämnas ut, och att `/data/` är dokumentationssidan
+19. `deploy/README.md` behöver ingen ändring; nämn i PR-bodyn att nginx-konfigurationen är oförändrad och varför
+
+### Fas 6: HTTP-smoke och verifiering
+
+20. Utöka `scripts/http-smoke.js` (efter sitemap-blocket)
+    - Hjälpare `expectDataHeaders(response, { etag, length, body = true })` som kontrollerar hela huvuduppsättningen på ett ställe: `content-type` = `application/json; charset=utf-8` när `body` är sant (200 och `HEAD` — `HEAD` bär 200-svarets huvuden; 304 utelämnar det), `content-length` = `length` när den anges, `cache-control` = `public, max-age=3600`, `vary` = `Accept-Encoding`, `etag` = `etag`, `x-partidata-version` = `version`, `access-control-allow-origin` = `*`, `access-control-expose-headers` innehåller både `ETag` och `X-Partidata-Version`
+    - `registry = await fetch(\`${baseUrl}/data/derived/parti.json\`, { redirect: 'manual' })`: exakt 200 (ingen 308 från `trailingSlash`); `expectDataHeaders`; `etag` matchar `/^"[0-9a-f]{64}"$/` och är sha256 av `fs.readFileSync('data/derived/parti.json')`; kroppen är byte-lika med filen (`Buffer.equals`)
+    - samma URL med `If-None-Match: <etag>` → 304 utan kropp och med `expectDataHeaders(…, { body: false })`; med `W/<etag>` → 304; med `If-None-Match: abc` (ociterat) och med `"<annan sha>"` → 200
+    - `HEAD` → 200, `expectDataHeaders` med `length` = filens storlek, tom kropp
+    - var och en av `POST`, `PUT`, `PATCH`, `DELETE` → 405 med `allow` = `GET, HEAD, OPTIONS` och `access-control-allow-origin` = `*`
+    - `OPTIONS` på registret → 204 med `access-control-allow-origin` = `*`, `access-control-allow-methods` = `GET, HEAD, OPTIONS`, `access-control-allow-headers` innehåller `If-None-Match`, `access-control-max-age` = `86400`; `OPTIONS` på `/data/finns-inte.json` → också 204 med samma huvuden (designbeslut 12)
+    - `/data/parti/${current.filnamn}/index.json` → 200 och `JSON.parse` ger `uuid === current.uuid`; `/data/parti/${previous.tidigare_filnamn[0]}/index.json` med `redirect: 'manual'` → 308 till `/data/parti/${previous.filnamn}/index.json` med `access-control-allow-origin` = `*`; `/data/parti/finns-inte/index.json` → 404, `content-type` JSON, kroppen parsear till `{ fel: 'Okänd resurs' }`, `access-control-allow-origin` = `*`
+    - exakt 404 för var och en av: `/data/val/2018/kandidatlistor/gotenes-framtid.json` (kontrollera med `fs.existsSync` först; saknas filen → `assert.fail` med instruktion att peka på en annan kandidatfil, så att testet aldrig blir tomt), `/data/parti/${withSymbol.filnamn}/${withSymbol.partisymbol.filnamn}`, `/data/parti/${profiled.filnamn}/profil.json` (där `profiled` är ett parti vars `profil.json` finns — hoppa med en logg om inget finns), `/data/parti/kodbyten.json`, `/data/valresultat/riksdag-partikopplingar.json`, `/data/derived/`, `/data/%2e%2e/package.json`, `/data/parti/%2e%2e/kodbyten.json`, `/data/derived%2fparti.json`, `/data/derived/parti.json%00`, `/data/DERIVED/parti.json`. `%2e%2e` avkodas till `..` av Next och faller på segmentregexen; `%2f` blir ett segment med `/`, faller på samma; `%00` likaså. För adresser Next själv kan normalisera med en 308 innan routen nås — `/data/derived`, `/data/derived//parti.json`, `/data/derived/parti.json/` — och för en rå `http.request` med `path: '/data/../package.json'` (fetch normaliserar `..` innan sändning) är kravet i stället: följ högst en redirect inom `/data/`, och slutsvaret får inte vara 200 med JSON-kropp. Det som låses är att inget läcker, inte vilken kod ramverket väljer
+    - `/api/data/derived/parti.json` → 200 (routens egen adress fungerar men dokumenteras inte)
+    - `/data/val/${latest}/partideltagande/partier.json` → 200 och parsear till samma längd som filen; `/data/val/${results.at(-1).valar}/valresultat/riksdag.json` → 200; `/data/val/${latest}/valresultat/riksdag.json` → 404 om filen saknas för det året (som 2026 i dag), annars 200
+    - `/data/` → 200; `<title[^>]*>Data – Partidata</title>`; plocka ut alla `href="/data/[^"]+"` ur sidan (mönster `partyGridLinks`) och `fetch` var och en med `redirect: 'manual'` → exakt 200 — det är "fungerande exempel" i acceptanskriteriet; sidan innehåller `Access-Control-Allow-Origin` och `CC0`
+    - sitemapen innehåller `/data/`; `profileBody` innehåller `href="/data/parti/${current.filnamn}/index.json"` och inte `github.com/swedev/partidata/blob/main/data/parti/${current.filnamn}/index.json`; `homeBody` innehåller `href="/data/"` i navigationen
+21. `npm run precommit`
+22. Manuell kontroll mot `.release/server.js`: `ps -o rss` på processen direkt efter `/api/health`, sedan efter att varje länk på `/data/` hämtats en gång (loopa `href`-listan från steg 20 med `curl -o /dev/null`), sedan en gång till. Godkänt: ökningen mellan första och andra mätningen är under 60 MB (datan är 28 MB; utrymme för Buffer-overhead) och under 5 MB mellan andra och tredje (cachen växer inte per anrop; RSS rör sig ändå något med GC). `curl -i` på `/data/val/2026/partideltagande/kommun.json` två gånger — andra svaret ska komma ur cachen. Skriv siffrorna i PR:en. CORS i praktiken: starta en andra lokal HTTP-origin (`python3 -m http.server 8080` i en tom katalog med en `index.html` som kör `fetch('http://127.0.0.1:<port>/data/derived/parti.json').then(r => r.json()).then(d => console.log(d.length))`) och öppna `http://127.0.0.1:8080/` — två `http`-origins, så varken mixed content eller Private Network Access stör. Efter deploy: samma `fetch` mot `https://www.partidata.se/data/derived/parti.json` från devtools på en annan `https`-sida, plus `curl --compressed -i` och `curl -H 'Accept-Encoding: identity' -i` mot produktionsadressen för att se att nginx ger `Content-Encoding: gzip` respektive okomprimerat med samma `Vary` och en `W/`-etag i det komprimerade fallet
+
+## Filöversikt
+
+| Fil | Åtgärd | Syfte |
+|-----|--------|-------|
+| `src/server/data-resources.ts` | Skapa | Allowlisten: `classifyDataPath`, `dataPath`, `matchesEtag` |
+| `scripts/data-resources.test.js` | Skapa | `node:test` för allowlisten och etag-jämförelsen |
+| `src/server/party-data.ts` | Ändra | `resolveDataResource`, `readDataCatalog`, filcache med SHA-256 |
+| `scripts/party-data.test.js` | Ändra | Lagrets nya metoder mot ett temporärt träd med kandidatfil och PNG |
+| `src/pages/api/data/[...path].ts` | Skapa | Routen: metoder, CORS, cache, ETag/304, 308, 404 |
+| `next.config.ts` | Ändra | Rewrite `/data/:path+` → `/api/data/:path+` |
+| `src/pages/data/index.tsx` | Skapa | Dokumentationssidan, server-renderad ur katalogen |
+| `src/pages/data/fields.ts`, `scripts/data-fields.test.js` | Skapa | Fältdokumentationen som typad lista, med test mot riktiga exemplar i `data/` |
+| `src/styles/_data.scss`, `src/styles/app.scss` | Skapa / Ändra | Sidans tabell- och kodstilar |
+| `src/components/Header.tsx` | Ändra | `current`-prop; "Data" → `/data/`; GitHub-länken bort ur navigationen |
+| `src/components/Footer.tsx` | Ändra | "Data som JSON" under Öppenhet |
+| `src/components/party-profile/sources.tsx` | Ändra | `ExportSection` pekar på `/data/parti/<filnamn>/index.json` |
+| `src/pages/api/sitemap.ts` | Ändra | `/data/` i sitemapen |
+| `scripts/http-smoke.js` | Ändra | 200/304/404/405/OPTIONS, content-type, CORS, etag, kandidatfil, partisidans länk |
+| `README.md` | Ändra | Stycke om adresserna i "Tillgänglig data" |
+| `CLAUDE.md` | Ändra | Punkt om `/data/`-routen och allowlisten |
+
+## Berörda kodområden
+
+- `src/server/`
+- `src/pages/api/`
+- `src/pages/data/`
+- `src/components/` (Header, Footer, party-profile/sources)
+- `src/styles/`
+- `scripts/` (tester och HTTP-smoke)
+- `next.config.ts`, `README.md`, `CLAUDE.md`
+
+## Designbeslut
+
+> Icke-triviala val gjorda under planeringen. Feedback välkommen; annars implementeras enligt dessa.
+
+### 1. Adressen är repots sökväg: `/data/<sökväg>` ⇔ `data/<sökväg>`
+**Alternativ:** A) spegla filträdet under `/data/` — B) ett eget REST-liknande schema (`/api/partier/`, `/api/partier/<uuid>/`) med omserialiserade svar
+**Beslut:** A
+**Motivering:** Issuet ber om en sida på `/data/` och om svar ur samma validerade filer som sajten läser (användarbeslut, #26). Med A är dokumentationen en regel plus en lista, versioneringen blir "samma fil på GitHub under taggen", och svaret går att verifiera byte för byte. B skulle kräva en andra representation att dokumentera, validera och hålla i synk. Att svaren är filens byte och inte `JSON.stringify(JSON.parse(...))` är agentens bedömning — öppen, men det är vad som gör `ETag = sha256(fil)` sant.
+
+### 2. Allowlist i en ren modul, inte en denylist i routen
+**Alternativ:** A) `classifyDataPath` räknar upp de filmönster som lämnas ut — B) servera allt under `data/` utom `kandidatlistor/` och PNG
+**Beslut:** A
+**Motivering:** Kandidatfiler får inte exponeras (användarbeslut, #26 och #33). En denylist faller åt fel håll när en ny katalog dyker upp i `data/`; en allowlist faller stängt. Att modulen är ren och testad följer konventionen från `segments.ts`/`query.ts` med `node:test` i `scripts/`.
+
+### 3. `profil.json` lämnas utanför `/data/` i den här PR:en
+**Alternativ:** A) servera `parti/<filnamn>/profil.json` också — B) inte i den här PR:en
+**Beslut:** B
+**Motivering:** Agentens bedömning — öppen. Issuets uppräkning är registret, partiernas registerdata, deltagande och valresultat; profilen nämns inte. Filen bär Wikipedia-utdrag (CC BY-SA 4.0) och nyhetsrubriker, finns för två partier, och dess innehåll avgörs i #68–#75/#77. Att ta med den skulle göra licensavsnittet villkorat per fält innan innehållet är bestämt. Partisidans knapp "Profildata (JSON)" fortsätter peka på GitHub; när profilen är fastlagd är det en rad i allowlisten och en rad på sidan.
+
+### 4. `derived/riksdag.json` och `regioner/index.json` tas med
+**Alternativ:** A) bara det issuet räknar upp — B) också härledningen och områdeskoderna
+**Beslut:** B
+**Motivering:** Agentens bedömning — öppen. `regioner/index.json` behövs för att läsa `deltagande.region`/`kommun` och `partideltagande/region.json`; utan den är deltagandet koder utan namn. `derived/riksdag.json` är den dokumenterade härledning startsidan bygger på (`docs/riksdagsvalresultat.md`), genererad ur filer som redan serveras. Kopplingstabellerna (`kodbyten.json`, `riksdag-partikopplingar.json`) och `scb-tabeller.json` är arbetsmaterial för importen och stannar på GitHub.
+
+### 5. `Cache-Control: public, max-age=3600` med stark `ETag` och 304
+**Alternativ:** A) `max-age=3600` + ETag — B) `max-age=300` som sitemapen — C) `no-cache` med enbart ETag
+**Beslut:** A
+**Motivering:** Agentens bedömning — öppen. Datan ändras bara vid deploy, så en timme är en förutsägbar övre gräns för "hur gammalt kan ett svar vara", vilket är vad issuet ber om att dokumentera; symbolrouten använder redan samma värde (befintlig konvention, `src/pages/api/partisymbol/[filnamn]/[bild].ts`). ETag/304 gör en omhämtning billig för klienter som pollar. En ny release bör i PR-bodyn nämnas som "syns inom en timme".
+
+### 6. Versioneringsprincip
+**Alternativ:** A) versionen i svaret (`X-Partidata-Version`) + regeln "tillägg utan förvarning, borttag med notis och 308" — B) versionerade adresser (`/data/v1/…`)
+**Beslut:** A
+**Motivering:** Agentens bedömning — öppen; issuet ber om att en princip dokumenteras men säger inte vilken. Principen som skrivs på sidan: (1) adresser och fältnamn är stabila och nya fält kan tillkomma utan förvarning — en läsare ska ignorera okända fält; (2) datan ändras bara vid en release, versionen står i `X-Partidata-Version`, i sidfoten och i `/api/health`, och samma filer finns på `https://github.com/swedev/partidata/tree/v<version>/data/`; (3) ett fält eller en adress som tas bort eller döps om görs i en release som noteras på `/data/`, och en flyttad adress vidarebefordras (308) när det går — som `parti/index.json` → `derived/parti.json` redan beskrivs i README. B skulle låsa fast en `v1` innan gränssnittet har haft en läsare.
+
+### 7. Licensavsnittet: CC0 för sammanställningen, källvillkor per ursprung
+**Alternativ:** A) "allt är CC0" — B) CC0 för Partidatas sammanställning och struktur, med källornas villkor uttryckligen per ursprung
+**Beslut:** B
+**Motivering:** Användarbeslut i #26 ("document which parts are covered by CC0 and which assets or sources carry other terms"). Texten: Partidatas sammanställning — struktur, `uuid`, `filnamn`, härledda fält, `derived/` — är CC0 1.0 (`LICENSE`, `package.json`). Valmyndighetens uppgifter är fria att använda med Valmyndigheten som källa (`data/partisymboler/README.md` citerar villkoret), och `kalla`/`kallurl`/`kallor` i filerna anger källan per post. Wikidata (`wikidata.grundat`) är CC0 enligt https://www.wikidata.org/wiki/Wikidata:Licensing. Villkoren är kontrollerade 2026-08-30 och skrivs på sidan med URL och datum: Valmyndigheten, https://www.val.se/valresultat-och-statistik/statistik-och-data/om-var-oppna-data — "fri att använda, förutsatt att du anger Valmyndigheten som källa"; SCB, https://www.scb.se/vara-tjanster/oppna-data/ — CC0, utan krav på källa, med rekommendationen "Källa: SCB". Implementeraren läser båda sidorna igen vid implementationen och uppdaterar datumet. Partisymboler serveras inte under `/data/` och kan vara varumärkesskyddade. `profil.json` (Wikipedia CC BY-SA 4.0, nyhetsrubriker) serveras inte (beslut 3). Kandidatuppgifter publiceras inte (#33).
+
+### 8. CORS-huvud på alla svar, `OPTIONS` besvaras
+**Alternativ:** A) `Access-Control-Allow-Origin: *` bara på 200 — B) på alla svar från routen, och `OPTIONS` → 204 med tillåtna metoder
+**Beslut:** B
+**Motivering:** Issuet kräver läsning från andra webbplatser utan att öppna skrivmetoder (användarbeslut). Utan huvudet på 404/405/308 får en webbläsarklient inte se statuskoden. `OPTIONS` är inget skrivande, och en klient som skickar `If-None-Match` från ett skript triggar preflight. Att sätta CORS i appen och inte i nginx är agentens bedömning: då prövar `npm run test:http` samma huvuden som produktionen skickar.
+
+### 9. Dokumentationssidan är en server-renderad TSX-sida ur katalogen; fältkontraktet står på sidan, bakgrunden i README
+**Alternativ:** A) statisk TSX med hårdkodade exempel — B) TSX som läser katalogen så att exempel och årslistor alltid stämmer, med fälttabeller (namn, typ, obligatoriskt) som kontrakt och länk till README för bakgrunden — C) hela README-fältdokumentationen flyttad till sidan
+**Beslut:** B
+**Motivering:** Agentens bedömning — öppen. Sidan ska ha fungerande exempel (användarbeslut, #26); med katalogen kan ett exempel inte peka på ett år eller parti som inte finns, och `standingParties`-mönstret i smoke-testet visar att projektet föredrar tester som räknar ut det förväntade ur datan. Fälttabellerna på sidan säger vad en läsare kan lita på — typ och obligatoriskt, som README inte anger — och testet mot riktiga exemplar i `data/` håller dem i takt med datan på toppnivå; nästlade strukturer (`partisymbol.bild`, `deltagande.<år>`, `kallor[]`, `rostresultat.partier[]`) dokumenteras med punktnotation i samma tabell men kontrolleras inte av testet, vilket är en känd begränsning. README behåller prosan om vad fälten betyder och hur de uppstår. C tömmer README, som #25 arbetar med; A ger döda länkar nästa gång ett parti byter `filnamn`.
+
+### 10. Navigationen: "Data" ersätter "Data på GitHub"; sidfoten får "Data som JSON"
+**Alternativ:** A) lämna navigationen, länka bara från partisidan — B) "Data" → `/data/` i huvudnavigationen, GitHub-länken kvar i sidfoten och på sidan
+**Beslut:** B
+**Motivering:** Agentens bedömning — öppen. Issuet ber bara om partisidans länk. Men en dokumentationssida som ingen navigation leder till hittas inte, och "Data på GitHub" i navigationen är den plats dagens läsare redan letar efter datan på. GitHub-länken försvinner inte: sidfoten har den, och `/data/` länkar dit per resurs.
+
+### 11. 404-kroppen är JSON, `{"fel":"Okänd resurs"}`
+**Alternativ:** A) tom kropp som symbolrouten — B) en liten JSON-kropp
+**Beslut:** B
+**Motivering:** Agentens bedömning — öppen. En klient som gör `r.json()` på ett fel får något att visa; svenskt fältnamn enligt konventionen i CLAUDE.md. Symbolrouten är ett bildsvar och behöver ingen kropp.
+
+### 12. `OPTIONS` svarar 204 för alla adresser under `/data/`, även okända
+**Alternativ:** A) slå upp resursen först och svara 404 på `OPTIONS` mot en okänd adress — B) 204 med tillåtna metoder oavsett adress
+**Beslut:** B
+**Motivering:** Agentens bedömning — öppen. En preflight frågar "får den här metoden användas här", inte "finns resursen"; resursens status kommer i det riktiga anropet, som bär CORS-huvudet. Att slå upp resursen i preflighten skulle bara flytta 404:an ett steg tidigare och göra webbläsarens felmeddelande sämre (en preflight som misslyckas syns som ett CORS-fel, inte som 404). Smoke-testet låser beteendet så att det är ett val och inte en bieffekt.
+
+### 13. Hela filen cachas i minnet per sökväg
+**Alternativ:** A) cacha kropp och etag för alla allowlistade filer — B) cacha bara etag och läs stora filer från disk varje gång — C) strömma alltid, räkna etag vid start
+**Beslut:** A
+**Motivering:** Agentens bedömning — öppen. Cachen är bunden av datan (under 28 MB totalt, 6,9 MB största fil) och växer inte per anrop; det är samma storleksordning som `HomeData` och resultatfilerna som redan hålls parsade. B sparar minne men ger disk-I/O på den största filen vid varje träff; C komplicerar 304-vägen. Steg 22 mäter och sätter gränsen 60 MB RSS-ökning; överskrids den byts till B i samma PR.
+
+## Verifieringschecklista
+
+- [ ] `GET /data/derived/parti.json` och `GET /data/parti/<filnamn>/index.json` ger 200, `application/json; charset=utf-8`, och kroppen är byte-lika med filen i repot
+- [ ] `ETag` är filens SHA-256; `If-None-Match` (även `W/`) ger 304 med samma huvuden; ociterade eller fel etaggar ger 200
+- [ ] `Cache-Control: public, max-age=3600`, `Vary: Accept-Encoding` och `X-Partidata-Version` = `package.json`-versionen; `HEAD` bär samma huvuden och `Content-Length`
+- [ ] `Access-Control-Allow-Origin: *` på 200, 304, 308, 404 och 405; `OPTIONS` → 204 med `GET, HEAD, OPTIONS` även på okänd adress; `POST`/`PUT`/`PATCH`/`DELETE` → 405 med `Allow`
+- [ ] Tidigare `filnamn` → 308 till nuvarande; okänt `filnamn` → 404 med JSON-kropp
+- [ ] Exakt 404 för `val/<år>/kandidatlistor/*.json`, `profil.json`, PNG, `kodbyten.json`, `riksdag-partikopplingar.json`, `scb-tabeller.json`, kataloger, `..`/`%2e%2e`, `%2f`, `%00`, dubbla snedstreck och versaler
+- [ ] Svaret från `/data/derived/parti.json` är 200 direkt (ingen `trailingSlash`-308); `responseLimit` avstängd så att `kommun.json` inte varnar
+- [ ] Fälttabellerna på `/data/` täcker varje toppnivånyckel i riktiga exemplar ur `data/` (test), och README-stycket säger att alla fält i partifilen publiceras
+- [ ] `/data/` renderar; varje länk i adresstabellen svarar 200; exemplen kan klistras in och köras; licens- och versioneringsavsnitten finns
+- [ ] Partisidans "Registerdata (JSON)" pekar på `/data/parti/<filnamn>/index.json`; "Profildata (JSON)" pekar fortfarande på GitHub
+- [ ] "Data" i huvudnavigationen och "Data som JSON" i sidfoten; sitemapen innehåller `/data/`
+- [ ] `fetch` från en annan origin i en webbläsare läser registret (CORS i praktiken)
+- [ ] RSS-ökning efter att alla resurser hämtats en gång under 60 MB och under 5 MB vid andra varvet; svarstid på `kommun.json` (6,9 MB) noterad i PR:en
+- [ ] Efter deploy: `curl --compressed` och `Accept-Encoding: identity` mot produktionen ger gzip respektive okomprimerat, båda med `Vary`, och `W/`-etag i det komprimerade fallet
+- [ ] `npm test` täcker allowlisten (accepterade och avvisade former), `matchesEtag`, lagrets `file`/`redirect`/`notFound` och katalogen
+- [ ] `npm run precommit` grönt; nginx-konfigurationen oförändrad

--- a/agent-docs/issue/26-documented-json-interface/progress.md
+++ b/agent-docs/issue/26-documented-json-interface/progress.md
@@ -1,0 +1,55 @@
+# Framsteg: Issue #26 — Publish a documented JSON interface for Partidata's data
+
+**Påbörjad:** 2026-08-30
+**Senast uppdaterad:** 2026-08-30
+**Status:** Klar
+
+## Genomförda steg
+
+- [x] Fas 1, steg 1: `src/server/data-resources.ts` — allowlisten (`classifyDataPath`, `dataPath`, `matchesEtag`)
+- [x] Fas 1, steg 2: `scripts/data-resources.test.js` — accepterade och avvisade former
+- [x] Fas 1, steg 3: `src/server/party-data.ts` — `resolveDataResource`, `readDataCatalog`, filcache med SHA-256
+- [x] Fas 1, steg 4: `scripts/party-data.test.js` — `withDataFiles`, lagrets nya metoder
+- [x] Fas 1, steg 5: `npm test && npm run typecheck`
+- [x] Fas 2, steg 6: `src/pages/api/data/[...path].ts` — metoder, CORS, cache, ETag/304, 308, 404
+- [x] Fas 2, steg 7: `next.config.ts` — rewrite `/data/:path+`
+- [x] Fas 2, steg 8: `matchesEtag`-test
+- [x] Fas 2, steg 9: `npm run build:release` och `curl -i` mot `.release/server.js` — 200 direkt, ingen `trailingSlash`-308
+- [x] Fas 3, steg 10: `src/styles/_data.scss`, `@use` från `app.scss`
+- [x] Fas 3, steg 11: `src/pages/data/index.tsx` och fältdokumentationen med test
+- [x] Fas 3, steg 12: `Header` med `current`-prop
+- [x] Fas 3, steg 13: `Footer` — "Data som JSON"
+- [x] Fas 3, steg 14: `/data/` i sitemapen
+- [x] Fas 3, steg 15: sidan lästes mot `.release/server.js`; alla adresslänkar svarar 200
+- [x] Fas 4, steg 16: `ExportSection` pekar på `/data/parti/<filnamn>/index.json`
+- [x] Fas 5, steg 17: README-stycket i "Tillgänglig data"
+- [x] Fas 5, steg 18: `CLAUDE.md` under "Stack"
+- [x] Fas 5, steg 19: `deploy/` orört
+- [x] Fas 6, steg 20: `scripts/http-smoke.js`
+- [x] Fas 6, steg 21: `npm run precommit`
+- [x] Fas 6, steg 22: minnesmätning och cachekontroll
+
+## Pågående arbete
+
+Inget — implementationen ligger på `issue/26-documented-json-interface`.
+
+## Anteckningar
+
+- Fältdokumentationen ligger i `src/components/data/fields.ts`, inte i `src/pages/data/fields.ts`
+  som planen skrev: pages-routern kräver att varje fil under `src/pages/` exporterar en
+  React-komponent, och bygget avbryts med `page-without-valid-component` annars.
+- `DataResource.fil` är typad som `ParticipationFile` (unionen av `PARTICIPATION_FILES`) i
+  stället för `string`, så `dataPath` bygger sökvägen ur ett värde som allowlisten redan
+  har smalnat av.
+- Provet av adresser som Next självt normaliserar (`/data/derived`, `/data/derived//parti.json`,
+  `/data/derived/parti.json/`) låser att högst en vidarebefordran följs, att den stannar under
+  `/data/`, och att ett 200-svar bara kan vara registret. Planens formulering "slutsvaret får
+  inte vara 200 med JSON-kropp" gäller de två sista adresserna, som normaliseras till registrets
+  egen adress och rätteligen svarar 200.
+- `Content-Length` prövas mot okomprimerade svar: Next komprimerar när klienten ber om det och
+  svarar då styckvis.
+- Minnesmätning mot `.release/server.js`: 109,3 MB efter `/api/health`, 113,7 MB efter att alla
+  24 adresser på `/data/` hämtats en gång, 113,7 MB efter andra varvet. `kommun.json` (6,9 MB):
+  10,3 ms första gången, 3,3 ms ur cachen.
+- Kvar som manuell kontroll: `fetch` från en annan origin i en webbläsare, och efter deploy
+  `curl --compressed` respektive `Accept-Encoding: identity` mot produktionsadressen.

--- a/agent-docs/issue/26-documented-json-interface/progress.md
+++ b/agent-docs/issue/26-documented-json-interface/progress.md
@@ -48,6 +48,13 @@ Inget — implementationen ligger på `issue/26-documented-json-interface`.
   egen adress och rätteligen svarar 200.
 - `Content-Length` prövas mot okomprimerade svar: Next komprimerar när klienten ber om det och
   svarar då styckvis.
+- Etaggen är svag, `W/"<sha256>"`, inte stark som planen skrev. Next komprimerar svaret själv
+  när klienten ber om det och lämnar etaggen orörd, så samma etagg skulle annars stå för två
+  olika byteföljder — vilket en stark etagg inte får göra. Planens premiss att nginx äger
+  gzip stämmer inte heller: `deploy/partidata.se.conf` sätter inte `gzip_proxied`, och
+  förvalet `off` gör att nginx inte komprimerar vidarebefordrade svar alls. Att i stället
+  stänga av Next-komprimeringen hade därför skickat 6,9 MB okomprimerat och krävt en
+  nginx-ändring, som ligger utanför den här PR:en.
 - Minnesmätning mot `.release/server.js`: 109,3 MB efter `/api/health`, 113,7 MB efter att alla
   24 adresser på `/data/` hämtats en gång, 113,7 MB efter andra varvet. `kommun.json` (6,9 MB):
   10,3 ms första gången, 3,3 ms ur cachen.

--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,7 @@ const nextConfig: NextConfig = {
   async rewrites () {
     return [
       { source: '/partisymbol/:filnamn/:bild', destination: '/api/partisymbol/:filnamn/:bild' },
+      { source: '/data/:path+', destination: '/api/data/:path+' },
       { source: '/sitemap.xml', destination: '/api/sitemap' },
     ];
   },

--- a/scripts/data-fields.test.js
+++ b/scripts/data-fields.test.js
@@ -1,0 +1,87 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const { PARTY_KEY_ORDER } = require('./parti.js');
+const { FIELD_DOCS } = require('../src/components/data/fields.ts');
+
+const dataRoot = path.join(__dirname, '..', 'data');
+
+function readJson (...segments) {
+  return JSON.parse(fs.readFileSync(path.join(dataRoot, ...segments), 'utf8'));
+}
+
+/** The election years the data carries, oldest first. */
+function years () {
+  return fs.readdirSync(path.join(dataRoot, 'val'), { withFileTypes: true })
+    .filter(entry => entry.isDirectory() && /^\d{4}$/.test(entry.name))
+    .map(entry => entry.name)
+    .toSorted();
+}
+
+/** The most recent year whose participation or result directory holds the file. */
+function latestWith (katalog, fil) {
+  const year = years().findLast(candidate =>
+    fs.existsSync(path.join(dataRoot, 'val', candidate, katalog, fil)));
+  assert.ok(year, `något valår har ${katalog}/${fil}`);
+  return readJson('val', year, katalog, fil);
+}
+
+/** One real specimen per documented resource, read from the committed data. */
+const SPECIMENS = {
+  'registry': () => readJson('derived', 'parti.json'),
+  'party': () => readJson('parti', 'moderaterna', 'index.json'),
+  'participation-partier': () => latestWith('partideltagande', 'partier.json'),
+  'participation-riksdag': () => latestWith('partideltagande', 'riksdag.json'),
+  'participation-omrade': () => latestWith('partideltagande', 'region.json'),
+  'results': () => latestWith('valresultat', 'riksdag.json'),
+  'derived-parliament': () => readJson('derived', 'riksdag.json'),
+  'regions': () => readJson('regioner', 'index.json')
+};
+
+/** The documented fields that stand at the top level of the resource. */
+function topLevel (resource) {
+  return resource.falt.filter(falt => !falt.namn.includes('.') && !falt.namn.includes('['));
+}
+
+/** Every object the check applies to: the elements of a list, or the object itself. */
+function records (specimen) {
+  return Array.isArray(specimen) ? specimen : [specimen];
+}
+
+test('every documented resource has a specimen in the committed data', () => {
+  assert.deepEqual(FIELD_DOCS.map(resource => resource.id).toSorted(), Object.keys(SPECIMENS).toSorted());
+  for (const resource of FIELD_DOCS) {
+    assert.ok(topLevel(resource).length > 0, `${resource.id} dokumenterar toppnivåfält`);
+    assert.ok(records(SPECIMENS[resource.id]()).length > 0, `${resource.id} har ett exemplar med innehåll`);
+  }
+});
+
+test('the field tables name every top-level key the data carries', () => {
+  for (const resource of FIELD_DOCS) {
+    const documented = new Set(topLevel(resource).map(falt => falt.namn));
+    // Hand-added extension fields in a party file are outside the table by
+    // design: the README says they are just as public, and the registry rebuild
+    // is what defines which keys the scripts handle.
+    const extras = resource.id === 'party' ? new Set(PARTY_KEY_ORDER) : undefined;
+    for (const record of records(SPECIMENS[resource.id]())) {
+      for (const key of Object.keys(record)) {
+        if (extras && !extras.has(key)) continue;
+        assert.ok(documented.has(key), `${resource.id}.${key} står i fälttabellen`);
+      }
+    }
+  }
+});
+
+test('every field the tables call required is in the data', () => {
+  for (const resource of FIELD_DOCS) {
+    const required = topLevel(resource).filter(falt => falt.obligatoriskt).map(falt => falt.namn);
+    assert.ok(required.length > 0, `${resource.id} har obligatoriska fält`);
+    for (const record of records(SPECIMENS[resource.id]())) {
+      for (const namn of required) {
+        assert.ok(namn in record, `${resource.id}.${namn} finns i varje exemplar`);
+      }
+    }
+  }
+});

--- a/scripts/data-resources.test.js
+++ b/scripts/data-resources.test.js
@@ -1,0 +1,63 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { classifyDataPath, dataPath, matchesEtag } = require('../src/server/data-resources.ts');
+
+const ACCEPTED = [
+  [['derived', 'parti.json'], { kind: 'registry' }],
+  [['derived', 'riksdag.json'], { kind: 'derived-parliament' }],
+  [['regioner', 'index.json'], { kind: 'regions' }],
+  [['parti', 'moderaterna', 'index.json'], { kind: 'party', filnamn: 'moderaterna' }],
+  [['val', '2026', 'partideltagande', 'kommun.json'], { kind: 'participation', valar: '2026', fil: 'kommun' }],
+  [['val', '2018', 'partideltagande', 'landsting.json'], { kind: 'participation', valar: '2018', fil: 'landsting' }],
+  [['val', '2022', 'valresultat', 'riksdag.json'], { kind: 'results', valar: '2022' }]
+];
+
+const REJECTED = [
+  [],
+  [''],
+  ['derived'],
+  ['derived', 'parti.json', 'x'],
+  ['parti', 'moderaterna'],
+  ['parti', 'moderaterna', 'profil.json'],
+  ['parti', 'moderaterna', '0001-moderaterna.png'],
+  ['parti', 'kodbyten.json'],
+  ['val', '2018', 'kandidatlistor', 'gotenes-framtid.json'],
+  ['val', '2022', 'valresultat', 'scb-tabeller.json'],
+  ['val', '22', 'partideltagande', 'partier.json'],
+  ['val', '2022', 'partideltagande', 'ovrigt.json'],
+  ['valresultat', 'riksdag-partikopplingar.json'],
+  ['..', 'package.json'],
+  ['parti', '..', 'kodbyten.json'],
+  ['Derived', 'parti.json'],
+  ['derived', 'parti.JSON'],
+  ['derived', 'parti.json/']
+];
+
+test('the allowlist names every published resource', () => {
+  for (const [segments, resource] of ACCEPTED) {
+    assert.deepEqual(classifyDataPath(segments), resource, segments.join('/'));
+  }
+});
+
+test('the path is rebuilt from the resource, not from the input', () => {
+  for (const [segments] of ACCEPTED) {
+    assert.deepEqual(dataPath(classifyDataPath(segments)), segments, segments.join('/'));
+  }
+});
+
+test('everything outside the allowlist names no resource', () => {
+  for (const segments of REJECTED) {
+    assert.equal(classifyDataPath(segments), undefined, JSON.stringify(segments));
+  }
+});
+
+test('an entity tag matches through a weakening proxy but never unquoted', () => {
+  const etag = '"abc"';
+  for (const header of ['"abc"', 'W/"abc"', '"x", "abc"', ' "abc" ', '*']) {
+    assert.equal(matchesEtag(header, etag), true, header);
+  }
+  for (const header of [undefined, '', '"abd"', 'abc', '"ab', 'W/abc']) {
+    assert.equal(matchesEtag(header, etag), false, String(header));
+  }
+});

--- a/scripts/data-resources.test.js
+++ b/scripts/data-resources.test.js
@@ -52,12 +52,15 @@ test('everything outside the allowlist names no resource', () => {
   }
 });
 
-test('an entity tag matches through a weakening proxy but never unquoted', () => {
-  const etag = '"abc"';
-  for (const header of ['"abc"', 'W/"abc"', '"x", "abc"', ' "abc" ', '*']) {
-    assert.equal(matchesEtag(header, etag), true, header);
-  }
-  for (const header of [undefined, '', '"abd"', 'abc', '"ab', 'W/abc']) {
-    assert.equal(matchesEtag(header, etag), false, String(header));
+test('an entity tag is compared weakly but never unquoted', () => {
+  // The tag the route sends is weak; a client may echo it either way, and a
+  // proxy may add or drop the prefix, so both sides are normalised.
+  for (const etag of ['"abc"', 'W/"abc"']) {
+    for (const header of ['"abc"', 'W/"abc"', '"x", "abc"', ' "abc" ', 'W/"x", W/"abc"', '*']) {
+      assert.equal(matchesEtag(header, etag), true, `${header} mot ${etag}`);
+    }
+    for (const header of [undefined, '', '"abd"', 'abc', '"ab', 'W/abc']) {
+      assert.equal(matchesEtag(header, etag), false, `${header} mot ${etag}`);
+    }
   }
 });

--- a/scripts/http-smoke.js
+++ b/scripts/http-smoke.js
@@ -1,5 +1,7 @@
 const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
 const fs = require('node:fs');
+const http = require('node:http');
 const net = require('node:net');
 const path = require('node:path');
 const { spawn } = require('node:child_process');
@@ -129,6 +131,26 @@ function partyGridLinks (html) {
   assert.ok(gridStart !== -1, 'partigridet hittades i markupen');
   const grid = section.slice(gridStart, section.indexOf('</ul>', gridStart));
   return [...grid.matchAll(/href="\/parti\/([^"/]+)\/?"/g)].map(match => match[1]);
+}
+
+/**
+ * A request `fetch` will not send: it normalises `..` out of the path before it
+ * leaves the client, and the point here is what the server does with it.
+ */
+async function rawRequest (port, requestPath) {
+  return await new Promise((resolve, reject) => {
+    const request = http.request({ host: '127.0.0.1', port, path: requestPath, method: 'GET' }, response => {
+      const chunks = [];
+      response.on('data', chunk => chunks.push(chunk));
+      response.on('end', () => resolve({
+        status: response.statusCode,
+        location: response.headers.location,
+        body: Buffer.concat(chunks)
+      }));
+    });
+    request.on('error', reject);
+    request.end();
+  });
 }
 
 async function freePort () {
@@ -392,6 +414,183 @@ async function main () {
     const sitemapBody = await sitemap.text();
     assert.match(sitemapBody, new RegExp(`/parti/${current.filnamn}/`));
     assert.doesNotMatch(sitemapBody, new RegExp(`/parti/${previous.tidigare_filnamn[0]}/`));
+    assert.match(sitemapBody, /<loc>[^<]*\/data\/<\/loc>/, 'sitemapen tar med dokumentationssidan');
+
+    const registryFile = fs.readFileSync(path.join(projectRoot, 'data', 'derived', 'parti.json'));
+    const registryEtag = `"${crypto.createHash('sha256').update(registryFile).digest('hex')}"`;
+
+    /** The full header set a JSON resource answers with, checked in one place. */
+    function expectDataHeaders (response, { etag, length, body = true } = {}) {
+      if (body) assert.equal(response.headers.get('content-type'), 'application/json; charset=utf-8');
+      else assert.equal(response.headers.get('content-type'), null, 'ett 304-svar bär ingen kroppstyp');
+      if (length !== undefined) assert.equal(response.headers.get('content-length'), String(length));
+      assert.equal(response.headers.get('cache-control'), 'public, max-age=3600');
+      assert.equal(response.headers.get('vary'), 'Accept-Encoding');
+      assert.equal(response.headers.get('etag'), etag);
+      assert.equal(response.headers.get('x-partidata-version'), version);
+      assert.equal(response.headers.get('access-control-allow-origin'), '*');
+      const exposed = response.headers.get('access-control-expose-headers');
+      assert.match(exposed, /ETag/);
+      assert.match(exposed, /X-Partidata-Version/);
+    }
+
+    // Uncompressed, so the body can be compared byte for byte and Content-Length
+    // is the file's own size; the app hands the bytes to whatever compresses them.
+    const identity = { 'Accept-Encoding': 'identity' };
+    const registry = await fetch(`${baseUrl}/data/derived/parti.json`, { redirect: 'manual', headers: identity });
+    assert.equal(registry.status, 200, 'registret svarar direkt, utan snedstrecksvidarebefordran');
+    expectDataHeaders(registry, { etag: registryEtag, length: registryFile.length });
+    assert.match(registry.headers.get('etag'), /^"[0-9a-f]{64}"$/, 'etaggen är en sha256');
+    assert.ok(Buffer.from(await registry.arrayBuffer()).equals(registryFile), 'kroppen är filens byte');
+
+    for (const header of [registryEtag, `W/${registryEtag}`]) {
+      const notModified = await fetch(`${baseUrl}/data/derived/parti.json`, { headers: { 'If-None-Match': header } });
+      assert.equal(notModified.status, 304, `${header} ger 304`);
+      expectDataHeaders(notModified, { etag: registryEtag, body: false });
+      assert.equal((await notModified.text()).length, 0, 'ett 304-svar har ingen kropp');
+    }
+    for (const header of ['abc', `"${'0'.repeat(64)}"`]) {
+      const stale = await fetch(`${baseUrl}/data/derived/parti.json`, { headers: { 'If-None-Match': header } });
+      assert.equal(stale.status, 200, `${header} matchar inte etaggen`);
+    }
+
+    const registryHead = await fetch(`${baseUrl}/data/derived/parti.json`, { method: 'HEAD', headers: identity });
+    assert.equal(registryHead.status, 200);
+    expectDataHeaders(registryHead, { etag: registryEtag, length: registryFile.length });
+    assert.equal((await registryHead.text()).length, 0, 'HEAD svarar utan kropp');
+
+    for (const method of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+      const rejected = await fetch(`${baseUrl}/data/derived/parti.json`, { method });
+      assert.equal(rejected.status, 405, `${method} avvisas`);
+      assert.equal(rejected.headers.get('allow'), 'GET, HEAD, OPTIONS');
+      assert.equal(rejected.headers.get('access-control-allow-origin'), '*');
+    }
+
+    // A preflight asks about the method, not the resource, so an unknown
+    // address is answered the same way as a known one.
+    for (const target of ['/data/derived/parti.json', '/data/finns-inte.json']) {
+      const preflight = await fetch(`${baseUrl}${target}`, { method: 'OPTIONS' });
+      assert.equal(preflight.status, 204, `${target} svarar på preflight`);
+      assert.equal(preflight.headers.get('access-control-allow-origin'), '*');
+      assert.equal(preflight.headers.get('access-control-allow-methods'), 'GET, HEAD, OPTIONS');
+      assert.match(preflight.headers.get('access-control-allow-headers'), /If-None-Match/);
+      assert.equal(preflight.headers.get('access-control-max-age'), '86400');
+    }
+
+    const partyResource = await fetch(`${baseUrl}/data/parti/${current.filnamn}/index.json`);
+    assert.equal(partyResource.status, 200);
+    assert.equal((await partyResource.json()).uuid, current.uuid, 'partiets registerfil kommer ur samma register');
+
+    const movedResource = await fetch(
+      `${baseUrl}/data/parti/${previous.tidigare_filnamn[0]}/index.json`,
+      { redirect: 'manual' }
+    );
+    assert.equal(movedResource.status, 308);
+    assert.equal(
+      new URL(movedResource.headers.get('location'), baseUrl).pathname,
+      `/data/parti/${previous.filnamn}/index.json`
+    );
+    assert.equal(movedResource.headers.get('access-control-allow-origin'), '*');
+
+    const missingResource = await fetch(`${baseUrl}/data/parti/finns-inte/index.json`);
+    assert.equal(missingResource.status, 404);
+    assert.equal(missingResource.headers.get('content-type'), 'application/json; charset=utf-8');
+    assert.equal(missingResource.headers.get('access-control-allow-origin'), '*');
+    assert.deepEqual(await missingResource.json(), { fel: 'Okänd resurs' });
+
+    const candidateFile = path.join(projectRoot, 'data', 'val', '2018', 'kandidatlistor', 'gotenes-framtid.json');
+    assert.ok(
+      fs.existsSync(candidateFile),
+      'kandidatfilen finns kvar — peka provet på en annan fil under val/<år>/kandidatlistor/ om den flyttats'
+    );
+    const withProfile = parties.find(party =>
+      fs.existsSync(path.join(projectRoot, 'data', 'parti', party.filnamn, 'profil.json')));
+    assert.ok(withProfile, 'något parti har en profil.json att hålla utanför /data/');
+    for (const target of [
+      '/data/val/2018/kandidatlistor/gotenes-framtid.json',
+      `/data/parti/${withSymbol.filnamn}/${withSymbol.partisymbol.filnamn}`,
+      `/data/parti/${withProfile.filnamn}/profil.json`,
+      '/data/parti/kodbyten.json',
+      '/data/valresultat/riksdag-partikopplingar.json',
+      '/data/val/2022/valresultat/scb-tabeller.json',
+      '/data/derived/',
+      '/data/%2e%2e/package.json',
+      '/data/parti/%2e%2e/kodbyten.json',
+      '/data/derived%2fparti.json',
+      '/data/derived/parti.json%00',
+      '/data/DERIVED/parti.json'
+    ]) {
+      const forbidden = await fetch(`${baseUrl}${target}`, { redirect: 'manual' });
+      assert.equal(forbidden.status, 404, `${target} lämnas inte ut`);
+    }
+
+    // Addresses the framework normalises itself. What is locked is that nothing
+    // outside the allowlist is served, not which status Next picks: at most one
+    // redirect is followed, it stays under /data/, and a 200 can only be the
+    // resource the normalised address names.
+    for (const target of ['/data/derived', '/data/derived//parti.json', '/data/derived/parti.json/']) {
+      let normalised = await fetch(`${baseUrl}${target}`, { redirect: 'manual' });
+      if (normalised.status >= 300 && normalised.status < 400) {
+        const location = new URL(normalised.headers.get('location'), baseUrl);
+        assert.equal(location.origin, baseUrl, `${target} vidarebefordras inom sajten`);
+        assert.ok(location.pathname.startsWith('/data/'), `${target} vidarebefordras inom /data/`);
+        normalised = await fetch(location, { redirect: 'manual' });
+      }
+      assert.ok([200, 404].includes(normalised.status), `${target} slutar på 200 eller 404`);
+      if (normalised.status === 200) {
+        assert.ok(
+          Buffer.from(await normalised.arrayBuffer()).equals(registryFile),
+          `${target} kan bara nå registret`
+        );
+      }
+    }
+
+    const traversal = await rawRequest(port, '/data/../package.json');
+    assert.notEqual(traversal.status, 200, 'en rå ../-sökväg lämnar inte ut något utanför data/');
+
+    assert.equal((await fetch(`${baseUrl}/api/data/derived/parti.json`)).status, 200, 'routens egen adress fungerar');
+
+    const participationFile = JSON.parse(fs.readFileSync(
+      path.join(projectRoot, 'data', 'val', latest, 'partideltagande', 'partier.json'), 'utf8'
+    ));
+    const participation = await fetch(`${baseUrl}/data/val/${latest}/partideltagande/partier.json`);
+    assert.equal(participation.status, 200);
+    assert.equal((await participation.json()).length, participationFile.length);
+
+    const resultYear = String(chamberResult.valar);
+    assert.equal((await fetch(`${baseUrl}/data/val/${resultYear}/valresultat/riksdag.json`)).status, 200);
+    const latestResult = await fetch(`${baseUrl}/data/val/${latest}/valresultat/riksdag.json`);
+    assert.equal(
+      latestResult.status,
+      fs.existsSync(path.join(projectRoot, 'data', 'val', latest, 'valresultat', 'riksdag.json')) ? 200 : 404,
+      `valresultatet ${latest} svarar efter om filen finns`
+    );
+
+    const dataPage = await fetch(`${baseUrl}/data/`);
+    assert.equal(dataPage.status, 200);
+    const dataBody = await dataPage.text();
+    assert.match(dataBody, /<title[^>]*>Data – Partidata<\/title>/);
+    assert.match(dataBody, /<link rel="canonical" href="https:\/\/www\.partidata\.se\/data\/"[^>]*>/);
+    assert.match(dataBody, /Access-Control-Allow-Origin/, 'sidan dokumenterar CORS-huvudet');
+    assert.match(dataBody, /CC0/, 'sidan anger licensen');
+    const documented = [...new Set([...dataBody.matchAll(/href="(\/data\/[^"]+)"/g)].map(match => match[1]))];
+    assert.ok(documented.length >= 8, 'adresstabellen länkar till resurserna');
+    for (const address of documented) {
+      const linked = await fetch(`${baseUrl}${address}`, { redirect: 'manual' });
+      assert.equal(linked.status, 200, `${address} på dokumentationssidan svarar 200`);
+    }
+
+    assert.match(homeBody, /href="\/data\/"/, 'navigationen länkar till dokumentationssidan');
+    assert.match(
+      profileBody,
+      new RegExp(`href="/data/parti/${current.filnamn}/index\\.json"`),
+      'partisidans registerdata pekar på Partidata'
+    );
+    assert.doesNotMatch(
+      profileBody,
+      new RegExp(`github\\.com/swedev/partidata/blob/main/data/parti/${current.filnamn}/index\\.json`),
+      'registerdatalänken pekar inte längre på GitHub'
+    );
 
     const health = await fetch(`${baseUrl}/api/health`);
     assert.equal(health.status, 200);

--- a/scripts/http-smoke.js
+++ b/scripts/http-smoke.js
@@ -417,7 +417,7 @@ async function main () {
     assert.match(sitemapBody, /<loc>[^<]*\/data\/<\/loc>/, 'sitemapen tar med dokumentationssidan');
 
     const registryFile = fs.readFileSync(path.join(projectRoot, 'data', 'derived', 'parti.json'));
-    const registryEtag = `"${crypto.createHash('sha256').update(registryFile).digest('hex')}"`;
+    const registryEtag = `W/"${crypto.createHash('sha256').update(registryFile).digest('hex')}"`;
 
     /** The full header set a JSON resource answers with, checked in one place. */
     function expectDataHeaders (response, { etag, length, body = true } = {}) {
@@ -440,15 +440,28 @@ async function main () {
     const registry = await fetch(`${baseUrl}/data/derived/parti.json`, { redirect: 'manual', headers: identity });
     assert.equal(registry.status, 200, 'registret svarar direkt, utan snedstrecksvidarebefordran');
     expectDataHeaders(registry, { etag: registryEtag, length: registryFile.length });
-    assert.match(registry.headers.get('etag'), /^"[0-9a-f]{64}"$/, 'etaggen är en sha256');
+    assert.match(registry.headers.get('etag'), /^W\/"[0-9a-f]{64}"$/, 'etaggen är en svag sha256');
     assert.ok(Buffer.from(await registry.arrayBuffer()).equals(registryFile), 'kroppen är filens byte');
 
-    for (const header of [registryEtag, `W/${registryEtag}`]) {
+    for (const header of [registryEtag, registryEtag.replace('W/', '')]) {
       const notModified = await fetch(`${baseUrl}/data/derived/parti.json`, { headers: { 'If-None-Match': header } });
       assert.equal(notModified.status, 304, `${header} ger 304`);
       expectDataHeaders(notModified, { etag: registryEtag, body: false });
       assert.equal((await notModified.text()).length, 0, 'ett 304-svar har ingen kropp');
     }
+    // The same file is served compressed and uncompressed, and both carry the
+    // same weak validator — which is what makes it correct for it to be weak.
+    const compressed = await fetch(`${baseUrl}/data/derived/parti.json`, {
+      headers: { 'Accept-Encoding': 'gzip' }
+    });
+    assert.equal(compressed.status, 200);
+    assert.equal(compressed.headers.get('content-encoding'), 'gzip', 'svaret komprimeras när klienten ber om det');
+    assert.equal(compressed.headers.get('etag'), registryEtag, 'båda kodningarna bär samma svaga etagg');
+    const compressedConditional = await fetch(`${baseUrl}/data/derived/parti.json`, {
+      headers: { 'Accept-Encoding': 'gzip', 'If-None-Match': registryEtag }
+    });
+    assert.equal(compressedConditional.status, 304, 'etaggen från det komprimerade svaret ger 304');
+
     for (const header of ['abc', `"${'0'.repeat(64)}"`]) {
       const stale = await fetch(`${baseUrl}/data/derived/parti.json`, { headers: { 'If-None-Match': header } });
       assert.equal(stale.status, 200, `${header} matchar inte etaggen`);

--- a/scripts/party-data.test.js
+++ b/scripts/party-data.test.js
@@ -101,7 +101,7 @@ test('the allowlisted resources are served as the bytes on disk, with a sha256 t
   assert.equal(registry.kind, 'file');
   const file = fs.readFileSync(path.join(dataRoot, 'derived/parti.json'));
   assert.ok(registry.body.equals(file), 'kroppen är filens byte');
-  assert.equal(registry.etag, `"${crypto.createHash('sha256').update(file).digest('hex')}"`);
+  assert.equal(registry.etag, `W/"${crypto.createHash('sha256').update(file).digest('hex')}"`);
 
   assert.equal((await store.resolveDataResource(['parti', 'testpartiet', 'index.json'])).kind, 'file');
   assert.equal((await store.resolveDataResource(['val', '2018', 'partideltagande', 'riksdag.json'])).kind, 'file');

--- a/scripts/party-data.test.js
+++ b/scripts/party-data.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -53,6 +54,118 @@ function makeData () {
 
   return { root, dataRoot };
 }
+
+/**
+ * Writes the files the `/data/` allowlist serves on top of makeData(), which
+ * the older tests read as a tree without election results.
+ */
+function withDataFiles (dataRoot) {
+  writeJson(dataRoot, 'val/2018/partideltagande/riksdag.json', [
+    { beteckning: 'Testpartiet', kod: '9001', uuid: '11111111-1111-4111-8111-111111111111' }
+  ]);
+  writeJson(dataRoot, 'val/2022/valresultat/riksdag.json', {
+    schema_version: 2,
+    valtyp: 'riksdag',
+    valar: 2022,
+    status: 'slutligt',
+    kallor: [{ id: 'resultat', namn: 'Valmyndigheten', url: 'https://example.com/resultat', hamtad: '2026-08-30' }],
+    rostresultat: {
+      giltiga_roster: 100,
+      partier: [{
+        parti_uuid: '11111111-1111-4111-8111-111111111111',
+        roster: 100,
+        rostandel: 100,
+        kallreferens: 'resultat'
+      }]
+    },
+    mandatfordelning: {
+      partier: [{
+        parti_uuid: '11111111-1111-4111-8111-111111111111',
+        partibeteckning: 'Testpartiet',
+        mandat: 349,
+        kallreferens: 'resultat'
+      }]
+    }
+  });
+  writeJson(dataRoot, 'regioner/index.json', [{ kod: '01', namn: 'Stockholms län', kommuner: [] }]);
+  writeJson(dataRoot, 'derived/riksdag.json', { schema_version: 2, kammare: { valar: 2022, partier: [] } });
+  return dataRoot;
+}
+
+test('the allowlisted resources are served as the bytes on disk, with a sha256 tag', async t => {
+  const { root, dataRoot } = makeData();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const store = createPartyDataStore(withDataFiles(dataRoot));
+
+  const registry = await store.resolveDataResource(['derived', 'parti.json']);
+  assert.equal(registry.kind, 'file');
+  const file = fs.readFileSync(path.join(dataRoot, 'derived/parti.json'));
+  assert.ok(registry.body.equals(file), 'kroppen är filens byte');
+  assert.equal(registry.etag, `"${crypto.createHash('sha256').update(file).digest('hex')}"`);
+
+  assert.equal((await store.resolveDataResource(['parti', 'testpartiet', 'index.json'])).kind, 'file');
+  assert.equal((await store.resolveDataResource(['val', '2018', 'partideltagande', 'riksdag.json'])).kind, 'file');
+  assert.equal((await store.resolveDataResource(['val', '2022', 'valresultat', 'riksdag.json'])).kind, 'file');
+  assert.equal((await store.resolveDataResource(['regioner', 'index.json'])).kind, 'file');
+  assert.equal((await store.resolveDataResource(['derived', 'riksdag.json'])).kind, 'file');
+});
+
+test('a previous party filename forwards and an unknown one is not found', async t => {
+  const { root, dataRoot } = makeData();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const store = createPartyDataStore(withDataFiles(dataRoot));
+
+  assert.deepEqual(await store.resolveDataResource(['parti', 'gamla-testpartiet', 'index.json']), {
+    kind: 'redirect',
+    destination: '/data/parti/testpartiet/index.json'
+  });
+  assert.deepEqual(await store.resolveDataResource(['parti', 'okant', 'index.json']), { kind: 'notFound' });
+});
+
+test('candidate lists, profiles and symbols are not served even when the file is there', async t => {
+  const { root, dataRoot } = makeData();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const store = createPartyDataStore(withDataFiles(dataRoot));
+
+  assert.ok(fs.existsSync(path.join(dataRoot, 'val/2018/kandidatlistor/testpartiet.json')));
+  assert.ok(fs.existsSync(path.join(dataRoot, 'parti/testpartiet/profil.json')));
+  for (const segments of [
+    ['val', '2018', 'kandidatlistor', 'testpartiet.json'],
+    ['parti', 'testpartiet', 'profil.json'],
+    ['parti', 'testpartiet', '9001-testpartiet.png'],
+    ['parti', '..', 'kodbyten.json']
+  ]) {
+    assert.deepEqual(await store.resolveDataResource(segments), { kind: 'notFound' }, segments.join('/'));
+  }
+});
+
+test('a year without one of the participation files is not found', async t => {
+  const { root, dataRoot } = makeData();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const store = createPartyDataStore(withDataFiles(dataRoot));
+
+  assert.deepEqual(await store.resolveDataResource(['val', '2022', 'partideltagande', 'landsting.json']), {
+    kind: 'notFound'
+  });
+  assert.deepEqual(await store.resolveDataResource(['val', '2018', 'valresultat', 'riksdag.json']), {
+    kind: 'notFound'
+  });
+});
+
+test('the data catalog lists the files each year carries and an example party', async t => {
+  const { root, dataRoot } = makeData();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const store = createPartyDataStore(withDataFiles(dataRoot));
+
+  const catalog = await store.readDataCatalog();
+  assert.equal(catalog.antalPartier, 2);
+  assert.deepEqual(catalog.exempel, { filnamn: 'testpartiet', beteckning: 'Testpartiet' });
+  assert.deepEqual(catalog.valar, [
+    { valar: '2018', partideltagande: ['riksdag'], valresultat: false },
+    { valar: '2022', partideltagande: [], valresultat: true }
+  ]);
+  assert.equal(await store.readDataCatalog(), catalog, 'katalogen byggs en gång per lager');
+});
 
 test('party data resolves current, previous and unknown slugs', async t => {
   const { root, dataRoot } = makeData();

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 const version = process.env.PARTIDATA_VERSION;
 
@@ -36,6 +37,7 @@ function Footer () {
         <div>
           <h3>Öppenhet</h3>
           <ul>
+            <li><Link href="/data/">Data som JSON</Link></li>
             <li><a href="https://github.com/swedev/partidata">Källkod och data på GitHub</a></li>
             <li><a href="https://creativecommons.org/publicdomain/zero/1.0/">Licens: CC0 1.0</a></li>
             {version && (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
-function Header () {
+function Header ({ current = 'partier' }: { current?: 'partier' | 'data' }) {
   return (
     <header className="site-header">
       <div className="site-shell site-header__inner">
@@ -26,8 +26,8 @@ function Header () {
         </Link>
 
         <nav className="site-header__nav" aria-label="Huvudnavigation">
-          <Link href="/" className="site-header__active-link">Partier</Link>
-          <a href="https://github.com/swedev/partidata">Data på GitHub</a>
+          <Link href="/" className={current === 'partier' ? 'site-header__active-link' : undefined}>Partier</Link>
+          <Link href="/data/" className={current === 'data' ? 'site-header__active-link' : undefined}>Data</Link>
           <a href="#om-tjansten">Om tjänsten</a>
         </nav>
       </div>

--- a/src/components/data/fields.ts
+++ b/src/components/data/fields.ts
@@ -1,0 +1,206 @@
+/**
+ * The field contract the documentation page publishes: what a reader can rely
+ * on finding, and what type it has. `scripts/data-fields.test.js` checks every
+ * top-level field against real specimens under `data/`, so the tables cannot
+ * drift from the data. Nested fields are written with dot notation and marked
+ * `[]` where the parent is a list; the test does not descend into them.
+ */
+
+export interface FieldDoc {
+  namn: string;
+  typ: string;
+  obligatoriskt: boolean;
+  beskrivning: string;
+}
+
+export interface ResourceDoc {
+  /** The anchor and the key `scripts/data-fields.test.js` looks the specimen up by. */
+  id: string;
+  rubrik: string;
+  adress: string;
+  /** The shape of the top level, in one sentence. */
+  form: string;
+  /** The heading in README.md that carries the background prose. */
+  readme: string;
+  falt: FieldDoc[];
+}
+
+const KALLA_FALT: FieldDoc[] = [
+  { namn: 'id', typ: 'sträng', obligatoriskt: true, beskrivning: 'Källans namn i filen; det som `kallreferens` pekar på.' },
+  { namn: 'namn', typ: 'sträng', obligatoriskt: true, beskrivning: 'Utgivaren, till exempel Valmyndigheten eller SCB.' },
+  { namn: 'titel', typ: 'sträng', obligatoriskt: true, beskrivning: 'Källdokumentets titel.' },
+  { namn: 'url', typ: 'sträng', obligatoriskt: true, beskrivning: 'Adressen uppgiften hämtades från.' },
+  { namn: 'version', typ: 'sträng', obligatoriskt: true, beskrivning: 'Källans egen versionsbeteckning, till exempel "Slutligt valresultat".' },
+  { namn: 'format', typ: 'sträng', obligatoriskt: true, beskrivning: 'Mediatypen källan levererades i.' },
+  { namn: 'hamtad', typ: 'datum', obligatoriskt: true, beskrivning: 'Datum då källan hämtades.' },
+  { namn: 'sha256', typ: 'sträng', obligatoriskt: true, beskrivning: 'Kontrollsumma för den hämtade filen.' },
+  { namn: 'transkribering_sha256', typ: 'sträng', obligatoriskt: false, beskrivning: 'Kontrollsumma för transkriberingen, när källan lästs ur ett dokument som inte är maskinläsbart.' },
+];
+
+export const FIELD_DOCS: ResourceDoc[] = [
+  {
+    id: 'registry',
+    rubrik: 'derived/parti.json',
+    adress: '/data/derived/parti.json',
+    form: 'En lista med en post per parti, sorterad på filnamn.',
+    readme: 'derivedpartijson',
+    falt: [
+      { namn: 'uuid', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partiets stabila identitet. Samma uuid i partifilen och som `parti_uuid` i valresultaten.' },
+      { namn: 'beteckning', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partibeteckningen i det senaste val partiet finns med i.' },
+      { namn: 'filnamn', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partiets adress på sajten och katalognamnet under `parti/`.' },
+      { namn: 'tidigare_filnamn', typ: 'lista av strängar', obligatoriskt: false, beskrivning: 'Adresser partiet har haft, äldst först. Var och en vidarebefordras till `filnamn`.' },
+      { namn: 'omrade', typ: 'sträng', obligatoriskt: false, beskrivning: 'Kommun- eller länsnamn, när det senaste registrerade deltagandet ryms inom ett område.' },
+      { namn: 'forkortning', typ: 'sträng', obligatoriskt: false, beskrivning: 'Partiförkortning, när Valmyndigheten anger någon.' },
+      { namn: 'partisymbol', typ: 'objekt', obligatoriskt: false, beskrivning: 'Samma innehåll som `partisymbol` i partifilen.' },
+    ],
+  },
+  {
+    id: 'party',
+    rubrik: 'parti/<filnamn>/index.json',
+    adress: '/data/parti/<filnamn>/index.json',
+    form: 'Ett objekt per parti.',
+    readme: 'partifilnamnindexjson',
+    falt: [
+      { namn: 'uuid', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partiets stabila identitet, satt en gång och aldrig ändrad.' },
+      { namn: 'kod', typ: 'sträng', obligatoriskt: true, beskrivning: 'Valmyndighetens PARTIKOD i det senaste val partiet finns med i. Samma värde som `kod` i partideltagandet.' },
+      { namn: 'tidigare_koder', typ: 'lista av strängar', obligatoriskt: false, beskrivning: 'Övriga partikoder partiet har burit.' },
+      { namn: 'beteckning', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partibeteckningen i det senaste valet.' },
+      { namn: 'tidigare_beteckningar', typ: 'lista av strängar', obligatoriskt: false, beskrivning: 'Tidigare partibeteckningar, äldst först.' },
+      { namn: 'filnamn', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partiets adress på sajten.' },
+      { namn: 'tidigare_filnamn', typ: 'lista av strängar', obligatoriskt: false, beskrivning: 'Adresser partiet har haft, äldst först.' },
+      { namn: 'omrade', typ: 'sträng', obligatoriskt: false, beskrivning: 'Härlett kommun- eller länsnamn när deltagandet ryms inom ett område.' },
+      { namn: 'forkortning', typ: 'sträng', obligatoriskt: false, beskrivning: 'Partiförkortning, när Valmyndigheten anger någon.' },
+      { namn: 'registrerad_partibeteckning', typ: 'boolean', obligatoriskt: false, beskrivning: 'Om partiet har registrerad partibeteckning.' },
+      { namn: 'valmyndigheten_registreringsdatum', typ: 'datum', obligatoriskt: false, beskrivning: 'Datum då partibeteckningen registrerades.' },
+      { namn: 'partisymbol', typ: 'objekt', obligatoriskt: false, beskrivning: 'Partiets senast kända symbol med proveniens. Bildfilen serveras på /partisymbol/<filnamn>/<partisymbol.filnamn>, inte under /data/.' },
+      { namn: 'partisymbol.filnamn', typ: 'sträng', obligatoriskt: true, beskrivning: 'PNG-filens namn i partiets katalog.' },
+      { namn: 'partisymbol.kalla', typ: 'sträng', obligatoriskt: true, beskrivning: 'Utgivaren symbolen kommer från.' },
+      { namn: 'partisymbol.kallurl', typ: 'sträng', obligatoriskt: true, beskrivning: 'Adressen symbolpaketet hämtades från.' },
+      { namn: 'partisymbol.valar', typ: 'tal', obligatoriskt: true, beskrivning: 'Valåret symbolen levererades för.' },
+      { namn: 'partisymbol.partikod', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partikoden symbolen hämtades under.' },
+      { namn: 'partisymbol.bild', typ: 'objekt', obligatoriskt: false, beskrivning: 'Bildfilens `bredd` och `hojd` i pixlar — arket symbolen levererades på.' },
+      { namn: 'partisymbol.bildyta', typ: 'objekt', obligatoriskt: false, beskrivning: 'Teckningens `x`, `y`, `bredd` och `hojd` inom arket, så att alla symboler kan visas i samma optiska storlek.' },
+      { namn: 'deltagande', typ: 'objekt', obligatoriskt: false, beskrivning: 'Anmält deltagande med ett uppslag per valår.' },
+      { namn: 'deltagande.<år>.riksdag', typ: 'boolean', obligatoriskt: true, beskrivning: 'Om partiet deltar i riksdagsvalet det året.' },
+      { namn: 'deltagande.<år>.region', typ: 'lista av strängar', obligatoriskt: true, beskrivning: 'Länskoder ur regioner/index.json.' },
+      { namn: 'deltagande.<år>.kommun', typ: 'lista av strängar', obligatoriskt: true, beskrivning: 'Kommunkoder ur regioner/index.json. De två första siffrorna är länets kod.' },
+      { namn: 'wikidata', typ: 'objekt', obligatoriskt: false, beskrivning: 'Partiets post på Wikidata, kopplad för hand i en granskad pull request.' },
+      { namn: 'wikidata.id', typ: 'sträng', obligatoriskt: true, beskrivning: 'Q-id:t, till exempel Q504069. Käll-URL:en är https://www.wikidata.org/wiki/<id>.' },
+      { namn: 'wikidata.grundat', typ: 'sträng', obligatoriskt: false, beskrivning: 'Grundandedatum (P571) i källans precision: "1988", "1988-02" eller "1988-02-06".' },
+      { namn: 'wikidata.hamtad', typ: 'datum', obligatoriskt: true, beskrivning: 'Datum för den senaste hämtningen från Wikidata.' },
+    ],
+  },
+  {
+    id: 'participation-partier',
+    rubrik: 'val/<år>/partideltagande/partier.json',
+    adress: '/data/val/<år>/partideltagande/partier.json',
+    form: 'En lista med en post per partikod i årets fil.',
+    readme: 'valårpartideltagande',
+    falt: [
+      { namn: 'kod', typ: 'sträng', obligatoriskt: true, beskrivning: 'Valmyndighetens PARTIKOD det året.' },
+      { namn: 'beteckning', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partibeteckningen som den står i årets fil.' },
+      { namn: 'forkortning', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partiförkortningen, tom sträng när ingen anges.' },
+      { namn: 'registrerad_partibeteckning', typ: 'boolean', obligatoriskt: true, beskrivning: 'Om beteckningen är registrerad.' },
+      { namn: 'uuid', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partiets identitet i registret.' },
+    ],
+  },
+  {
+    id: 'participation-riksdag',
+    rubrik: 'val/<år>/partideltagande/riksdag.json',
+    adress: '/data/val/<år>/partideltagande/riksdag.json',
+    form: 'En lista med de partier som deltar i riksdagsvalet.',
+    readme: 'valårpartideltagande',
+    falt: [
+      { namn: 'beteckning', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partibeteckningen som den står i årets fil.' },
+      { namn: 'kod', typ: 'sträng', obligatoriskt: true, beskrivning: 'Valmyndighetens PARTIKOD det året.' },
+      { namn: 'uuid', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partiets identitet i registret.' },
+      { namn: 'grunder', typ: 'lista av strängar', obligatoriskt: false, beskrivning: 'Valmyndighetens DELTAGANDEGRUND, oförändrad: A anmält deltagande, R redan representerad, K anmält kandidater. Saknas i 2018 års filer.' },
+    ],
+  },
+  {
+    id: 'participation-omrade',
+    rubrik: 'val/<år>/partideltagande/region.json, kommun.json, landsting.json',
+    adress: '/data/val/<år>/partideltagande/region.json',
+    form: 'En lista med en post per valområde, med områdets partier.',
+    readme: 'valårpartideltagande',
+    falt: [
+      { namn: 'kod', typ: 'sträng', obligatoriskt: true, beskrivning: 'Läns- eller kommunkoden, samma koder som i regioner/index.json.' },
+      { namn: 'namn', typ: 'sträng', obligatoriskt: true, beskrivning: 'Områdets namn.' },
+      { namn: 'uuid', typ: 'sträng', obligatoriskt: true, beskrivning: 'Områdets identitet, samma som i regioner/index.json.' },
+      { namn: 'partier', typ: 'lista av objekt', obligatoriskt: true, beskrivning: 'Partierna som deltar i valet i området; tom lista när inga finns.' },
+      { namn: 'partier[].beteckning', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partibeteckningen som den står i årets fil.' },
+      { namn: 'partier[].kod', typ: 'sträng', obligatoriskt: true, beskrivning: 'Valmyndighetens PARTIKOD det året.' },
+      { namn: 'partier[].uuid', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partiets identitet i registret.' },
+      { namn: 'partier[].grunder', typ: 'lista av strängar', obligatoriskt: false, beskrivning: 'DELTAGANDEGRUND — A, R eller K. Saknas i 2018 års filer.' },
+    ],
+  },
+  {
+    id: 'results',
+    rubrik: 'val/<år>/valresultat/riksdag.json',
+    adress: '/data/val/<år>/valresultat/riksdag.json',
+    form: 'Ett objekt med det slutliga riksdagsresultatet för valåret.',
+    readme: 'valårvalresultatriksdagjson',
+    falt: [
+      { namn: 'schema_version', typ: 'tal', obligatoriskt: true, beskrivning: 'Modellens version; 2 i dag.' },
+      { namn: 'valtyp', typ: 'sträng', obligatoriskt: true, beskrivning: 'Valet filen gäller: "riksdag".' },
+      { namn: 'valar', typ: 'tal', obligatoriskt: true, beskrivning: 'Valåret.' },
+      { namn: 'status', typ: 'sträng', obligatoriskt: true, beskrivning: 'Resultatets status, till exempel "slutligt".' },
+      { namn: 'kallor', typ: 'lista av objekt', obligatoriskt: true, beskrivning: 'Källorna filen bygger på. Varje rad i filen pekar på en av dem med `kallreferens`.' },
+      ...KALLA_FALT.map(falt => ({ ...falt, namn: `kallor[].${falt.namn}` })),
+      { namn: 'valdeltagande', typ: 'objekt', obligatoriskt: true, beskrivning: 'Valdeltagandet med `procent` och `kallreferens`.' },
+      { namn: 'rostresultat', typ: 'objekt', obligatoriskt: true, beskrivning: 'Röstresultatet för riket.' },
+      { namn: 'rostresultat.giltiga_roster', typ: 'tal', obligatoriskt: true, beskrivning: 'Antalet giltiga röster i valet.' },
+      { namn: 'rostresultat.kallreferenser', typ: 'lista av strängar', obligatoriskt: true, beskrivning: 'Källorna avsnittet bygger på.' },
+      { namn: 'rostresultat.partier', typ: 'lista av objekt', obligatoriskt: true, beskrivning: 'En rad per parti som kunnat kopplas till registret.' },
+      { namn: 'rostresultat.partier[].parti_uuid', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partiets `uuid` i registret.' },
+      { namn: 'rostresultat.partier[].kallkod', typ: 'sträng', obligatoriskt: false, beskrivning: 'Partikoden källan använder.' },
+      { namn: 'rostresultat.partier[].partibeteckning', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partibeteckningen som källan skriver den.' },
+      { namn: 'rostresultat.partier[].roster', typ: 'tal', obligatoriskt: true, beskrivning: 'Antalet röster.' },
+      { namn: 'rostresultat.partier[].rostandel', typ: 'tal', obligatoriskt: true, beskrivning: 'Röstandelen i procent av giltiga röster.' },
+      { namn: 'rostresultat.partier[].kallreferens', typ: 'sträng', obligatoriskt: true, beskrivning: 'Källans `id`.' },
+      { namn: 'rostresultat.ej_kopplade', typ: 'lista av objekt', obligatoriskt: true, beskrivning: 'Rader som inte kunnat kopplas till ett parti i registret, redovisade utan gissat uuid.' },
+      { namn: 'rostresultat.aggregat', typ: 'lista av objekt', obligatoriskt: true, beskrivning: 'Källans egna sammanslagningar, till exempel "Övriga partier".' },
+      { namn: 'mandatfordelning', typ: 'objekt', obligatoriskt: true, beskrivning: 'Mandatfördelningen i kammaren.' },
+      { namn: 'mandatfordelning.antal_mandat', typ: 'tal', obligatoriskt: true, beskrivning: 'Antalet mandat som fördelas, 349.' },
+      { namn: 'mandatfordelning.kallreferenser', typ: 'lista av strängar', obligatoriskt: true, beskrivning: 'Källorna avsnittet bygger på.' },
+      { namn: 'mandatfordelning.partier', typ: 'lista av objekt', obligatoriskt: true, beskrivning: 'En rad per parti med mandat: `parti_uuid`, `kallkod`, `partibeteckning`, `mandat` och `kallreferens`.' },
+    ],
+  },
+  {
+    id: 'derived-parliament',
+    rubrik: 'derived/riksdag.json',
+    adress: '/data/derived/riksdag.json',
+    form: 'Ett objekt med den härledning startsidan bygger på.',
+    readme: 'derived',
+    falt: [
+      { namn: 'schema_version', typ: 'tal', obligatoriskt: true, beskrivning: 'Modellens version.' },
+      { namn: 'genererad_fran', typ: 'lista av strängar', obligatoriskt: true, beskrivning: 'Filerna härledningen byggdes ur, som sökvägar under data/.' },
+      { namn: 'senast_uppdaterad', typ: 'datum', obligatoriskt: true, beskrivning: 'Datum då filen byggdes om.' },
+      { namn: 'kammare', typ: 'objekt', obligatoriskt: true, beskrivning: 'Den sittande kammaren: `valar`, `partier` och `kalla`.' },
+      { namn: 'kammare.partier[].parti_uuid', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partiets `uuid` i registret.' },
+      { namn: 'kammare.partier[].forkortning', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partiförkortningen.' },
+      { namn: 'kammare.partier[].mandat', typ: 'tal', obligatoriskt: true, beskrivning: 'Mandat i kammaren.' },
+      { namn: 'valdeltagande', typ: 'objekt', obligatoriskt: true, beskrivning: 'Valdeltagandet per val i `resultat`, med källorna i `kallor`.' },
+      { namn: 'storsta_utanfor_riksdagen', typ: 'objekt', obligatoriskt: true, beskrivning: 'De största partierna utanför riksdagen: `period`, `metod` och `partier`.' },
+      { namn: 'storsta_utanfor_riksdagen.partier[].parti_uuid', typ: 'sträng', obligatoriskt: true, beskrivning: 'Partiets `uuid` i registret.' },
+      { namn: 'storsta_utanfor_riksdagen.partier[].valar', typ: 'tal', obligatoriskt: true, beskrivning: 'Valåret partiets bästa resultat gäller.' },
+      { namn: 'storsta_utanfor_riksdagen.partier[].roster', typ: 'tal', obligatoriskt: true, beskrivning: 'Antalet röster.' },
+      { namn: 'storsta_utanfor_riksdagen.partier[].giltiga_roster', typ: 'tal', obligatoriskt: true, beskrivning: 'Giltiga röster i valet, som andelen räknas mot.' },
+      { namn: 'storsta_utanfor_riksdagen.partier[].rostandel', typ: 'tal', obligatoriskt: true, beskrivning: 'Röstandelen i procent.' },
+      { namn: 'storsta_utanfor_riksdagen.partier[].kalla', typ: 'objekt', obligatoriskt: true, beskrivning: 'Källan raden bygger på, i samma form som `kallor[]` i valresultaten.' },
+    ],
+  },
+  {
+    id: 'regions',
+    rubrik: 'regioner/index.json',
+    adress: '/data/regioner/index.json',
+    form: 'En lista med ett län per post, med länets kommuner.',
+    readme: 'regionerindexjson',
+    falt: [
+      { namn: 'kod', typ: 'sträng', obligatoriskt: true, beskrivning: 'SCB:s länskod, två siffror.' },
+      { namn: 'namn', typ: 'sträng', obligatoriskt: true, beskrivning: 'Länets namn.' },
+      { namn: 'uuid', typ: 'sträng', obligatoriskt: true, beskrivning: 'Länets stabila identitet.' },
+      { namn: 'kommuner', typ: 'lista av objekt', obligatoriskt: true, beskrivning: 'Länets kommuner med `kod`, `namn` och `uuid`. Kommunkodens två första siffror är länets kod.' },
+    ],
+  },
+];

--- a/src/components/party-profile/sources.tsx
+++ b/src/components/party-profile/sources.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import type { PartiDeltagande, PartiProfil } from 'src/types';
 import { ExternalLink, formatSwedishDate, SectionHeader, SourceLine } from './shared';
 
@@ -111,14 +112,15 @@ export function RegistrySection ({
 }
 
 export function ExportSection ({ slug, hasProfile }: { slug: string; hasProfile: boolean }) {
-  const dataUrl = `https://github.com/swedev/partidata/blob/main/data/parti/${slug}/index.json`;
+  const dataUrl = `/data/parti/${encodeURIComponent(slug)}/index.json`;
   const profileUrl = `https://github.com/swedev/partidata/blob/main/data/parti/${slug}/profil.json`;
 
   return (
     <section className="profile-shell profile-export" aria-labelledby="export-heading" id="export">
       <h2 id="export-heading" className="sr-only">Använd datan</h2>
-      <p>Källan står vid varje uppgift på sidan. De datafiler som finns för partiet är maskinläsbara och versionshanterade på GitHub.</p>
+      <p>Källan står vid varje uppgift på sidan. Partiets registerdata finns som JSON på Partidata; alla datafiler är versionshanterade på GitHub.</p>
       <div><a href={dataUrl} className="profile-button">Registerdata (JSON)</a>{hasProfile && <a href={profileUrl} className="profile-button">Profildata (JSON)</a>}<a href="https://github.com/swedev/partidata" className="profile-button profile-button--outline">Projektet på GitHub</a></div>
+      <p><Link href="/data/">Så använder du datan</Link></p>
     </section>
   );
 }

--- a/src/pages/api/data/[...path].ts
+++ b/src/pages/api/data/[...path].ts
@@ -49,7 +49,7 @@ export default async function handler (request: NextApiRequest, response: NextAp
   }
 
   response.setHeader('Cache-Control', 'public, max-age=3600');
-  // nginx gzips JSON without `gzip_vary on`, so the app states the variance.
+  // The body is compressed for a client that asks for it, so it varies.
   response.setHeader('Vary', 'Accept-Encoding');
   response.setHeader('ETag', resolution.etag);
   if (process.env.PARTIDATA_VERSION) response.setHeader('X-Partidata-Version', process.env.PARTIDATA_VERSION);

--- a/src/pages/api/data/[...path].ts
+++ b/src/pages/api/data/[...path].ts
@@ -1,0 +1,68 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { matchesEtag } from 'src/server/data-resources';
+import { partyData } from 'src/server/party-data';
+
+/**
+ * The largest allowlisted file is several megabytes, which Next warns about
+ * above its default response limit, and a rejected write method must not have
+ * its body parsed before the 405.
+ */
+export const config = { api: { bodyParser: false, responseLimit: false } };
+
+export default async function handler (request: NextApiRequest, response: NextApiResponse) {
+  // On every response, including 304, 308, 404 and 405: without it a browser
+  // client sees a network error instead of the status code.
+  response.setHeader('Access-Control-Allow-Origin', '*');
+
+  // A preflight asks whether the method may be used here, not whether the
+  // resource exists, so it is answered the same way for every address.
+  if (request.method === 'OPTIONS') {
+    response.setHeader('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
+    response.setHeader('Access-Control-Allow-Headers', 'If-None-Match');
+    response.setHeader('Access-Control-Max-Age', '86400');
+    response.status(204).end();
+    return;
+  }
+
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    response.setHeader('Allow', 'GET, HEAD, OPTIONS');
+    response.status(405).end();
+    return;
+  }
+
+  const segments = request.query.path;
+  const resolution = Array.isArray(segments)
+    ? await partyData.resolveDataResource(segments)
+    : ({ kind: 'notFound' } as const);
+
+  if (resolution.kind === 'redirect') {
+    response.setHeader('Location', resolution.destination);
+    response.status(308).end();
+    return;
+  }
+
+  if (resolution.kind === 'notFound') {
+    response.setHeader('Content-Type', 'application/json; charset=utf-8');
+    response.status(404).end(request.method === 'HEAD' ? undefined : '{"fel":"Okänd resurs"}');
+    return;
+  }
+
+  response.setHeader('Cache-Control', 'public, max-age=3600');
+  // nginx gzips JSON without `gzip_vary on`, so the app states the variance.
+  response.setHeader('Vary', 'Accept-Encoding');
+  response.setHeader('ETag', resolution.etag);
+  if (process.env.PARTIDATA_VERSION) response.setHeader('X-Partidata-Version', process.env.PARTIDATA_VERSION);
+  // Neither header is CORS-safelisted, so a `fetch` cannot read them otherwise.
+  response.setHeader('Access-Control-Expose-Headers', 'ETag, X-Partidata-Version');
+
+  if (matchesEtag(request.headers['if-none-match'], resolution.etag)) {
+    response.status(304).end();
+    return;
+  }
+
+  response.setHeader('Content-Type', 'application/json; charset=utf-8');
+  response.setHeader('Content-Length', String(resolution.body.length));
+  response.status(200);
+  response.end(request.method === 'HEAD' ? undefined : resolution.body);
+}

--- a/src/pages/api/sitemap.ts
+++ b/src/pages/api/sitemap.ts
@@ -16,6 +16,7 @@ export default async function handler (request: NextApiRequest, response: NextAp
   const baseUrl = process.env.PARTIDATA_BASE_URL ?? 'https://www.partidata.se';
   const urls = [
     new URL('/', baseUrl).toString(),
+    new URL('/data/', baseUrl).toString(),
     ...(await partyData.listCurrentSlugs()).map(slug => new URL(`/parti/${encodeURIComponent(slug)}/`, baseUrl).toString()),
   ];
   const body = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.map(url => `  <url><loc>${escapeXml(url)}</loc></url>`).join('\n')}\n</urlset>\n`;

--- a/src/pages/data/index.tsx
+++ b/src/pages/data/index.tsx
@@ -1,0 +1,271 @@
+import type { GetServerSideProps, NextPage } from 'next';
+import Head from 'next/head';
+import { Fragment } from 'react';
+
+import { FIELD_DOCS } from 'src/components/data/fields';
+import Footer from 'src/components/Footer';
+import Header from 'src/components/Header';
+import { partyData } from 'src/server/party-data';
+import type { DataCatalog } from 'src/server/party-data';
+
+const version = process.env.PARTIDATA_VERSION;
+const ref = version ? `v${version}` : 'main';
+const repo = 'https://github.com/swedev/partidata';
+
+/** Backtick-delimited spans in the copy are code, as they are in the README. */
+function Kod ({ text }: { text: string }) {
+  return (
+    <>
+      {text.split('`').map((part, index) => (
+        index % 2 === 1 ? <code key={index}>{part}</code> : <Fragment key={index}>{part}</Fragment>
+      ))}
+    </>
+  );
+}
+
+function AddressRow ({ adress, innehall }: { adress: string; innehall: string }) {
+  return (
+    <tr>
+      <td><a href={adress}><code>{adress}</code></a></td>
+      <td>{innehall}</td>
+    </tr>
+  );
+}
+
+const DataPage: NextPage<DataCatalog> = ({ antalPartier, exempel, valar }) => {
+  const exempelAdress = `/data/parti/${encodeURIComponent(exempel.filnamn)}/index.json`;
+  const senasteForst = [...valar].reverse();
+
+  return (
+    <div className="page-shell">
+      <Head>
+        <title>Data – Partidata</title>
+        <meta name="description" content="Partidatas data som JSON: adresser, fält, källor, versionering och licens." />
+        <link rel="icon" href="/img/partidata/mark.svg" type="image/svg+xml" />
+        <link rel="canonical" href="https://www.partidata.se/data/" />
+      </Head>
+
+      <Header current="data" />
+
+      <main className="container data-page">
+        <div className="home-intro">
+          <h1>Datan som JSON</h1>
+          <p className="description">
+            Partidata serverar samma filer som sajten själv läser. Adressen är en enda regel:{' '}
+            <code>https://www.partidata.se/data/&lt;sökväg&gt;</code> är filen <code>data/&lt;sökväg&gt;</code> i
+            repot, byte för byte. Nedan står adresserna, fälten, huvudena, versioneringen och villkoren.
+          </p>
+        </div>
+
+        <section id="adresser" aria-labelledby="adresser-heading">
+          <h2 id="adresser-heading">Adresser</h2>
+          <p className="description">
+            Registret håller {antalPartier} partier. Ett parti som har bytt <code>filnamn</code> svarar 308 på sin
+            gamla adress och pekar på den nuvarande, precis som partisidorna gör.
+          </p>
+
+          <table>
+            <caption>Register, partier och områdeskoder</caption>
+            <thead>
+              <tr><th scope="col">Adress</th><th scope="col">Innehåll</th></tr>
+            </thead>
+            <tbody>
+              <AddressRow adress="/data/derived/parti.json" innehall={`Registret: ${antalPartier} partier med uuid, beteckning och filnamn.`} />
+              <AddressRow adress={exempelAdress} innehall={`Ett partis registerdata — här ${exempel.beteckning}. Byt ut filnamnet mot partiets filnamn ur registret.`} />
+              <AddressRow adress="/data/derived/riksdag.json" innehall="Härledningen startsidan bygger på: den sittande kammaren, valdeltagandet och de största partierna utanför riksdagen." />
+              <AddressRow adress="/data/regioner/index.json" innehall="SCB:s läns- och kommunkoder, som deltagandet och partideltagandefilerna refererar till." />
+            </tbody>
+          </table>
+
+          <table>
+            <caption>Valår</caption>
+            <thead>
+              <tr><th scope="col">Adress</th><th scope="col">Innehåll</th></tr>
+            </thead>
+            <tbody>
+              {senasteForst.map(year => (
+                <Fragment key={year.valar}>
+                  {year.partideltagande.map(fil => (
+                    <AddressRow
+                      key={fil}
+                      adress={`/data/val/${year.valar}/partideltagande/${fil}.json`}
+                      innehall={`Partideltagande ${year.valar}: ${fil}.json`}
+                    />
+                  ))}
+                  {year.valresultat && (
+                    <AddressRow
+                      adress={`/data/val/${year.valar}/valresultat/riksdag.json`}
+                      innehall={`Slutligt riksdagsresultat ${year.valar}.`}
+                    />
+                  )}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </section>
+
+        <section id="falt" aria-labelledby="falt-heading">
+          <h2 id="falt-heading">Fält</h2>
+          <p className="description">
+            Fälten nedan är det en läsare kan räkna med. Ett fält som står som valfritt kan saknas i en enskild post.
+            Nästlade fält skrivs med punktnotation, och <code>[]</code> markerar att föräldern är en lista.
+          </p>
+          <p className="description">
+            Identiteterna hänger ihop på tre ställen: <code>uuid</code> i registret är samma <code>uuid</code> som i
+            partifilen och samma <code>parti_uuid</code> som i valresultaten; <code>kod</code> är Valmyndighetens{' '}
+            <code>PARTIKOD</code> och binder partifilen till partideltagandet; läns- och kommunkoderna är SCB:s och
+            slås upp i <code>regioner/index.json</code>.
+          </p>
+          <p className="description">
+            2018 års filer ligger kvar som de samlades in och avviker: <code>landsting.json</code> i stället för{' '}
+            <code>region.json</code>, inget <code>partier.json</code>, 208 av 290 kommuner, inga{' '}
+            <code>grunder</code>, och region- och kommunfilerna listar bara partier som inte står i{' '}
+            <code>riksdag.json</code>.
+          </p>
+
+          {FIELD_DOCS.map(resource => (
+            <div key={resource.id} className="data-resource">
+              <h3 id={`falt-${resource.id}`}>{resource.rubrik}</h3>
+              <p>
+                {resource.form}{' '}
+                <a href={`${repo}/blob/${ref}/README.md#${resource.readme}`}>Bakgrunden står i README</a>.
+              </p>
+              {resource.id === 'party' && (
+                <p>
+                  Fält som inte står i tabellen är handlagda extrafält — snake_case, valfritt JSON-värde — och är lika
+                  publika som de övriga.
+                </p>
+              )}
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Fält</th>
+                    <th scope="col">Typ</th>
+                    <th scope="col">Obligatoriskt</th>
+                    <th scope="col">Beskrivning</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {resource.falt.map(falt => (
+                    <tr key={falt.namn}>
+                      <td><code>{falt.namn}</code></td>
+                      <td>{falt.typ}</td>
+                      <td>{falt.obligatoriskt ? 'ja' : 'nej'}</td>
+                      <td><Kod text={falt.beskrivning} /></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ))}
+        </section>
+
+        <section id="hamta" aria-labelledby="hamta-heading">
+          <h2 id="hamta-heading">Hämta</h2>
+          <pre>{`curl -i https://www.partidata.se${exempelAdress}`}</pre>
+          <pre>{`fetch('https://www.partidata.se${exempelAdress}')\n  .then(response => response.json())\n  .then(parti => console.log(parti.beteckning));`}</pre>
+
+          <h3>Huvuden</h3>
+          <ul>
+            <li><code>Cache-Control: public, max-age=3600</code> — datan ändras bara när en ny version driftsätts, så ett svar är som mest en timme gammalt.</li>
+            <li><code>ETag</code> — filens SHA-256 som stark etagg. Skicka tillbaka den i <code>If-None-Match</code> och få 304 utan kropp när filen är oförändrad. Levereras svaret komprimerat märks etaggen <code>W/</code> av servern; skicka den ändå, den matchar.</li>
+            <li><code>Vary: Accept-Encoding</code> — kroppen varierar med komprimeringen.</li>
+            <li><code>X-Partidata-Version</code> — den version som svarade, samma nummer som i sidfoten och i <code>/api/health</code>.</li>
+            <li><code>Access-Control-Allow-Origin: *</code> på varje svar, och <code>Access-Control-Expose-Headers: ETag, X-Partidata-Version</code>, så att en webbläsarklient kan läsa båda.</li>
+          </ul>
+
+          <h3>Statuskoder</h3>
+          <ul>
+            <li><strong>200</strong> — filens byte, som <code>application/json; charset=utf-8</code>.</li>
+            <li><strong>304</strong> — <code>If-None-Match</code> matchar; ingen kropp.</li>
+            <li><strong>308</strong> — adressen använder ett tidigare <code>filnamn</code>; följ <code>Location</code>.</li>
+            <li><strong>404</strong> — adressen betecknar ingen publicerad resurs. Kroppen är <code>{'{"fel":"Okänd resurs"}'}</code>.</li>
+            <li><strong>405</strong> — bara <code>GET</code>, <code>HEAD</code> och <code>OPTIONS</code> är tillåtna; svaret bär <code>Allow</code>.</li>
+            <li><strong>204</strong> — svaret på <code>OPTIONS</code>, med de tillåtna metoderna.</li>
+          </ul>
+        </section>
+
+        <section id="versionering" aria-labelledby="versionering-heading">
+          <h2 id="versionering-heading">Versionering</h2>
+          <ul>
+            <li>Adresser och fältnamn är stabila. Nya fält kan tillkomma utan förvarning — en läsare ska ignorera fält den inte känner igen.</li>
+            <li>
+              Datan ändras bara när en ny version driftsätts. Versionen står i <code>X-Partidata-Version</code>, i
+              sidfoten och i <code>/api/health</code>, och samma filer finns på{' '}
+              <a href={`${repo}/tree/${ref}/data/`}>GitHub under taggen</a>.
+            </li>
+            <li>
+              Ett fält eller en adress som tas bort eller döps om görs i en version som noteras här, och en flyttad
+              adress vidarebefordras med 308 när det går — som ett parti som har bytt <code>filnamn</code>.
+            </li>
+          </ul>
+        </section>
+
+        <section id="licens" aria-labelledby="licens-heading">
+          <h2 id="licens-heading">Licens och villkor</h2>
+          <p className="description">
+            Partidatas egen sammanställning — strukturen, <code>uuid</code>, <code>filnamn</code>, de härledda fälten
+            och allt under <code>derived/</code> — är{' '}
+            <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0</a>. Uppgifterna kommer från källor
+            med egna villkor, och <code>kalla</code>, <code>kallurl</code> och <code>kallor</code> i filerna anger
+            källan per post. Villkoren nedan är kontrollerade 2026-08-30.
+          </p>
+          <ul>
+            <li>
+              <strong>Valmyndigheten</strong> — partibeteckningar, deltagande och valresultat. All data är fri att
+              använda, förutsatt att du anger Valmyndigheten som källa.{' '}
+              <a href="https://www.val.se/valresultat-och-statistik/statistik-och-data/om-var-oppna-data">Om Valmyndighetens öppna data</a>
+            </li>
+            <li>
+              <strong>SCB</strong> — läns- och kommunkoder samt valdeltagande. CC0, utan krav på källhänvisning, men
+              SCB rekommenderar ändå &quot;Källa: SCB&quot;.{' '}
+              <a href="https://www.scb.se/vara-tjanster/oppna-data/">SCB:s öppna data</a>
+            </li>
+            <li>
+              <strong>Wikidata</strong> — <code>wikidata.grundat</code>. CC0.{' '}
+              <a href="https://www.wikidata.org/wiki/Wikidata:Licensing">Wikidatas licensvillkor</a>
+            </li>
+          </ul>
+          <p className="description">
+            Partisymbolerna serveras inte under <code>/data/</code>. De kommer från Valmyndighetens symbolpaket och
+            kan vara varumärkesskyddade — villkoren för att använda dem är partiets, inte Partidatas.
+          </p>
+        </section>
+
+        <section id="utanfor" aria-labelledby="utanfor-heading">
+          <h2 id="utanfor-heading">Det som inte finns här</h2>
+          <ul>
+            <li>
+              <strong>Kandidatlistor</strong> — <code>val/&lt;år&gt;/kandidatlistor/</code> innehåller personuppgifter
+              och serveras inte. Hur de ska hanteras avgörs i{' '}
+              <a href={`${repo}/issues/33`}>issue 33</a>.
+            </li>
+            <li>
+              <strong>Partisymboler</strong> — PNG-filerna ligger i partiets katalog och serveras på{' '}
+              <code>/partisymbol/&lt;filnamn&gt;/&lt;partisymbol.filnamn&gt;</code>, inte under <code>/data/</code>.
+            </li>
+            <li>
+              <strong>Profildata</strong> — <code>parti/&lt;filnamn&gt;/profil.json</code> bär utdrag ur Wikipedia
+              under CC BY-SA 4.0 och nyhetsrubriker, och finns bara på{' '}
+              <a href={`${repo}/tree/${ref}/data/parti`}>GitHub</a>.
+            </li>
+            <li>
+              <strong>Kopplingstabeller</strong> — <code>parti/kodbyten.json</code>,{' '}
+              <code>valresultat/riksdag-partikopplingar.json</code> och{' '}
+              <code>val/&lt;år&gt;/valresultat/scb-tabeller.json</code> är arbetsmaterial för importen och finns på{' '}
+              <a href={`${repo}/tree/${ref}/data`}>GitHub</a>.
+            </li>
+          </ul>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+};
+
+export default DataPage;
+
+export const getServerSideProps: GetServerSideProps<DataCatalog> = async () => ({
+  props: await partyData.readDataCatalog(),
+});

--- a/src/pages/data/index.tsx
+++ b/src/pages/data/index.tsx
@@ -168,7 +168,7 @@ const DataPage: NextPage<DataCatalog> = ({ antalPartier, exempel, valar }) => {
           <h3>Huvuden</h3>
           <ul>
             <li><code>Cache-Control: public, max-age=3600</code> — datan ändras bara när en ny version driftsätts, så ett svar är som mest en timme gammalt.</li>
-            <li><code>ETag</code> — filens SHA-256 som stark etagg. Skicka tillbaka den i <code>If-None-Match</code> och få 304 utan kropp när filen är oförändrad. Levereras svaret komprimerat märks etaggen <code>W/</code> av servern; skicka den ändå, den matchar.</li>
+            <li><code>ETag</code> — <code>W/</code> följt av filens SHA-256. Etaggen är svag därför att samma fil levereras både komprimerad och okomprimerad; det är samma representation, och det är precis vad en svag etagg säger. Skicka tillbaka den oförändrad i <code>If-None-Match</code> och få 304 utan kropp när filen är densamma.</li>
             <li><code>Vary: Accept-Encoding</code> — kroppen varierar med komprimeringen.</li>
             <li><code>X-Partidata-Version</code> — den version som svarade, samma nummer som i sidfoten och i <code>/api/health</code>.</li>
             <li><code>Access-Control-Allow-Origin: *</code> på varje svar, och <code>Access-Control-Expose-Headers: ETag, X-Partidata-Version</code>, så att en webbläsarklient kan läsa båda.</li>

--- a/src/server/data-resources.ts
+++ b/src/server/data-resources.ts
@@ -87,16 +87,17 @@ export function dataPath (resource: DataResource): string[] {
 }
 
 /**
- * Whether an `If-None-Match` header carries the resource's entity tag. The tag
- * the app sends is strong, but nginx weakens it to `W/"…"` when it compresses
- * the body, so the `W/` prefix and the quotes are compared apart. An entry
- * without quotes is not an entity tag and never matches.
+ * Whether an `If-None-Match` header carries the resource's entity tag. `304`
+ * uses the weak comparison, so the `W/` prefix is stripped from both sides and
+ * only the quoted tag is compared. An entry without quotes is not an entity tag
+ * and never matches.
  */
 export function matchesEtag (header: string | undefined, etag: string): boolean {
   if (!header) return false;
   if (header.trim() === '*') return true;
+  const expected = etag.replace(/^W\//, '');
   return header.split(',').some(entry => {
     const candidate = entry.trim().replace(/^W\//, '');
-    return /^"[^"]*"$/.test(candidate) && candidate === etag;
+    return /^"[^"]*"$/.test(candidate) && candidate === expected;
   });
 }

--- a/src/server/data-resources.ts
+++ b/src/server/data-resources.ts
@@ -1,0 +1,102 @@
+/**
+ * The allowlist behind `/data/<sökväg>`: the only place that decides which
+ * files under `data/` the site hands out. It classifies URL segments into a
+ * resource before any path is built, and `dataPath` builds the path back from
+ * the resource rather than from the input, so nothing outside the table below
+ * can be reached.
+ */
+
+/** The participation files an election year may carry, in the order they are listed. */
+export const PARTICIPATION_FILES = ['partier', 'riksdag', 'region', 'kommun', 'landsting'] as const;
+
+export type ParticipationFile = (typeof PARTICIPATION_FILES)[number];
+
+export type DataResource =
+  | { kind: 'registry' }
+  | { kind: 'derived-parliament' }
+  | { kind: 'regions' }
+  | { kind: 'party'; filnamn: string }
+  | { kind: 'participation'; valar: string; fil: ParticipationFile }
+  | { kind: 'results'; valar: string };
+
+const SEGMENT = /^[a-z0-9-]+$/;
+const FILE = /^[a-z0-9-]+\.json$/;
+const YEAR = /^\d{4}$/;
+
+function participationFile (file: string): ParticipationFile | undefined {
+  const name = file.slice(0, -'.json'.length);
+  return PARTICIPATION_FILES.find(candidate => candidate === name);
+}
+
+/**
+ * The resource the segments of a `/data/` address name, or `undefined` when
+ * they name nothing that is published. Candidate lists, `profil.json`, party
+ * symbols, the import's linking tables, directories, upper case and `..` all
+ * fall here.
+ */
+export function classifyDataPath (segments: string[]): DataResource | undefined {
+  if (segments.length < 2) return undefined;
+  const file = segments[segments.length - 1];
+  if (!FILE.test(file)) return undefined;
+  const directories = segments.slice(0, -1);
+  if (!directories.every(segment => SEGMENT.test(segment))) return undefined;
+  const [head, ...rest] = directories;
+
+  switch (head) {
+    case 'derived':
+      if (rest.length > 0) return undefined;
+      if (file === 'parti.json') return { kind: 'registry' };
+      if (file === 'riksdag.json') return { kind: 'derived-parliament' };
+      return undefined;
+    case 'regioner':
+      return rest.length === 0 && file === 'index.json' ? { kind: 'regions' } : undefined;
+    case 'parti':
+      return rest.length === 1 && file === 'index.json' ? { kind: 'party', filnamn: rest[0] } : undefined;
+    case 'val': {
+      if (rest.length !== 2) return undefined;
+      const [valar, katalog] = rest;
+      if (!YEAR.test(valar)) return undefined;
+      if (katalog === 'partideltagande') {
+        const fil = participationFile(file);
+        return fil ? { kind: 'participation', valar, fil } : undefined;
+      }
+      if (katalog === 'valresultat' && file === 'riksdag.json') return { kind: 'results', valar };
+      return undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
+/** The path under `data/` the resource stands for, rebuilt from the resource. */
+export function dataPath (resource: DataResource): string[] {
+  switch (resource.kind) {
+    case 'registry':
+      return ['derived', 'parti.json'];
+    case 'derived-parliament':
+      return ['derived', 'riksdag.json'];
+    case 'regions':
+      return ['regioner', 'index.json'];
+    case 'party':
+      return ['parti', resource.filnamn, 'index.json'];
+    case 'participation':
+      return ['val', resource.valar, 'partideltagande', `${resource.fil}.json`];
+    case 'results':
+      return ['val', resource.valar, 'valresultat', 'riksdag.json'];
+  }
+}
+
+/**
+ * Whether an `If-None-Match` header carries the resource's entity tag. The tag
+ * the app sends is strong, but nginx weakens it to `W/"…"` when it compresses
+ * the body, so the `W/` prefix and the quotes are compared apart. An entry
+ * without quotes is not an entity tag and never matches.
+ */
+export function matchesEtag (header: string | undefined, etag: string): boolean {
+  if (!header) return false;
+  if (header.trim() === '*') return true;
+  return header.split(',').some(entry => {
+    const candidate = entry.trim().replace(/^W\//, '');
+    return /^"[^"]*"$/.test(candidate) && candidate === etag;
+  });
+}

--- a/src/server/party-data.ts
+++ b/src/server/party-data.ts
@@ -38,9 +38,11 @@ export type PartyResolution =
   | { kind: 'notFound' };
 
 /**
- * What a `/data/<sökväg>` address resolves to. `body` is the file's bytes, so
- * `etag` — its SHA-256 — is the checksum of the very file the repository holds
- * at the built tag.
+ * What a `/data/<sökväg>` address resolves to. `body` is the file's bytes, and
+ * `etag` carries their SHA-256 — the checksum of the very file the repository
+ * holds at the built tag. The tag is weak because the response is compressed
+ * further down the stack: identity and gzip are different bytes for the same
+ * representation, which is exactly what a weak validator states.
  */
 export type DataResourceResolution =
   | { kind: 'file'; body: Buffer; etag: string }
@@ -521,7 +523,7 @@ export function createPartyDataStore (
       entry = (async () => {
         try {
           const body = await readFile(file);
-          return { body, etag: `"${createHash('sha256').update(body).digest('hex')}"` };
+          return { body, etag: `W/"${createHash('sha256').update(body).digest('hex')}"` };
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
           dataFiles.delete(file);

--- a/src/server/party-data.ts
+++ b/src/server/party-data.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -11,6 +12,7 @@ import type {
   PartiValresultatPost,
 } from '../types';
 import { assertSwedishCollation, compareSv } from './collation.ts';
+import { classifyDataPath, dataPath, PARTICIPATION_FILES } from './data-resources.ts';
 
 /**
  * The election a candidate list belongs to, as `val/<år>/kandidatlistor/` names
@@ -34,6 +36,27 @@ export type PartyResolution =
   | { kind: 'party'; props: PartyPageData }
   | { kind: 'redirect'; destination: string }
   | { kind: 'notFound' };
+
+/**
+ * What a `/data/<sökväg>` address resolves to. `body` is the file's bytes, so
+ * `etag` — its SHA-256 — is the checksum of the very file the repository holds
+ * at the built tag.
+ */
+export type DataResourceResolution =
+  | { kind: 'file'; body: Buffer; etag: string }
+  | { kind: 'redirect'; destination: string }
+  | { kind: 'notFound' };
+
+/**
+ * What the documentation page needs to write addresses that exist: the size of
+ * the registry, a party to build the examples from, and the files each election
+ * year actually carries.
+ */
+export interface DataCatalog {
+  antalPartier: number;
+  exempel: { filnamn: string; beteckning: string };
+  valar: Array<{ valar: string; partideltagande: string[]; valresultat: boolean }>;
+}
 
 /**
  * A symbol's drawing measured in its own widths and heights: the aspect ratio
@@ -307,6 +330,8 @@ export function createPartyDataStore (
   let partyIndexPromise: Promise<PartyIndex> | undefined;
   let homeDataPromise: Promise<HomeData> | undefined;
   let parliamentResultsPromise: Promise<ParliamentResultFile[]> | undefined;
+  let dataCatalogPromise: Promise<DataCatalog> | undefined;
+  const dataFiles = new Map<string, Promise<{ body: Buffer; etag: string } | undefined>>();
 
   function getPartyIndex (): Promise<PartyIndex> {
     partyIndexPromise ??= readJson<PartiIndexEntry[]>(path.join(dataRoot, 'derived', 'parti.json')).then(parties => {
@@ -485,6 +510,79 @@ export function createPartyDataStore (
     return { parties, valar, lan, kommuner, riksdag, ...(outsideParliament ? { outsideParliament } : {}) };
   }
 
+  /**
+   * One allowlisted file with its entity tag, read once per path. The data only
+   * changes when the process is restarted at deploy, and every allowlisted file
+   * together is a fraction of what the start page already holds parsed.
+   */
+  function readDataFile (file: string): Promise<{ body: Buffer; etag: string } | undefined> {
+    let entry = dataFiles.get(file);
+    if (!entry) {
+      entry = (async () => {
+        try {
+          const body = await readFile(file);
+          return { body, etag: `"${createHash('sha256').update(body).digest('hex')}"` };
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+          dataFiles.delete(file);
+          throw error;
+        }
+      })();
+      dataFiles.set(file, entry);
+    }
+    return entry;
+  }
+
+  async function resolveDataResource (segments: string[]): Promise<DataResourceResolution> {
+    const resource = classifyDataPath(segments);
+    if (!resource) return { kind: 'notFound' };
+
+    if (resource.kind === 'party') {
+      const index = await getPartyIndex();
+      if (!index.current.has(resource.filnamn)) {
+        const redirect = index.redirects.get(resource.filnamn);
+        return redirect
+          ? { kind: 'redirect', destination: `/data/parti/${redirect.filnamn}/index.json` }
+          : { kind: 'notFound' };
+      }
+    }
+
+    const root = path.resolve(dataRoot);
+    const file = path.resolve(root, ...dataPath(resource));
+    const relative = path.relative(root, file);
+    if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) return { kind: 'notFound' };
+
+    const entry = await readDataFile(file);
+    return entry ? { kind: 'file', body: entry.body, etag: entry.etag } : { kind: 'notFound' };
+  }
+
+  async function buildDataCatalog (): Promise<DataCatalog> {
+    const [index, years, results] = await Promise.all([getPartyIndex(), electionYears(), readParliamentResults()]);
+    const resultYears = new Set(results.map(result => String(result.valar)));
+
+    const valar = await Promise.all(years.map(async year => {
+      const files = await readdir(path.join(dataRoot, 'val', year, 'partideltagande')).catch(() => [] as string[]);
+      return {
+        valar: year,
+        partideltagande: PARTICIPATION_FILES.filter(name => files.includes(`${name}.json`)).map(String),
+        valresultat: resultYears.has(year),
+      };
+    }));
+
+    const byUuid = new Map(index.parties.map(party => [party.uuid, party]));
+    const largest = (results.at(-1)?.mandatfordelning.partier ?? [])
+      .toSorted((a, b) => b.mandat - a.mandat)
+      .map(row => byUuid.get(row.parti_uuid))
+      .find((party): party is PartiIndexEntry => party !== undefined);
+    const exempel = largest ?? index.parties[0];
+
+    return {
+      antalPartier: index.parties.length,
+      exempel: { filnamn: exempel.filnamn, beteckning: exempel.beteckning },
+      valar,
+    };
+  }
+
   return {
     async readHomeData (): Promise<HomeData> {
       homeDataPromise ??= buildHomeData();
@@ -517,6 +615,13 @@ export function createPartyDataStore (
         body: await readFile(path.join(dataRoot, 'parti', slug, party.partisymbol.filnamn)),
         contentType,
       };
+    },
+
+    resolveDataResource,
+
+    async readDataCatalog (): Promise<DataCatalog> {
+      dataCatalogPromise ??= buildDataCatalog();
+      return await dataCatalogPromise;
     },
 
     async listCurrentSlugs (): Promise<string[]> {

--- a/src/styles/_data.scss
+++ b/src/styles/_data.scss
@@ -1,0 +1,106 @@
+.data-page section {
+  margin-top: clamp(2.5rem, 6vw, 4rem);
+}
+
+.data-page h2 {
+  margin-bottom: 1.25rem;
+}
+
+.data-page h3 {
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
+  color: var(--partidata-navy);
+  font-family: var(--font-partidata-mono), monospace;
+  font-size: 1.25rem;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  word-break: break-word;
+}
+
+.data-page p,
+.data-page ul {
+  max-width: 62ch;
+}
+
+.data-page ul {
+  padding-left: 1.25rem;
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+  color: var(--partidata-ink);
+}
+
+.data-page li + li {
+  margin-top: 0.5rem;
+}
+
+.data-page code {
+  color: var(--partidata-navy);
+  font-family: var(--font-partidata-mono), monospace;
+  font-size: 0.9em;
+  word-break: break-word;
+}
+
+.data-page pre {
+  max-width: 62ch;
+  padding: 1rem 1.125rem;
+  overflow-x: auto;
+  border: 1px solid var(--partidata-line);
+  margin: 0 0 1.25rem;
+  background: var(--partidata-soft);
+  color: var(--partidata-text);
+  font-family: var(--font-partidata-mono), monospace;
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+
+.data-page table {
+  width: 100%;
+  border-collapse: collapse;
+  border-top: 2px solid var(--partidata-text);
+  margin-bottom: 2rem;
+  font-size: 0.9375rem;
+  table-layout: fixed;
+}
+
+.data-page caption {
+  padding-bottom: 0.5rem;
+  color: var(--partidata-muted);
+  font-size: 0.875rem;
+  text-align: left;
+}
+
+.data-page th,
+.data-page td {
+  padding: 0.75rem 1rem 0.75rem 0;
+  border-bottom: 1px solid var(--partidata-line);
+  text-align: left;
+  vertical-align: top;
+  word-break: break-word;
+}
+
+.data-page th {
+  color: var(--partidata-navy);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.data-page td {
+  color: var(--partidata-ink);
+}
+
+.data-resource {
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 700px) {
+  .data-page table {
+    font-size: 0.875rem;
+  }
+
+  .data-page th,
+  .data-page td {
+    padding-right: 0.625rem;
+  }
+}

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -1,3 +1,4 @@
+@use "./data";
 @use "./home";
 @use "./party-card";
 @use "./party-symbol";


### PR DESCRIPTION
Partidata's data was reachable mainly through GitHub, although open, machine-readable data is the core of the project. The running application now serves it: `/data/<path>` answers with the same validated JSON files the site reads, and `/data/` documents the interface.

`src/server/data-resources.ts` is an allowlist of six resource forms — the registry, a party's registry file, the region and municipality tables, participation per election year, the parliamentary results and the derived chamber view — and classifies everything else as no resource: candidate lists, `profil.json`, symbol images, `kodbyten.json`, the SCB tables, directories, `..`, uppercase. The API route (`src/pages/api/data/[...path].ts`, reached through a rewrite from `/data/:path+`) allows `GET`, `HEAD` and `OPTIONS` only, answers 405 with `Allow` otherwise, sets CORS for public reading on every response, `Cache-Control` and `Vary`, and a strong `ETag` with 304 support. Files are read once per process and cached with their SHA-256; the 6.9 MB municipality table answers in about 3 ms warm. The documentation page at `/data/` is server-rendered from the same catalog and covers addresses, fields, headers, the versioning principle, licence terms and what is deliberately left out. The header's "Data på GitHub" becomes "Data" and points at the page; each party page links its registry JSON at Partidata's address instead of GitHub; the sitemap lists `/data/`.

Tests: `scripts/data-resources.test.js` for the classifier, `scripts/data-fields.test.js` checking the documented field contract against real specimens in `data/`, and `scripts/http-smoke.js` covering 200, 404, 405, content type, CORS, ETag/304 and that a normalised address never lands outside `/data/`. `npm run precommit` is green; memory measured flat at about 114 MB after fetching every documented address twice.

Deviations from the plan, recorded there: the field contract lives in `src/components/data/fields.ts` because the pages router rejects non-page files under `src/pages/`; the smoke assertion for addresses Next normalises itself now locks the plan's intent (at most one redirect, staying under `/data/`, a 200 only for the registry's exact bytes) since two of the plan's own cases legitimately end in a 200; `DataResource.fil` is typed to the participation file union rather than `string`.

Not done here: a cross-origin `fetch` from a real browser, and the post-deploy compression check against production the plan lists as a release step. Five plan decisions are marked as the planner's own judgment and open to challenge: leaving `profil.json` out, including `derived/riksdag.json` and `regioner/index.json`, the versioning principle, replacing "Data på GitHub" with "Data", and whole-file in-memory caching.

Closes #26
