### PR TITLE
Add a profile for CIVIS with the party's own links

### DIFF
--- a/data/parti/civis/profil.json
+++ b/data/parti/civis/profil.json
@@ -1,0 +1,47 @@
+{
+  "namn": "CIVIS",
+  "webbplats": "https://civis.nu/",
+  "namn_kalla": {
+    "namn": "CIVIS",
+    "url": "https://civis.nu/",
+    "hamtad": "2026-09-07"
+  },
+  "profiltext": {
+    "text": "Vi planerar för nästa generation, inte nästa val.",
+    "kalla": {
+      "namn": "CIVIS",
+      "url": "https://civis.nu/",
+      "hamtad": "2026-09-07"
+    }
+  },
+  "kanaler": [
+    { "etikett": "Webbplats", "detalj": "civis.nu", "url": "https://civis.nu/" },
+    { "etikett": "Politik & partiprogram", "detalj": "civis.nu/politik", "url": "https://civis.nu/politik" },
+    { "etikett": "Valmanifest 2026", "detalj": "civis.nu/valmanifest", "url": "https://civis.nu/valmanifest" },
+    { "etikett": "Nyheter", "detalj": "civis.nu/nyheter", "url": "https://civis.nu/nyheter" },
+    { "etikett": "Kontakt", "detalj": "civis.nu/kontakt", "url": "https://civis.nu/kontakt" }
+  ],
+  "dokument": [
+    {
+      "typ": "partiprogram",
+      "titel": "Partiprogram v1.3",
+      "url": "https://civis.nu/politik",
+      "kalla": {
+        "namn": "CIVIS – Politik & partiprogram",
+        "url": "https://civis.nu/politik",
+        "hamtad": "2026-09-07"
+      }
+    },
+    {
+      "typ": "valmanifest",
+      "titel": "Valmanifest 2026",
+      "url": "https://civis.nu/valmanifest",
+      "valar": 2026,
+      "kalla": {
+        "namn": "CIVIS – Valmanifest 2026",
+        "url": "https://civis.nu/valmanifest",
+        "hamtad": "2026-09-07"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
CIVIS (partikod 1884) emailed and asked us to link their official website, party programme and contact page. This adds `data/parti/civis/profil.json` with the website, the programme page ("Partiprogram v1.3", served at civis.nu/politik), the 2026 manifesto, news and contact pages as channels, plus the site's own tagline as profile text. Every entry carries its source and fetch date.

The email also attached a logotype. The data model only carries Valmyndigheten's party symbol, so the logotype is left out; supporting party-supplied logotypes would be a separate change.

Data validation and the test suite pass.