### PR TITLE
Publish data changes without a release

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,8 @@
 name: Build and deploy
 
 # Pushing a v* tag builds the standalone app, rsyncs it to production and
-# restarts the managed Node process. workflow_dispatch re-deploys the selected ref.
-# Nothing is built on the server.
+# restarts the managed Node process. workflow_dispatch re-deploys the selected
+# tag. Nothing is built on the server.
 on:
   push:
     tags:
@@ -33,10 +33,19 @@ jobs:
 
       - run: npm ci
 
+      # A release is a tag, as deploy/README.md describes it: the version the
+      # deployed artifact reports then always names a tag whose tree is the
+      # deployed code.
+      - name: Require a tag
+        run: |
+          if [ "$GITHUB_REF_TYPE" != "tag" ]; then
+            echo "A release is built from a v* tag, not from $GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+
       # The artifact reports the version from package.json, so a tag that names
       # a different one would deploy a build that misidentifies itself.
       - name: Verify the tag matches package.json
-        if: github.ref_type == 'tag'
         run: |
           version="v$(node -p "require('./package.json').version")"
           if [ "$version" != "$GITHUB_REF_NAME" ]; then
@@ -66,15 +75,24 @@ jobs:
             -e "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes" \
             .release/ "$USER@$HOST:$TARGET/"
 
-      - name: Restart and local health check
+      # The rsync above deleted $TARGET/data-commit along with the rest of the
+      # old artifact, so the release writes it back: this tag's commit is the
+      # commit the data comes from. The temporary file keeps a reader from ever
+      # seeing half a line.
+      - name: Record the commit, restart and local health check
         env:
           HOST: ${{ secrets.DEPLOY_HOST }}
           USER: ${{ secrets.DEPLOY_USER }}
+          TARGET: ${{ secrets.DEPLOY_TARGET }}
         run: |
           ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes "$USER@$HOST" \
-            'sudo systemctl restart partidata.service && curl --fail --silent --show-error --retry 10 --retry-delay 1 --retry-connrefused http://127.0.0.1:3000/api/health/'
+            "printf '%s\n' '$GITHUB_SHA' > '$TARGET/data-commit.tmp' && chmod 0644 '$TARGET/data-commit.tmp' && mv -f '$TARGET/data-commit.tmp' '$TARGET/data-commit' && sudo systemctl restart partidata.service && curl --fail --silent --show-error --retry 10 --retry-delay 1 --retry-connrefused http://127.0.0.1:3000/api/health/"
 
+      # Requiring the commit proves both that the file landed and that the
+      # restarted process is the one answering.
       - name: Public smoke test
+        shell: bash
         run: |
-          curl --fail --silent --show-error --retry 5 --retry-delay 1 https://www.partidata.se/api/health/
+          curl --fail --silent --show-error --retry 5 --retry-delay 1 https://www.partidata.se/api/health/ \
+            | jq -e --arg sha "$GITHUB_SHA" '.status == "ok" and .data.commit == $sha'
           curl --fail --silent --show-error --retry 5 --retry-delay 1 https://www.partidata.se/ > /dev/null

--- a/.github/workflows/publish-data.yaml
+++ b/.github/workflows/publish-data.yaml
@@ -1,0 +1,94 @@
+name: Publish data
+
+# A push to main that touches data/** rsyncs data/ to production and restarts
+# the managed Node process, so a data change goes live without a release.
+# Nothing is built, and nothing here depends on the deployed code: publishing
+# data and releasing code are separate. Whatever triggered the run, it is main's
+# tip that is published.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'data/**'
+  workflow_dispatch:
+
+# Shared with the release, so a data publish and a deploy never interleave.
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Validate and rsync data
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: production
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+
+      # Every later step refers to this commit rather than to the event's sha:
+      # a dispatch from a branch, a re-run of an old run and a push that waited
+      # behind a release all publish what main is when the job runs.
+      - name: Read main's tip
+        run: echo "DATA_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run validate:data
+
+      - run: npm run check:derived-data
+
+      - name: Install deploy key
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/deploy_key
+          printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/deploy_key ~/.ssh/known_hosts
+
+      # --delete is scoped to $TARGET/data/, which is the directory
+      # build-release.js fills from data/ and the server reads from its working
+      # directory. The rest of the artifact is untouched.
+      - name: Rsync data to server
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+          USER: ${{ secrets.DEPLOY_USER }}
+          TARGET: ${{ secrets.DEPLOY_TARGET }}
+        run: |
+          rsync -az --delete \
+            -e "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes" \
+            data/ "$USER@$HOST:$TARGET/data/"
+
+      # The restart is what makes the module caches in party-data.ts let go of
+      # the old files. The temporary file keeps a reader from ever seeing half a
+      # line.
+      - name: Record the commit, restart and local health check
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+          USER: ${{ secrets.DEPLOY_USER }}
+          TARGET: ${{ secrets.DEPLOY_TARGET }}
+        run: |
+          ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes "$USER@$HOST" \
+            "printf '%s\n' '$DATA_COMMIT' > '$TARGET/data-commit.tmp' && chmod 0644 '$TARGET/data-commit.tmp' && mv -f '$TARGET/data-commit.tmp' '$TARGET/data-commit' && sudo systemctl restart partidata.service && curl --fail --silent --show-error --retry 10 --retry-delay 1 --retry-connrefused http://127.0.0.1:3000/api/health/"
+
+      # Requiring the commit proves both that the file landed and that the
+      # restarted process is the one answering.
+      - name: Public smoke test
+        shell: bash
+        run: |
+          curl --fail --silent --show-error --retry 5 --retry-delay 1 https://www.partidata.se/api/health/ \
+            | jq -e --arg sha "$DATA_COMMIT" '.status == "ok" and .data.commit == $sha'
+          curl --fail --silent --show-error --retry 5 --retry-delay 1 https://www.partidata.se/ > /dev/null

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,13 @@ Open data about Swedish political parties. Swedish copy.
 - Branch + PR flow; PRs are squash-merged.
 - CI (`Integrate`) must be green; `npm run precommit` runs the equivalent local
   lint, typecheck, data validation, tests, standalone build and HTTP smoke.
-- Deploys happen on `v*` tags, not on merge: tag `main` and push the tag
-  (see `deploy/README.md`). Merging is not releasing.
+- Code deploys on `v*` tags: tag `main` and push the tag (see
+  `deploy/README.md`). A merge to `main` that touches `data/` publishes the data
+  by itself through `publish-data.yaml` — data and code ship independently. A
+  code change still needs a tag, and takes the data with it.
+  `data/derived/riksdag.json` and `public/img/sveriges_riksdag.svg` are built
+  into the bundle, so a change to them reaches the party pages only with a
+  release.
 
 ## Stack
 

--- a/agent-docs/issue/100-publish-data-without-release/index.md
+++ b/agent-docs/issue/100-publish-data-without-release/index.md
@@ -1,0 +1,33 @@
+# Issue #100: Publish data changes without a release
+
+**Baserad på:** main
+
+## Sammanfattning
+
+En ändring under `data/` når i dag partidata.se bara genom en full release med versionshöjning, tagg, bygge och omstart, fast de flesta ändringar på `main` är ren data. Ett nytt workflow `publish-data.yaml` körs vid push till `main` som rör `data/**` (och vid `workflow_dispatch`), checkar alltid ut `main`s spets, kör `validate:data` och `check:derived-data`, rsyncar `data/` till `$TARGET/data/` med `--delete` avgränsat till den katalogen, startar om `partidata.service` så att modul-cacherna i `party-data.ts` släpper de gamla filerna, och delar concurrency-gruppen `production-deploy` med releasen. Jobbet jämför inte `main` med den driftsatta koden: att publicera data och att släppa kod är två skilda saker. `deploy.yaml` bygger bara taggar, så den version servern anger alltid namnger en tagg vars träd är dess kod. Båda workflowen skriver `$TARGET/data-commit` efter sin rsync; `/api/health` anger `data.commit` när filen finns, workflowens publika kontroll kräver att den stämmer, och `/data/`-sidan länkar datan till den committen och säger att datan publiceras från `main` medan `X-Partidata-Version` och sidfoten fortsatt är kodens version. `deploy/README.md` och `CLAUDE.md` skrivs om från "merging is not releasing" till "dataändringar går live vid merge, kod behöver en tagg", och noterar att `data/derived/riksdag.json` och `public/img/sveriges_riksdag.svg` ligger i bundeln och därför bara når partisidorna med en release. Allt går i en PR.
+
+## Triageringsstatus
+
+| Fält | Värde |
+|------|-------|
+| **Redo att arbeta** | Ja |
+| **Risk** | Medel |
+| **Säker för junior** | Nej |
+
+## Plangranskning
+
+**Status:** Reviewed
+**Granskad:** 2026-09-07
+**Feedback:** Fem granskningsrundor (codex). Första rundan: `.version` identifierar inte en manuellt byggd gren; dispatch från gren och omkörningar kunde rsynca gammal data med `--delete`; concurrency-gruppen håller bara en väntande körning; felhantering, `TARGET`-miljön i omstartssteget, `pipefail`, undantagslistans motivering, props-typen och alla datalänkar, att `profil.json` inte serveras på `/data/`, och det manuella receptet — alla åtgärdade. Andra rundan: `data/derived/riksdag.json` importeras statiskt i `elections.tsx` (nu beslut 9), releasen måste bara bygga taggar (beslut 10), vakten läser versionen utan `--fail`, och jobbet checkar alltid ut `main`s spets (beslut 8). Tredje och fjärde rundan rättade baslinjen (`main` är en commit före `v0.11.2`) och filantalet i omfattningen (9); femte rundan bekräftade innehållet utan anmärkning.
+
+## Relaterade filer
+
+- [plan.md](plan.md) — Fullständig implementationsplan
+- [progress.md](progress.md) — Implementationsframsteg
+- [research.md](research.md) — Forskningsresultat (om finns)
+
+## Relaterade issues
+
+- #99 — (mergad PR) CIVIS-profilen; dataändringen som motiverade issuet
+- #98 — Avgör om nginx eller Next komprimerar `/data/`; rör samma "Huvuden"-avsnitt på `/data/`-sidan
+- #35 — Omkörningen av 2026-importen; första stora dataändringen som går den nya vägen, och kan ändra `public/img/sveriges_riksdag.svg` och `data/derived/riksdag.json` så att en release ändå krävs

--- a/agent-docs/issue/100-publish-data-without-release/plan.md
+++ b/agent-docs/issue/100-publish-data-without-release/plan.md
@@ -1,0 +1,214 @@
+# Plan: Issue #100 — Publish data changes without a release
+
+## Mål
+
+I dag når en ändring under `data/` partidata.se bara genom en full release: `package.json` höjs, en `v*`-tagg pushas, `deploy.yaml` bygger den fristående appen, rsyncar `.release/` och startar om tjänsten. De flesta ändringar på `main` är ren data — ett parti som skickar in sina länkar (#99) — och en versionshöjning per sådan ändring är brus.
+
+Ett separat workflow, `publish-data.yaml`, ska publicera enbart datan: det körs vid push till `main` som rör `data/**` (och vid `workflow_dispatch`), kör `npm run validate:data` och `npm run check:derived-data`, rsyncar `data/` till `$TARGET/data/` på produktionsvärden med den befintliga deploy-nyckeln, startar om `partidata.service` så att serverns modul-cacher släpper de gamla filerna, och delar concurrency-gruppen `production-deploy` så att det aldrig går omlott med en release. Servern får veta vilken commit datan kommer från, `/api/health` och `/data/`-sidan anger den, och `deploy/README.md`, `CLAUDE.md` och `/data/`-sidans versioneringsavsnitt skrivs om så att de säger det som blir sant: dataändringar går live vid merge, kodändringar behöver fortfarande en tagg, och de två filer som ligger i bundeln når partisidorna bara med en release.
+
+## Triagering
+
+> Beslutsunderlag för detta issue.
+
+| Fält | Värde |
+|------|-------|
+| **Blockeras av** | Inget |
+| **Blockerar** | Inget (men #35 — omkörningen av 2026-importen — blir den första stora dataändringen som går den här vägen) |
+| **Relaterade issues** | #99 (mergad PR; den dataändring som motiverade issuet), #98 (öppet; avgör var `/data/` komprimeras och rör samma "Huvuden"-avsnitt på `/data/`-sidan), #35 (öppet; stor dataimport som kan ändra `public/img/sveriges_riksdag.svg` och `data/derived/riksdag.json` och därmed ändå kräva en release) |
+| **Omfattning** | 9 filer att skapa eller ändra i `.github/workflows/`, `src/server/`, `src/pages/`, `scripts/`, `deploy/` och repots rot, plus `README.md` att kontrollera |
+| **Risk** | Medel |
+| **Komplexitet** | Medel |
+| **Säker för junior** | Nej |
+| **Konfliktrisk** | Låg (ingen annan öppen plan finns; alla planmappar under `agent-docs/issue/` hör till stängda issues. #98 saknar plan men kommer att röra `deploy/partidata.se.conf` och "Huvuden"-listan i `src/pages/data/index.tsx`, som den här planen ändrar en rad i) |
+
+### Triagemässiga noteringar
+
+- Issuet är öppet utan etiketter, ansvarig eller kommentarer, och repot har ingen `agent-docs/github/`-konfiguration, så ingen projekttavla har frågats. Inga blockerare nämns i texten. #99 är verifierat mergad (`gh pr view 99`, 2026-09-07).
+- `main` är i dag en commit före `v0.11.2` (`891ab2c`, en rad i `src/components/Header.tsx`). Datapubliceringen bryr sig inte om det (designbeslut 2), men det säger vad `main` är, inte vad servern kör: releaseflödet är det enda som skriver `$TARGET/`, och det bygger i dag taggar eller — vid manuell körning — vilken ref som helst, fast `deploy/README.md` bara beskriver "an earlier tag". Planen gör README:s regel till workflowets (fas 3), så att den version servern anger alltid är en tagg vars kod är serverns.
+- Servern läser `data/` från `process.cwd()` (`createPartyDataStore` i `src/server/party-data.ts`), och `WorkingDirectory` i `deploy/partidata.service.template` är `$DEPLOY_TARGET`, så `$TARGET/data/` är precis den katalog `build-release.js` kopierar `data/` till i `.release/data/`. Rsync av `data/` dit ersätter alltså samma filer som en release levererar.
+- Fyra saker cachas i modul-promises i `party-data.ts`: partiregistret (`getPartyIndex`), riksdagsresultaten (`readParliamentResults`), startsidan (`readHomeData`) och datakatalogen (`readDataCatalog`), plus varje utlämnad `/data/`-fil med sin etagg (`dataFiles`). Partisidor och partisymboler läses däremot per anrop. Utan omstart skulle en ny `profil.json` synas på partisidan medan ett ändrat `index.json` inte nådde `/data/`-svaret, och ett nytt parti inte synas alls. Därför startas tjänsten om (designbeslut 1).
+- En datafil ligger *i bundeln*, inte på disken: `src/components/party-profile/elections.tsx` importerar `data/derived/riksdag.json` statiskt (kammarens sammansättning, valdeltagande, källor), så det värdet bakas in vid `next build` och ändras inte av rsync och omstart. En ändring av den filen når partisidorna bara genom en release; det dokumenteras i stället för att bevakas (designbeslut 9). Ingen annan fil under `data/` importeras statiskt (`grep -rn "data/" src` med `import`/`require`, 2026-09-07).
+- Sudoers-regeln på servern tillåter deploy-kontot exakt `systemctl restart partidata.service` (`deploy/README.md`). Det nya workflowet behöver inget mer än det, samma deploy-nyckel och samma fem hemligheter i miljön `production`. Steget "Restart and local health check" i `deploy.yaml` har i dag bara `HOST` och `USER` i sin miljö; `TARGET` måste läggas till där när steget också ska skriva en fil.
+- `/data/`-sidan lovar i dag "Datan ändras bara när en ny version driftsätts" och länkar filerna "på GitHub under taggen". Det slutar vara sant med det här issuet, så texten måste ändras oavsett vad `/api/health` gör (designbeslut 4 och 5). `profil.json` ligger utanför allowlisten i `src/server/data-resources.ts` och serveras inte på `/data/`; en ändring som ska synas där måste röra en allowlistad fil, t.ex. ett partis `index.json`.
+- `public/img/sveriges_riksdag.svg` genereras ur datan av `scripts/build-derived-data.js`, och `check:derived-data` faller om den inte stämmer. En dataändring som flyttar mandat ändrar alltså också en fil i `public/`, som bara skeppas av en release. Det är den andra bundlade filen, vid sidan av `data/derived/riksdag.json` (designbeslut 9).
+- GitHubs concurrency-grupper håller högst *en* väntande körning: en ny körning i gruppen ersätter den som redan väntar, också med `cancel-in-progress: false`. Med en pågående körning, en väntande release och en ny datapush blir releasen avbruten. Det är sällsynt (tre händelser inom några minuter), utfallet syns som en avbruten körning, och releasen körs om med `workflow_dispatch` på taggen. Planen lovar därför inte en kö, bara att två körningar aldrig går samtidigt. Eftersom datajobbet alltid publicerar `main`s spets (nedan) spelar det ingen roll vilken datapush som till slut kör.
+
+## Angreppssätt
+
+Workflowet gör i tur och ordning: checka ut `main`s spets, `npm ci`, validera datan, rsynca `data/`, skriva vilken commit datan kommer från, starta om tjänsten och kontrollera via `/api/health` att servern svarar och rapporterar just den committen.
+
+**Alltid `main`s spets.** `actions/checkout` får `ref: main`, oavsett trigger, och jobbet läser `git rev-parse HEAD` till `DATA_COMMIT` i `$GITHUB_ENV` som den commit allt sedan syftar på — inte `github.sha`. Det gör tre saker rätt på en gång: en `workflow_dispatch` från en gren publicerar ändå `main`; en omkörning av en gammal körning publicerar dagens `main`, inte gårdagens data med `--delete`; och en datapush som väntat i gruppen bakom en release publicerar det `main` är när den väl kör, också om andra commits hunnit landa. En avsiktlig återställning är en revert på `main`.
+
+**Ingen vakt.** Jobbet jämför inte `main` med den driftsatta taggen: att publicera data och att släppa kod är två skilda saker (designbeslut 2). Datan valideras på `main`s spets av `validate:data` och `check:derived-data`, och det som rsyncas är det CI godkände. Två filer ligger i bundeln och nås inte av en datapublicering — `data/derived/riksdag.json`, som `elections.tsx` importerar statiskt, och `public/img/sveriges_riksdag.svg`, som `build-derived-data.js` genererar; det står i `CLAUDE.md` och `deploy/README.md` (designbeslut 9).
+
+**Rsync och omstart.** `rsync -az --delete -e "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes" data/ "$USER@$HOST:$TARGET/data/"` — samma flaggor som releasen, men källa och mål är `data/`-katalogen, så `--delete` bara städar där. Därefter ett enda ssh-anrop, med `HOST`, `USER`, `TARGET` och `DATA_COMMIT` i stegets miljö, som skriver committen till `$TARGET/data-commit` via en temporär fil (`printf '%s\n' '<sha>' > '<target>/data-commit.tmp' && chmod 0644 '<target>/data-commit.tmp' && mv -f '<target>/data-commit.tmp' '<target>/data-commit'`, så att tjänstekontot kan läsa filen och den aldrig är halvskriven), kör `sudo systemctl restart partidata.service` och pollar `http://127.0.0.1:3000/api/health/` med samma `curl --retry` som releasen; `&&` mellan delarna gör att ett fel avbryter och ger stegets fel. Sist en publik kontroll som förutom att sidan svarar också kräver `.status == "ok" and .data.commit == $sha` i hälsosvaret (`jq -e`), vilket är beviset för att både filen och omstarten landade — inte att varje byte är rätt, men `validate:data` har kontrollerat filerna och rsync deras checksummor.
+
+**Felhantering.** Rsync skriver varje fil till en temporär fil och byter namn, så en enskild fil är aldrig halv, men trädet är blandat medan rsyncen pågår, och en avbruten rsync lämnar det blandat tills nästa körning; releasen har exakt samma fönster i dag, och partisidorna läser per anrop medan cacherna håller det gamla tills omstarten. Ett fel i något steg gör körningen röd utan att något rullas tillbaka: nästa push till `main` som rör `data/`, eller en `workflow_dispatch`, rsyncar hela trädet på nytt och är återställningen så länge servern svarar på `/api/health` (också med 500), och en release återställer allt oavsett. Skrivs `data-commit` men omstarten faller, rapporterar den gamla processen den nya committen tills nästa lyckade omstart — det syns som en röd körning med fallerat omstartssteg, och det är därför den publika kontrollen inte ensam är beviset.
+
+**Datans proveniens.** `PARTIDATA_VERSION` bakas in vid bygget ur `package.json` och är kodens version; den ska fortsätta betyda det i sidfoten, i `X-Partidata-Version` och i `/api/health`. Datan får en egen identitet: filen `data-commit` i arbetskatalogen, en rad med den 40 tecken långa commit-hashen, skriven av *båda* workflowen efter sin rsync (releasens `--delete` av `$TARGET/` tar bort filen, så releasen skriver den med taggens commit). En liten modul `src/server/data-commit.ts` läser filen per anrop — den är en rad och läses bara av `/api/health` och `/data/`-sidans `getServerSideProps` — och ger `undefined` om den saknas, som lokalt och i `npm run test:http`. Hälsosvaret blir `{ status, version, data: { commit } }` när filen finns och oförändrat annars. Eftersom filen läses per anrop kan `http-smoke.js` täcka båda lägena mot samma process: först utan fil (dagens `deepEqual` mot `{ status: 'ok', version }`), sedan med en fil skriven i `.release/` mitt under körningen, och sist tas filen bort. `/data/`-sidan länkar datan till `tree/<commit>/data/` när committen är känd och till taggen annars, och versioneringsavsnittet säger det nya: adresser och fält är stabila, datan publiceras från `main` när den mergas, kodversionen står i `X-Partidata-Version`, och `/api/health` anger datans commit.
+
+**Ordning vid införandet.** Allt går i en PR. När den mergas rör den `src/`, så det nya workflowet triggas inte (ingen `data/**`-ändring). Första releasen efter mergen skeppar hälsokontrollen och skriver `data-commit`; en dataändring dessförinnan publiceras men saknar `data.commit` tills dess. Det ska stå i PR-bodyn.
+
+## Steg
+
+### Fas 1: Servern känner datans commit
+1. Skapa `src/server/data-commit.ts` med `readDataCommit(root = process.cwd()): Promise<string | undefined>`.
+   - Läser `path.join(root, 'data-commit')` som utf8, trimmar, returnerar strängen om den matchar `/^[0-9a-f]{40}$/` och annars `undefined`; `ENOENT` ger `undefined`, andra fel kastas.
+   - Ingen cachning: filen är en rad och läses bara av hälsokontrollen och `/data/`-sidan.
+   - Filer att skapa: `src/server/data-commit.ts`
+2. Låt `/api/health` ange committen.
+   - I `src/pages/api/health.ts`: läs `readDataCommit()` vid sidan av `assertHealthy()` och svara `{ status: 'ok', version, ...(commit ? { data: { commit } } : {}) }`; felgrenen får samma tillägg så att ett trasigt register fortfarande talar om vilken data det gäller. Läs committen före `assertHealthy()` så att den finns i båda grenarna; kastar läsningen (annat fel än `ENOENT`) hamnar det i felgrenen som i dag.
+   - Filer att ändra: `src/pages/api/health.ts`
+3. Testa läsaren.
+   - `scripts/data-commit.test.js` med `node:test`, som `scripts/data-fields.test.js` importerar `.ts` ur `src/` direkt: en temporär katalog utan fil ger `undefined`, med en giltig hash ger hashen (även med avslutande radbrytning), med skräp ger `undefined`.
+   - Filer att skapa: `scripts/data-commit.test.js`
+
+### Fas 2: `/data/`-sidan säger det som blir sant
+1. Ge sidan committen.
+   - Nytt props-typ `DataPageProps = DataCatalog & { dataCommit?: string }` i `src/pages/data/index.tsx`; `NextPage<DataPageProps>` och `GetServerSideProps<DataPageProps>`, som returnerar `{ ...catalog, ...(dataCommit ? { dataCommit } : {}) }` (fältet utelämnas när det är `undefined`, som sidans övriga props). Komponenten destrukturerar `dataCommit` och räknar `dataRef = dataCommit ?? ref`.
+   - De tre datalänkarna (versioneringsavsnittet, `tree/${ref}/data/parti` och `tree/${ref}/data` i licensavsnittet) går till `dataRef`; README-länken (`blob/${ref}/README.md#…`) står kvar på `ref`, för README hör till koden.
+   - Filer att ändra: `src/pages/data/index.tsx`
+2. Skriv om versioneringsavsnittet och `Cache-Control`-raden.
+   - "Datan ändras bara när en ny version driftsätts" ersätts av att datan publiceras från `main` när en ändring mergas, att `X-Partidata-Version`, sidfoten och `/api/health` anger kodversionen, och att `/api/health` dessutom anger vilken commit datan kommer från (`data.commit`) — samma commit som länken pekar på. `Cache-Control`-raden säger att ett svar är som mest en timme äldre än filen på servern. Punkten om borttagna eller omdöpta fält står kvar; "en version som noteras här" gäller fortfarande, eftersom sådana ändringar rör koden.
+   - Texten är svensk sajtkopia; fältnamnet `data.commit` och sökvägen `data-commit` är de enda engelska orden.
+   - Filer att ändra: `src/pages/data/index.tsx`
+3. Täck båda lägena i `scripts/http-smoke.js`.
+   - Efter dagens hälsokontroll (rad 608–611): skriv en känd hash till `.release/data-commit`, hämta `/api/health` och kräv `{ status: 'ok', version, data: { commit } }`, hämta `/data/` och kräv att sidan länkar `tree/<hash>/data/`; ta bort filen i `finally` så att ett fallerat test inte lämnar den kvar. `.release/` byggs om av varje `build:release`, så filen är aldrig en del av artefakten.
+   - Filer att ändra: `scripts/http-smoke.js`
+
+### Fas 3: Releasen bygger bara taggar och skriver `data-commit`
+1. I `.github/workflows/deploy.yaml`: gör versionskontrollen ovillkorlig genom att först kräva `github.ref_type == 'tag'` (ett steg som annars faller med beskedet att releasen körs från en tagg, som `deploy/README.md` säger) och sedan behålla jämförelsen tagg mot `package.json` utan `if:`. Uppdatera huvudkommentaren ("workflow_dispatch re-deploys the selected ref" blir "the selected tag") och README:s rad "The version check is skipped then" i fas 5.
+   - Filer att ändra: `.github/workflows/deploy.yaml`
+2. Steget "Restart and local health check": lägg `TARGET: ${{ secrets.DEPLOY_TARGET }}` i stegets miljö och lägg skrivningen via temporär fil (Angreppssätt) före `sudo systemctl restart …` i samma ssh-kommando, med `github.sha` (taggens commit) och `$TARGET` insatta lokalt och enkelcitat runt sökvägen i det fjärrkörda kommandot.
+   - Filer att ändra: `.github/workflows/deploy.yaml`
+3. Låt "Public smoke test" kräva committen: `shell: bash` och `curl … /api/health/ | jq -e --arg sha "$GITHUB_SHA" '.status == "ok" and .data.commit == $sha'` i stället för bara `--fail`. `jq` finns på `ubuntu-24.04`-runnern.
+   - Filer att ändra: `.github/workflows/deploy.yaml`
+
+### Fas 4: Workflowet `publish-data.yaml`
+1. Skapa `.github/workflows/publish-data.yaml` med namnet "Publish data" och en huvudkommentar av samma slag som i `deploy.yaml`: vad som triggar, att det alltid är `main`s spets som publiceras, att inget byggs, att koden på servern måste vara `main`s.
+   - `on: push: branches: [main], paths: ['data/**']` och `workflow_dispatch`.
+   - `concurrency: { group: production-deploy, cancel-in-progress: false }`, `permissions: { contents: read }`, ett jobb `publish` med `runs-on: ubuntu-24.04`, `timeout-minutes: 10`, `environment: production`.
+   - Filer att skapa: `.github/workflows/publish-data.yaml`
+2. Steg i jobbet, i ordning:
+   - `actions/checkout@v5` med `ref: main`; ett steg som skriver `DATA_COMMIT=$(git rev-parse HEAD)` till `$GITHUB_ENV`.
+   - `actions/setup-node@v5` (node 24, npm-cache), `npm ci` — validatorerna kräver `scripts/`-modulerna men inga andra beroenden än de i `package.json`.
+   - `npm run validate:data` och `npm run check:derived-data`.
+   - "Install deploy key" — samma steg som i `deploy.yaml`.
+   - "Rsync data to server": rsync-raden i Angreppssätt, med `data/` som källa och `$TARGET/data/` som mål.
+   - "Record the commit, restart and local health check": ssh-kommandot i Angreppssätt, med `HOST`, `USER`, `TARGET` och `DATA_COMMIT` i miljön.
+   - "Public smoke test": `shell: bash`; samma två curl-anrop som releasen, där hälsosvaret körs genom `jq -e` med kravet `.status == "ok" and .data.commit == $DATA_COMMIT`.
+   - Filer att skapa: `.github/workflows/publish-data.yaml`
+
+### Fas 5: Dokumentationen
+1. `deploy/README.md`: inledningen får en mening om att `publish-data.yaml` rsyncar `data/` och startar om tjänsten när en push till `main` rör `data/**`; avsnittet "Release" får en not om att en release också tar med datan, och raden om att versionskontrollen hoppas över vid manuell körning ersätts av att workflowet bara bygger taggar; ett nytt kort avsnitt "Data" beskriver `data-commit`, vad `/api/health` anger, att jobbet alltid publicerar `main`s spets, att en väntande körning i `production-deploy` ersätts av nästa, att `workflow_dispatch` kör om synkningen, att en server som inte svarar alls återställs med en manuell release på gällande tagg, och att `data/derived/riksdag.json` och `public/img/sveriges_riksdag.svg` ligger i bundeln och därför bara når partisidorna med en release. "Manual deploy" får `data-commit`-skrivningen tillagd i det befintliga receptet (dess `rsync --delete` av roten tar bort filen) och en variant för enbart data: `npm ci`, de två validatorerna, rsync av `data/`, skrivning av committen och omstart.
+   - Filer att ändra: `deploy/README.md`
+2. `CLAUDE.md`, punkten under "Workflow": kod driftsätts på `v*`-taggar; en merge till `main` som rör `data/` publicerar datan av sig själv via `publish-data.yaml` så länge `main`s kod är den driftsatta (och `data/derived/riksdag.json` är orörd, eftersom den ligger i bundeln); en kodändring behöver fortfarande en tagg, och tar datan med sig.
+   - Filer att ändra: `CLAUDE.md`
+3. Kontrollera att `README.md` inte påstår något som blir fel (rad 28 säger bara "samma sökväg, samma byte" och hänvisar till `/data/` för versioneringen — ingen ändring väntas).
+
+## Filöversikt
+
+| Fil | Åtgärd | Syfte |
+|-----|--------|-------|
+| `.github/workflows/publish-data.yaml` | Skapa | Publicerar `main`s `data/` vid push till `main` som rör `data/**`, och vid `workflow_dispatch` |
+| `.github/workflows/deploy.yaml` | Ändra | Bygger bara taggar; skriver `data-commit` före omstarten; kräver committen i det publika hälsosvaret |
+| `src/server/data-commit.ts` | Skapa | Läser `data-commit` ur arbetskatalogen; `undefined` när filen saknas |
+| `src/pages/api/health.ts` | Ändra | Anger `data.commit` när filen finns |
+| `src/pages/data/index.tsx` | Ändra | Versioneringsavsnittet och `Cache-Control`-raden säger det nya; datalänkarna går till datans commit |
+| `scripts/data-commit.test.js` | Skapa | `node:test` för läsaren: saknad fil, giltig hash, skräp |
+| `scripts/http-smoke.js` | Ändra | Hälsosvaret och `/data/`-sidan med och utan `data-commit` |
+| `deploy/README.md` | Ändra | Beskriver dataworkflowet, `data-commit`, taggkravet och manuell datapublicering |
+| `CLAUDE.md` | Ändra | "Merging is not releasing" blir "dataändringar går live vid merge, kod behöver en tagg" |
+| `README.md` | Kontrollera | Ingen ändring väntas |
+
+## Berörda kodområden
+
+- `.github/workflows/`
+- `src/server/`
+- `src/pages/api/`
+- `src/pages/data/`
+- `scripts/`
+- `deploy/`
+- repots rot (`CLAUDE.md`)
+
+## Designbeslut
+
+> Icke-triviala val gjorda under planeringen. Varje beslut är antingen avgjort här, med proveniens, eller uttryckligen markerat som att det kräver användaren eftersom ett felval skulle ge skada som inte går att backa. Feedback välkommen; annars implementeras enligt dessa, och beslut som är agentens bedömning listas i PR:en för granskning.
+
+### 1. Omstart efter rsync i stället för att servern släpper sina cacher
+**Alternativ:** A: `sudo systemctl restart partidata.service` efter rsyncen, som releasen. B: en väg för servern att släppa modul-promisarna i `party-data.ts` (t.ex. en signal eller en skyddad endpoint).
+**Beslut:** A
+**Proveniens:** agentens bedömning — issuet ställer upp båda och avgör inte.
+**Vid fel val:** begränsat — omstarten kostar den sekund av 502 från nginx som varje release redan kostar; B kan läggas till senare utan att workflowet ändras mer än i ett steg.
+**Motivering:** A kräver ingen kodändring, återanvänder den enda sudoers-regeln deploy-kontot har och ger ett hälsosvar som bevisar att den nya processen läser de nya filerna. B skulle behöva en autentiserad väg in i processen och kan ändå inte lova att en pågående begäran inte läser blandad data. B blir rätt val den dag dataändringar är så täta att omstarterna märks.
+
+### 2. Ingen vakt: workflowet synkar `data/` från `main` oavsett vad koden gör
+**Alternativ:** A: alltid synka `data/` från `main`. B: synka bara när taggen för den version `/api/health` anger och `HEAD` är lika utanför det som inte körs på servern.
+**Beslut:** A
+**Proveniens:** användarbeslut (konversation 2026-09-07) — att publicera data och att släppa kod är två skilda saker, och datapubliceringen får aldrig bero på om `main` har oskeppade kodändringar.
+**Vid fel val:** begränsat — B är ett steg att lägga till om behovet visar sig.
+**Motivering:** Datan valideras av `validate:data` och `check:derived-data` på `main`s spets, och det som når servern är det CI godkände. Fälten är additiva och adresserna stabila, så en dataändring är läsbar för den driftsatta koden. Beslut 3 (vad vakten gör när den faller) faller bort med vakten.
+
+### 3. Utgår
+Beslutet gällde vad vakten skulle göra när den föll. Det finns ingen vakt (beslut 2).
+
+### 4. Datans commit anges i `/api/health`, inte i sidfoten eller i `X-Partidata-Version`
+**Alternativ:** A: lämna allt som det är; bara texten på `/data/` ändras. B: `data-commit`-filen och `data.commit` i `/api/health`, kodversionen orörd överallt. C: dessutom ett nytt svarshuvud på `/data/` och en rad i sidfoten.
+**Beslut:** B
+**Proveniens:** agentens bedömning — issuet ber om just det här avgörandet.
+**Vid fel val:** begränsat — C är ett tillägg ovanpå B; A är B minus en fil och ett fält.
+**Motivering:** Utan committen finns inget sätt att kontrollera att en datapublicering landade, och `/data/`-sidans länk "samma filer på GitHub" skulle behöva peka på `main` i rörelse. Med B blir workflowets publika kontroll ett bevis (`.data.commit == $DATA_COMMIT`) och länken pekar på exakt de bytes som serveras. Sidfoten och `X-Partidata-Version` betyder fortfarande "kodens version", och hälsosvaret är där en driftsättning verifieras. C blir rätt om konsumenter av `/data/` visar sig behöva committen per svar; då är det ett huvud till i `[...path].ts`.
+
+### 5. `data-commit` är en fil i arbetskatalogen, skriven av båda workflowen
+**Alternativ:** A: en textfil `$TARGET/data-commit` som varje workflow skriver efter sin rsync. B: `build-release.js` skriver den in i `.release/` ur `git rev-parse HEAD`, så att releasens rsync bär den; dataworkflowet skriver den via ssh. C: en miljövariabel i systemd-enheten.
+**Beslut:** A
+**Proveniens:** agentens bedömning.
+**Vid fel val:** begränsat — filen läses per anrop, så var den skrivs kan ändras utan kodändring i servern.
+**Motivering:** Med A skriver båda workflowen filen på samma sätt, i samma ssh-anrop som omstarten, och `.release/` är identisk med ett lokalt bygge. B binder artefakten till git: ett lokalt bygge ur ett smutsigt träd eller utan `.git` skulle bära en commit som inte är dess data, och `http-smoke.js` skulle behöva veta vilken. C kräver `daemon-reload` och en ändrad sudoers-regel. Filen läses per anrop och cachas inte, eftersom den bara läses av hälsokontrollen och `/data/`-sidan.
+
+### 6. Trigger: push till `main` med sökvägsfilter, inte `workflow_run` efter Integrate
+**Alternativ:** A: `on: push` med `paths: ['data/**']`, och validatorerna körs om i jobbet. B: `workflow_run` efter "Integrate" så att bara grönt CI publicerar.
+**Beslut:** A
+**Proveniens:** användarbeslut (issue #100, "Trigger on pushes to `main` that touch `data/**`") — valet av vad som körs om i jobbet är issuets också.
+**Vid fel val:** begränsat — B är en ändring av `on:` och ett steg som läser ut committen ur händelsen.
+**Motivering:** B har inget sökvägsfilter och skulle kräva att jobbet själv räknar ut om pushen rörde `data/`; A får det gratis och kör de två datakontrollerna igen på samma commit, vilket är det issuet ber om.
+
+### 7. Rsync-omfång: `data/` till `$TARGET/data/` med `--delete`
+**Alternativ:** A: som ovan. B: rsync utan `--delete`. C: hela `.release/`-mönstret utan bygge.
+**Beslut:** A
+**Proveniens:** användarbeslut (issue #100, "`--delete` scoped to that directory").
+**Vid fel val:** begränsat — filen som saknas i `data/` på `main` ska inte heller finnas på servern; det är hela poängen.
+**Motivering:** Servern svarar ur registret (`getPartyIndex`) innan den rör disken, så en kvarlämnad katalog ger inte fel svar — men serverns `data/` ska vara `main`s `data/` byte för byte, som `/data/`-sidan lovar, och utan `--delete` växer skillnaden med varje borttagen fil och varje parti som byter `filnamn`.
+
+### 8. Jobbet publicerar alltid `main`s spets, oavsett trigger
+**Alternativ:** A: `actions/checkout` med `ref: main` och `DATA_COMMIT` ur `git rev-parse HEAD`. B: checka ut händelsens ref (`github.sha`) och kräva att den är `main`s spets. C: checka ut händelsens ref utan krav.
+**Beslut:** A
+**Proveniens:** agentens bedömning.
+**Vid fel val:** begränsat — B är `ref:` bort och ett kontrollsteg till; ingen data skadas av A som inte också är `main`.
+**Motivering:** Med A kan ingen körning publicera något annat än `main`: en `workflow_dispatch` från en gren, en omkörning av en gammal körning (som med `--delete` skulle rulla tillbaka datan) och en datapush som väntat bakom en release medan andra commits landat ger alla samma resultat — det `main` är när jobbet kör. B skulle fälla den väntande datapushen så snart en dokumentationscommit hunnit före, och datan bleve liggande tills nästa datapush. C är rollback-risken. En avsiktlig återställning är en revert på `main`.
+
+### 9. `data/derived/riksdag.json` är dokumenterad som bundlad, inte bevakad
+**Alternativ:** A: vakten diffar också `data/derived/riksdag.json` mot den driftsatta taggen och kräver release när den ändrats. B: bygg om partisidans riksdagsvy så att filen läses vid körning (via `party-data.ts` och sidans props). C: dokumentera att filen ligger i bundeln och att en ändring av den når partisidorna först med en release.
+**Beslut:** C, med B som möjlig uppföljning
+**Proveniens:** användarbeslut (konversation 2026-09-07) — samma beslut som 2: ingen vakt.
+**Vid fel val:** begränsat — mellan en riksdagsdataändring på `main` och nästa release visar partisidorna gammal kammare medan `/data/derived/riksdag.json` visar ny. Filen ändras bara när ett riksdagsval importeras eller korrigeras.
+**Motivering:** `elections.tsx` importerar filen statiskt och `public/img/sveriges_riksdag.svg` genereras av `build-derived-data.js`, så båda ligger i bundeln och nås inte av rsync och omstart. Det är ett faktum om systemet, och `CLAUDE.md` och `deploy/README.md` säger det. B tar bort skillnaden och hör till ett eget issue.
+
+### 10. Releasen bygger bara taggar
+**Alternativ:** A: `deploy.yaml` faller när `github.ref_type` inte är `tag`, och versionskontrollen görs ovillkorlig. B: lämna `workflow_dispatch` fri att bygga vilken ref som helst, som i dag.
+**Beslut:** A
+**Proveniens:** befintlig konvention (`deploy/README.md`: "run the workflow manually from an earlier tag") som workflowet inte upprätthåller; att göra den bindande är agentens bedömning.
+**Vid fel val:** begränsat — ett `if:` på ett steg; den som behöver bygga en gren taggar den.
+**Motivering:** Har en gren byggts manuellt anger servern en version vars tagg inte är dess kod, och `X-Partidata-Version`, sidfoten och `/api/health` pekar då ut något som inte går att slå upp. Med A är `.version` alltid en tagg vars träd är serverns, och README:s beskrivning blir sann. B blir rätt om det finns ett behov av att provköra otaggad kod i produktion — det bör då vara en separat miljö, inte ett undantag.
+
+## Verifieringschecklista
+
+- [ ] `npm run precommit` grönt; `node --test scripts/data-commit.test.js` täcker saknad fil, giltig hash (med och utan radbrytning) och skräp
+- [ ] `npm run test:http`: hälsosvaret är exakt `{ status: 'ok', version }` utan `data-commit`, anger `data.commit` med filen skriven mitt under körningen, `/data/`-sidan länkar `tree/<hash>/data/` då och taggen annars, och filen är borta efteråt
+- [ ] `/data/`-sidans versioneringsavsnitt och `Cache-Control`-raden stämmer med det nya flödet; README-länken går fortfarande till taggen; sidfoten och `X-Partidata-Version` är oförändrade
+- [ ] Efter merge: `deploy.yaml` körs vid nästa `v*`-tagg, skriver `data-commit` och den publika kontrollen kräver committen; en `workflow_dispatch` av `deploy.yaml` från en gren faller i första steget
+- [ ] Efter den releasen: en ändring i ett partis `index.json` på `main` triggar "Publish data"; körningen är grön, `https://www.partidata.se/api/health/` anger `main`s commit, och `/data/parti/<filnamn>/index.json` serveras med ny etagg
+- [ ] En push till `main` som *inte* rör `data/**` triggar inte workflowet; `workflow_dispatch` från en gren publicerar ändå `main`s spets; en omkörning av en äldre körning publicerar dagens `main`
+- [ ] En dataändring på `main` publiceras också när `main` har oskeppad kod i `src/`; en ändring i `data/derived/riksdag.json` når `/data/derived/riksdag.json` men inte partisidornas riksdagsvy förrän nästa release
+- [ ] En release som taggas medan "Publish data" kör startar först när datajobbet är klart; en tredje händelse under tiden ersätter den väntande, och den avbrutna körningen körs om manuellt
+- [ ] `deploy/README.md` och `CLAUDE.md` beskriver flödet; "Merging is not releasing" är ersatt; det manuella receptet skriver `data-commit`; raden om överhoppad versionskontroll är borta

--- a/agent-docs/issue/100-publish-data-without-release/progress.md
+++ b/agent-docs/issue/100-publish-data-without-release/progress.md
@@ -1,0 +1,60 @@
+# Framsteg: Issue #100 — Publish data changes without a release
+
+**Påbörjad:** 2026-09-07
+**Senast uppdaterad:** 2026-09-07
+**Status:** Slutförd (kod), produktionsverifiering återstår
+
+## Genomförda steg
+
+- [x] Fas 1, steg 1: `src/server/data-commit.ts`
+- [x] Fas 1, steg 2: `/api/health` anger `data.commit` i båda grenarna
+- [x] Fas 1, steg 3: `scripts/data-commit.test.js` — 4 tester
+- [x] Fas 2, steg 1: `/data/`-sidan får `dataCommit` och länkar datan dit
+- [x] Fas 2, steg 2: Versioneringsavsnittet och `Cache-Control`-raden
+- [x] Fas 2, steg 3: `scripts/http-smoke.js` täcker med och utan `data-commit`
+- [x] Fas 3, steg 1: `deploy.yaml` bygger bara taggar
+- [x] Fas 3, steg 2: Releasen skriver `data-commit` före omstarten
+- [x] Fas 3, steg 3: Publika röktestet kräver committen
+- [x] Fas 4, steg 1: `.github/workflows/publish-data.yaml`
+- [x] Fas 4, steg 2: Jobbets steg
+- [x] Fas 5, steg 1: `deploy/README.md`
+- [x] Fas 5, steg 2: `CLAUDE.md`
+- [x] Fas 5, steg 3: `README.md` kontrollerad — ingen ändring behövdes
+
+## Verifierat
+
+- `npm run precommit` grönt: lint, typecheck, `check:derived-data`, `validate:data`,
+  238 tester, `build:release` och `test:http`.
+- `node --test scripts/data-commit.test.js`: saknad fil, giltig hash med och utan
+  radbrytning, skräpinnehåll och en katalog i filens ställe.
+- `npm run test:http`: hälsosvaret är exakt `{ status: 'ok', version }` utan filen,
+  anger `data.commit` med en hash skriven i `.release/` mitt under körningen, och är
+  sig likt igen när filen tagits bort. `/data/`-sidan länkar `tree/v<version>/data/`
+  utan filen och `tree/<hash>/data/` med den. `.release/data-commit` finns inte kvar
+  efteråt.
+- Båda workflowfilerna parsas som YAML.
+
+## Beslut under implementationen
+
+- **Ingen vakt** (planens designbeslut 2 och 9). Användarbeslut i konversationen
+  2026-09-07: publiceringen av data får aldrig bero på om `main` har oskeppade
+  kodändringar — att publicera data och att släppa kod är två skilda saker.
+  `publish-data.yaml` jämför alltså inte `main` med den driftsatta taggen, och
+  `data/derived/riksdag.json` bevakas inte. I stället säger `CLAUDE.md` och
+  `deploy/README.md` att den filen och `public/img/sveriges_riksdag.svg` ligger i
+  bundeln och därför bara når partisidorna med en release. Planens beslut 2, 3 och 9
+  är uppdaterade.
+
+## Återstår
+
+Punkterna i planens verifieringschecklista som kräver produktion, efter merge:
+
+- Nästa `v*`-tagg: `deploy.yaml` skriver `data-commit` och den publika kontrollen
+  kräver committen; en `workflow_dispatch` från en gren faller i "Require a tag".
+- En ändring i ett partis `index.json` på `main` triggar "Publish data";
+  `https://www.partidata.se/api/health/` anger `main`s commit och
+  `/data/parti/<filnamn>/index.json` serveras med ny etagg.
+- En push till `main` utan `data/**` triggar inte workflowet; `workflow_dispatch`
+  från en gren publicerar ändå `main`s spets.
+- En release som taggas medan "Publish data" kör startar först när datajobbet är
+  klart.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,6 +4,10 @@ partidata.se runs as a standalone Next.js process behind nginx. GitHub Actions
 builds every pushed `v*` tag, rsyncs `.release/` to the configured production
 target and restarts `partidata.service`.
 
+Data has a shorter path. `publish-data.yaml` rsyncs `data/` and restarts the
+service whenever a push to `main` touches `data/**`, so a data change goes live
+at merge, without a release.
+
 The service has no database. Versioned JSON and party symbols under `data/` are
 included in the artifact and read by the Node process at request time.
 
@@ -22,9 +26,40 @@ git tag "v$(node -p "require('./package.json').version")"
 git push origin "v$(node -p "require('./package.json').version")"
 ```
 
-To return to older code, run the workflow manually from an earlier tag. The
-version check is skipped then, so the artifact reports the version that ref
-carries.
+A release also carries the data: `.release/` holds the `data/` tree of the
+tagged commit.
+
+To return to older code, run the workflow manually from an earlier tag. It
+builds tags only, so the version the artifact reports always names a tag whose
+tree is the deployed code.
+
+## Data
+
+Both workflows write the commit their data comes from to `<target>/data-commit`,
+a single line with the 40-character hash, and `/api/health` reports it as
+`data.commit` when the file is there. The `/data/` page links its files to that
+commit. The release writes the tag's commit; `publish-data.yaml` writes main's
+tip.
+
+- The job always publishes main's tip, whatever triggered it. A
+  `workflow_dispatch` from a branch, a re-run of an older run and a push that
+  waited behind a release all send the same thing: what `main` is when the job
+  runs. An intentional rollback is a revert on `main`.
+- `production-deploy` holds at most one waiting run, so a third event within
+  the same few minutes replaces the one already queued and cancels it. Re-run
+  it manually.
+- A failed run rolls nothing back. The next push to `main` that touches `data/`,
+  or a `workflow_dispatch`, rsyncs the whole tree again and is the repair, as
+  long as the server answers `/api/health` at all — a 500 still counts.
+- A server that does not answer is restored with a manual release run on the
+  current tag.
+
+Two files are built into the bundle rather than read from `data/` at request
+time: `data/derived/riksdag.json`, which `src/components/party-profile/elections.tsx`
+imports statically, and `public/img/sveriges_riksdag.svg`, which
+`scripts/build-derived-data.js` generates. A change to either reaches the party
+pages only with a release. `/data/derived/riksdag.json` itself is served from
+disk and does follow a data publish.
 
 ## One-time server setup
 
@@ -90,10 +125,24 @@ GitHub → repository settings → Environments → `production` → secrets:
 
 ## Manual deploy
 
+The whole artifact, from a tag checked out locally. The `--delete` removes
+`data-commit` along with the old build, so it is written back.
+
 ```bash
 npm ci
 npm run precommit
 rsync -az --delete .release/ <deploy-account>@<deploy-host>:<absolute-target>/
-ssh <deploy-account>@<deploy-host> 'sudo systemctl restart partidata.service'
+ssh <deploy-account>@<deploy-host> "printf '%s\n' '$(git rev-parse HEAD)' > '<absolute-target>/data-commit.tmp' && chmod 0644 '<absolute-target>/data-commit.tmp' && mv -f '<absolute-target>/data-commit.tmp' '<absolute-target>/data-commit' && sudo systemctl restart partidata.service"
+curl --fail https://www.partidata.se/api/health/
+```
+
+The data alone, from `main` — the same thing `publish-data.yaml` does.
+
+```bash
+npm ci
+npm run validate:data
+npm run check:derived-data
+rsync -az --delete data/ <deploy-account>@<deploy-host>:<absolute-target>/data/
+ssh <deploy-account>@<deploy-host> "printf '%s\n' '$(git rev-parse HEAD)' > '<absolute-target>/data-commit.tmp' && chmod 0644 '<absolute-target>/data-commit.tmp' && mv -f '<absolute-target>/data-commit.tmp' '<absolute-target>/data-commit' && sudo systemctl restart partidata.service"
 curl --fail https://www.partidata.se/api/health/
 ```

--- a/scripts/data-commit.test.js
+++ b/scripts/data-commit.test.js
@@ -1,0 +1,38 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { readDataCommit } = require('../src/server/data-commit.ts');
+
+const HASH = '0123456789abcdef0123456789abcdef01234567';
+
+/** A working directory with the given `data-commit`, or none when omitted. */
+function makeRoot (contents) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'partidata-commit-'));
+  if (contents !== undefined) fs.writeFileSync(path.join(root, 'data-commit'), contents);
+  return root;
+}
+
+test('a working directory without the file has no commit', async () => {
+  assert.equal(await readDataCommit(makeRoot()), undefined);
+});
+
+test('a commit hash is read back, with or without a trailing newline', async () => {
+  assert.equal(await readDataCommit(makeRoot(`${HASH}\n`)), HASH);
+  assert.equal(await readDataCommit(makeRoot(HASH)), HASH);
+  assert.equal(await readDataCommit(makeRoot(`  ${HASH}  \n`)), HASH);
+});
+
+test('anything that is not a commit hash is no commit', async () => {
+  for (const junk of ['', 'main', HASH.slice(0, 39), `${HASH}0`, HASH.toUpperCase(), `${HASH} ${HASH}`]) {
+    assert.equal(await readDataCommit(makeRoot(junk)), undefined, `"${junk}" är ingen commit`);
+  }
+});
+
+test('a directory in place of the file is an error, not a missing commit', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'partidata-commit-'));
+  fs.mkdirSync(path.join(root, 'data-commit'));
+  await assert.rejects(readDataCommit(root));
+});

--- a/scripts/http-smoke.js
+++ b/scripts/http-smoke.js
@@ -609,6 +609,42 @@ async function main () {
     assert.equal(health.status, 200);
     assert.equal(health.headers.get('cache-control'), 'no-store');
     assert.deepEqual(await health.json(), { status: 'ok', version }, 'hälsokontrollen anger versionen som byggdes');
+    assert.match(
+      dataBody,
+      new RegExp(`href="https://github\\.com/swedev/partidata/tree/v${version.replace(/\./g, '\\.')}/data/"`),
+      'utan data-commit pekar datalänken på taggen'
+    );
+
+    // The data workflows write `data-commit` next to the artifact after their
+    // rsync, and the module reads it per request, so both states are reachable
+    // against the same running process.
+    const commitFile = path.join(releaseRoot, 'data-commit');
+    const commit = 'a'.repeat(7) + 'b'.repeat(33);
+    try {
+      fs.writeFileSync(commitFile, `${commit}\n`);
+      const withCommit = await fetch(`${baseUrl}/api/health`);
+      assert.equal(withCommit.status, 200);
+      assert.deepEqual(
+        await withCommit.json(),
+        { status: 'ok', version, data: { commit } },
+        'hälsokontrollen anger datans commit när filen finns'
+      );
+      const dataWithCommit = await fetch(`${baseUrl}/data/`);
+      assert.equal(dataWithCommit.status, 200);
+      assert.match(
+        await dataWithCommit.text(),
+        new RegExp(`href="https://github\\.com/swedev/partidata/tree/${commit}/data/"`),
+        'datalänken pekar på den commit som serveras'
+      );
+    } finally {
+      fs.rmSync(commitFile, { force: true });
+    }
+    const withoutCommit = await fetch(`${baseUrl}/api/health`);
+    assert.deepEqual(
+      await withoutCommit.json(),
+      { status: 'ok', version },
+      'hälsokontrollen är sig lik när filen är borta igen'
+    );
 
     assert.match(homeBody, new RegExp(`Version <!-- -->${version.replace(/\./g, '\\.')}`), 'sidfoten visar versionen');
     console.log('HTTP-smoke passerade');

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+import { readDataCommit } from 'src/server/data-commit';
 import { partyData } from 'src/server/party-data';
 
 export default async function handler (request: NextApiRequest, response: NextApiResponse) {
@@ -10,15 +11,20 @@ export default async function handler (request: NextApiRequest, response: NextAp
     return;
   }
 
+  // The commit is read before the registry is asserted, so that a broken
+  // registry still says which data it was reading.
+  let data: { data?: { commit: string } } = {};
   try {
+    const commit = await readDataCommit();
+    if (commit) data = { data: { commit } };
     await partyData.assertHealthy();
     response.status(200);
     if (request.method === 'HEAD') response.end();
-    else response.json({ status: 'ok', version: process.env.PARTIDATA_VERSION });
+    else response.json({ status: 'ok', version: process.env.PARTIDATA_VERSION, ...data });
   } catch (error) {
     console.error('Hälsokontrollen misslyckades', error);
     response.status(500);
     if (request.method === 'HEAD') response.end();
-    else response.json({ status: 'error', version: process.env.PARTIDATA_VERSION });
+    else response.json({ status: 'error', version: process.env.PARTIDATA_VERSION, ...data });
   }
 }

--- a/src/pages/data/index.tsx
+++ b/src/pages/data/index.tsx
@@ -5,8 +5,12 @@ import { Fragment } from 'react';
 import { FIELD_DOCS } from 'src/components/data/fields';
 import Footer from 'src/components/Footer';
 import Header from 'src/components/Header';
+import { readDataCommit } from 'src/server/data-commit';
 import { partyData } from 'src/server/party-data';
 import type { DataCatalog } from 'src/server/party-data';
+
+/** The catalog the page renders, plus the commit the served data comes from. */
+type DataPageProps = DataCatalog & { dataCommit?: string };
 
 const version = process.env.PARTIDATA_VERSION;
 const ref = version ? `v${version}` : 'main';
@@ -32,9 +36,10 @@ function AddressRow ({ adress, innehall }: { adress: string; innehall: string })
   );
 }
 
-const DataPage: NextPage<DataCatalog> = ({ antalPartier, exempel, valar }) => {
+const DataPage: NextPage<DataPageProps> = ({ antalPartier, dataCommit, exempel, valar }) => {
   const exempelAdress = `/data/parti/${encodeURIComponent(exempel.filnamn)}/index.json`;
   const senasteForst = [...valar].reverse();
+  const dataRef = dataCommit ?? ref;
 
   return (
     <div className="page-shell">
@@ -167,7 +172,7 @@ const DataPage: NextPage<DataCatalog> = ({ antalPartier, exempel, valar }) => {
 
           <h3>Huvuden</h3>
           <ul>
-            <li><code>Cache-Control: public, max-age=3600</code> — datan ändras bara när en ny version driftsätts, så ett svar är som mest en timme gammalt.</li>
+            <li><code>Cache-Control: public, max-age=3600</code> — ett svar är som mest en timme äldre än filen på servern.</li>
             <li><code>ETag</code> — <code>W/</code> följt av filens SHA-256. Etaggen är svag därför att samma fil levereras både komprimerad och okomprimerad; det är samma representation, och det är precis vad en svag etagg säger. Skicka tillbaka den oförändrad i <code>If-None-Match</code> och få 304 utan kropp när filen är densamma.</li>
             <li><code>Vary: Accept-Encoding</code> — kroppen varierar med komprimeringen.</li>
             <li><code>X-Partidata-Version</code> — den version som svarade, samma nummer som i sidfoten och i <code>/api/health</code>.</li>
@@ -190,9 +195,13 @@ const DataPage: NextPage<DataCatalog> = ({ antalPartier, exempel, valar }) => {
           <ul>
             <li>Adresser och fältnamn är stabila. Nya fält kan tillkomma utan förvarning — en läsare ska ignorera fält den inte känner igen.</li>
             <li>
-              Datan ändras bara när en ny version driftsätts. Versionen står i <code>X-Partidata-Version</code>, i
-              sidfoten och i <code>/api/health</code>, och samma filer finns på{' '}
-              <a href={`${repo}/tree/${ref}/data/`}>GitHub under taggen</a>.
+              Datan publiceras från <code>main</code>: en ändring under <code>data/</code> går live när den mergas.
+              Samma filer finns på{' '}
+              <a href={`${repo}/tree/${dataRef}/data/`}>GitHub under den commit som serveras</a>.
+            </li>
+            <li>
+              Kodens version står i <code>X-Partidata-Version</code>, i sidfoten och i <code>/api/health</code>. Där
+              anges också datans commit som <code>data.commit</code> — samma commit som länken ovan pekar på.
             </li>
             <li>
               Ett fält eller en adress som tas bort eller döps om görs i en version som noteras här, och en flyttad
@@ -247,13 +256,13 @@ const DataPage: NextPage<DataCatalog> = ({ antalPartier, exempel, valar }) => {
             <li>
               <strong>Profildata</strong> — <code>parti/&lt;filnamn&gt;/profil.json</code> bär utdrag ur Wikipedia
               under CC BY-SA 4.0 och nyhetsrubriker, och finns bara på{' '}
-              <a href={`${repo}/tree/${ref}/data/parti`}>GitHub</a>.
+              <a href={`${repo}/tree/${dataRef}/data/parti`}>GitHub</a>.
             </li>
             <li>
               <strong>Kopplingstabeller</strong> — <code>parti/kodbyten.json</code>,{' '}
               <code>valresultat/riksdag-partikopplingar.json</code> och{' '}
               <code>val/&lt;år&gt;/valresultat/scb-tabeller.json</code> är arbetsmaterial för importen och finns på{' '}
-              <a href={`${repo}/tree/${ref}/data`}>GitHub</a>.
+              <a href={`${repo}/tree/${dataRef}/data`}>GitHub</a>.
             </li>
           </ul>
         </section>
@@ -266,6 +275,7 @@ const DataPage: NextPage<DataCatalog> = ({ antalPartier, exempel, valar }) => {
 
 export default DataPage;
 
-export const getServerSideProps: GetServerSideProps<DataCatalog> = async () => ({
-  props: await partyData.readDataCatalog(),
-});
+export const getServerSideProps: GetServerSideProps<DataPageProps> = async () => {
+  const [catalog, dataCommit] = await Promise.all([partyData.readDataCatalog(), readDataCommit()]);
+  return { props: { ...catalog, ...(dataCommit ? { dataCommit } : {}) } };
+};

--- a/src/server/data-commit.ts
+++ b/src/server/data-commit.ts
@@ -1,0 +1,25 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+/** The 40 hex characters a git commit hash is, and nothing else. */
+const COMMIT = /^[0-9a-f]{40}$/;
+
+/**
+ * The commit the served `data/` tree comes from. Both deployment workflows
+ * write `data-commit` next to the artifact after their rsync; a local run or a
+ * checkout without one has no such file, and the answer is `undefined`.
+ *
+ * The file is one line and is read by the health check and the documentation
+ * page only, so it is read per call rather than cached.
+ */
+export async function readDataCommit (root: string = process.cwd()): Promise<string | undefined> {
+  let contents: string;
+  try {
+    contents = await readFile(path.join(root, 'data-commit'), 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+  const commit = contents.trim();
+  return COMMIT.test(commit) ? commit : undefined;
+}


### PR DESCRIPTION
A change under `data/` merged to `main` currently reaches partidata.se only with a release. This adds a second workflow, `publish-data.yaml`, that runs on pushes to `main` touching `data/**` (and on `workflow_dispatch`): it validates the data, rsyncs `data/` into the deployed artifact with the existing deploy key, writes the published commit to a `data-commit` file, restarts the service and checks health. It shares the `production-deploy` concurrency group with the release workflow, so the two never interleave.

Publishing data and releasing code are kept separate by decision of the maintainer: the data workflow never compares `main` against the deployed version and never fails because `main` carries unshipped code. The one caveat is documented instead: `data/derived/riksdag.json` and `public/img/sveriges_riksdag.svg` are built into the bundle, so a change to them reaches the party pages only with a release.

The served data commit is reported as `data.commit` in `/api/health`, the release workflow writes the same file, and the `/data/` page links the data files at that commit rather than at the release tag. `deploy/README.md`, `CLAUDE.md` and the `/data/` page describe the two paths. `scripts/http-smoke.js` covers the health body with and without the file.

After merge, the first `v*` tag ships the new health check and starts writing `data-commit`; a data publish before that release works but reports no commit. The merge itself touches `src/`, so it does not trigger the new workflow.

## Decisions open to review

- The data workflow restarts `partidata.service` after the rsync rather than giving the server a way to drop its in-memory caches. A restart reuses the one sudoers rule the deploy account has; a cache-drop endpoint becomes the better choice if data publishes get frequent enough for the restart blip to matter.
- The data commit is exposed in `/api/health` only, not in the footer or the `X-Partidata-Version` header. Showing it on the page would be right if readers need to cite the exact data state without calling the API.
- The workflow always publishes the tip of `main`, whatever triggered it, so a re-run of an old run cannot roll data back. An explicit ref input would be the alternative if publishing an older data state on purpose is ever needed.
- The release workflow now builds tags only; `workflow_dispatch` on a branch is refused. Re-running the workflow from an older tag still works for rolling back.

Closes #100
