### PR TITLE
Read data/derived/riksdag.json at request time instead of bundling it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,9 @@ Open data about Swedish political parties. Swedish copy.
   `publish-data.yaml` by hand (`gh workflow run publish-data.yaml`) — data and
   code ship independently. A code change still needs a tag, and takes the data
   with it.
-  `data/derived/riksdag.json` and `public/img/sveriges_riksdag.svg` are built
-  into the bundle, so a change to them reaches the party pages only with a
-  release.
+  Everything under `data/` is read from disk at request time; the one file
+  built into the bundle is `public/img/sveriges_riksdag.svg`, so a change to it
+  reaches the header only with a release.
 
 ## Stack
 

--- a/agent-docs/issue/105-read-riksdag-json-at-request-time/index.md
+++ b/agent-docs/issue/105-read-riksdag-json-at-request-time/index.md
@@ -1,0 +1,33 @@
+# Issue #105: Read data/derived/riksdag.json at request time instead of bundling it
+
+**Baserad på:** main
+
+## Sammanfattning
+
+`src/components/party-profile/elections.tsx` importerar `data/derived/riksdag.json` statiskt, så kammarens sammansättning och valdeltagandeserien kompileras in i bundeln och följer inte med en datapublicering (#100) förrän nästa release. Läsningen flyttas till `src/server/party-data.ts` som en cachad `readParliamentView()` bredvid `readParliamentResults()`; `readOutsideParliament` byter till samma läsning så filen läses en gång per store. `resolveParty` sätter en smal vy — kammarens valår, källa och partier med förkortning och mandat, samt valdeltagandets serie och källor — som `riksdag` på partisidans props. `ElectionResultsSection` får `chamber` och `TurnoutSection` får `turnout` som props och räknar seriens punkter, diagrammets `aria-label` och kammarens platser ur dem i renderingen; sidan renderar valdeltagandesektionen bara när vyn finns. Tester i `scripts/party-data.test.js`, två påståenden i `scripts/http-smoke.js` och ett nytt `scripts/source-imports.test.js` som vaktar att `src/` inte importerar från `data/`. `CLAUDE.md`, `deploy/README.md` och `docs/riksdagsvalresultat.md` skrivs om så att bara `public/img/sveriges_riksdag.svg` nämns som bundlad; SVG:n lämnas som issuet tillåter. Allt går i en PR.
+
+## Triageringsstatus
+
+| Fält | Värde |
+|------|-------|
+| **Redo att arbeta** | Ja |
+| **Risk** | Låg |
+| **Säker för junior** | Ja |
+
+## Plangranskning
+
+**Status:** Reviewed
+**Granskad:** 2026-09-07
+**Feedback:** Tre granskningsrundor (codex). Första rundan: namnkrocken `chamber` i `ElectionResultsSection`, Reacts `<!-- -->` i röktestets mönster, en verifiering som visar ändrad data utan ombyggnad, tre fall för saknad fil/sektion, explicit projektion av `kammare.kalla`, den hårdkodade `aria-label`-texten "1994 till 2022", importvaktens täckning och triagens formulering om #35 och filantalet — alla åtgärdade. Andra rundan la till sidoeffektsimporter i vakten; tredje bekräftade planen utan anmärkning.
+
+## Relaterade filer
+
+- [plan.md](plan.md) — Fullständig implementationsplan
+- [progress.md](progress.md) — Implementationsframsteg
+- [research.md](research.md) — Forskningsresultat (om finns)
+
+## Relaterade issues
+
+- #100 — Publish data changes without a release; uppföljningen kommer från dess plan (beslut 9 där)
+- #104 — Mergad PR för #100
+- #35 — Omkörningen av 2026-importen; ändrar `data/derived/riksdag.json` och når partisidorna utan release först när det här är gjort

--- a/agent-docs/issue/105-read-riksdag-json-at-request-time/plan.md
+++ b/agent-docs/issue/105-read-riksdag-json-at-request-time/plan.md
@@ -1,0 +1,204 @@
+# Plan: Issue #105 — Read data/derived/riksdag.json at request time instead of bundling it
+
+## Mål
+
+Varje datafil sajten visar läses från `data/` på disk vid förfrågan genom `src/server/party-data.ts`. Det är det som gör att `publish-data.yaml` (#100) kan sätta en dataändring i drift genom att rsynca `data/` och starta om processen. En fil bryter mot det: `src/components/party-profile/elections.tsx` importerar `data/derived/riksdag.json` statiskt (`import parliamentView from 'data/derived/riksdag.json'`), så kammarens sammansättning, valdeltagandeserien och dess källor kompileras in i JavaScript-bundeln vid bygget. En datapublicering uppdaterar `/data/derived/riksdag.json` på servern medan partisidorna fortsätter visa bundelns kopia till nästa release. `party-data.ts` läser redan samma fil vid förfrågan för startsidans "största partier utanför riksdagen" (`readOutsideParliament`), så filen laddas på två sätt i dag.
+
+Läsningen flyttas till `party-data.ts`, det partisidans två sektioner behöver skickas som en prop genom `getServerSideProps`, importen försvinner, och de värden komponenten i dag räknar ut på modulnivå (`chamberComposition`, `parliamentComposition`, `nationalTurnout`, `turnoutSourceNames`, `turnoutFetched`, `chamberSeats`) räknas ut ur propen i stället. När ingenting i `src/` längre importerar från `data/` skrivs noterna i `CLAUDE.md` och `deploy/README.md` om så att bara `public/img/sveriges_riksdag.svg` nämns som det som fortfarande kräver en release.
+
+## Triagering
+
+> Beslutsunderlag för detta issue.
+
+| Fält | Värde |
+|------|-------|
+| **Blockeras av** | Inget |
+| **Blockerar** | Inget |
+| **Relaterade issues** | #100 (stängt; uppföljningen kommer därifrån, och dess plan är där den statiska importen upptäcktes), #104 (mergad PR för #100), #35 (öppet; omkörningen av 2026-importen rör partideltagandet, inte valresultaten — `derived/riksdag.json` ändras bara om partiregistret ändrar de partier härledningen pekar på, och först då märks det här issuet) |
+| **Omfattning** | 9 filer i `src/server/`, `src/components/party-profile/`, `src/pages/parti/`, `scripts/` och dokumentation |
+| **Risk** | Låg |
+| **Komplexitet** | Låg |
+| **Säker för junior** | Ja |
+| **Konfliktrisk** | Låg (#100 är mergad; ingen annan öppen plan rör `elections.tsx` eller `party-data.ts`) |
+
+### Triagemässiga noteringar
+
+- Inga blockerare. Repot har ingen `agent-docs/github/`-konfiguration, så projekttavlan har inte slagits upp.
+- Arbetet utgår från `main` (`a436f5c`, tre commits efter `v0.11.2`). `publish-data.yaml` körs för hand med `gh workflow run`, och `CLAUDE.md`/`deploy/README.md` beskriver det tillståndet — det är de styckena som uppdateras här.
+- `public/img/sveriges_riksdag.svg` genereras av `scripts/build-derived-data.js` ur samma data och serveras som statisk fil ur bundeln (sidhuvudets kammarbild i `src/components/Header.tsx`). Den ligger utanför det här issuet: dokumentationen behåller noten om att den fortfarande kräver en release (beslut 6).
+- Ingen annan öppen plan i `agent-docs/issue/` nämner `elections.tsx`, `[filnamn].tsx` eller `party-data.ts` som fil att ändra.
+
+## Angreppssätt
+
+`party-data.ts` får en läsare `readParliamentView()` som, precis som `readParliamentResults()`, läser sin fil en gång per store och cachar promisen; omstarten vid en datapublicering är det som släpper cachen, vilket är samma kontrakt som alla andra läsningar i filen. Läsaren returnerar en smal vy av `data/derived/riksdag.json` — kammarens valår, källa och partier med förkortning och mandat, samt valdeltagandets serie och källor — inte hela filen, så att `storsta_utanfor_riksdagen` och proveniensfälten inte hamnar i sidans props. `readCurrentParty` sätter den som `riksdag` på `PartyPageData`, bara när filen finns och har både `kammare` och `valdeltagande` — `scripts/build-derived-data.js` skriver alltid båda, så en fil med bara det ena är ett trasigt bygge, inte ett tillstånd att rendera halvt (beslut 3).
+
+`elections.tsx` tappar importen och modulkonstanterna. `ElectionResultsSection` får `riksdag` som prop och räknar `parliamentComposition` och `chamberSeats` ur den; `TurnoutSection` får `valdeltagande` som prop och räknar serien, källnamnen, hämtdatumet och diagrammets `aria-label` (första och sista valåret; i dag hårdkodat "1994 till 2022") ur den. Uträkningarna är små (349 platser, åtta valår) och görs i renderingen; sidan är serverrenderad, så ingen memoization behövs. `[filnamn].tsx` skickar propen vidare och renderar valdeltagandesektionen bara när både `valresultat` och `riksdag` finns; kammarblocket i resultatsektionen kräver dessutom `results.kammare` som i dag.
+
+Testerna i `scripts/party-data.test.js` får ett fall som visar att `resolveParty` bär vyn ur filen och ett fall utan fil. `scripts/http-smoke.js` läser redan `data/derived/riksdag.json` och får två påståenden till: partisidan visar kammarens valår i sammansättningsrubriken och det senaste valdeltagandevärdet. Ett litet test i `scripts/` vaktar att ingen fil under `src/` importerar från `data/`, så att regeln issuet formulerar går att läsa ur testsviten.
+
+Dokumentationen (`CLAUDE.md` rad 18–20, `deploy/README.md` rad 59–65) skrivs i nu-läge: bara `public/img/sveriges_riksdag.svg` ligger i bundeln.
+
+## Steg
+
+### Fas 1: Läsaren i `party-data.ts`
+
+1. Utöka `DerivedParliamentFile` med filens `kammare` och `valdeltagande` som valfria fält
+   - `kammare?: { valar: number; kalla: PartiProfilKalla; partier: Array<{ parti_uuid: string; forkortning: string; mandat: number }> }`
+   - `valdeltagande?: { resultat: Array<{ valar: number; procent: number }>; kallor: Array<PartiProfilKalla & { id: string; titel?: string; version?: string; format?: string; sha256?: string; transkribering_sha256?: string }> }`
+   - Filer att ändra: `src/server/party-data.ts`
+2. Lägg till de exporterade typerna för vyn, bredvid `ParliamentYear`/`OutsideParliamentData`
+   - `ParliamentChamber { valar: number; kalla: PartiProfilKalla; partier: Array<{ forkortning: string; mandat: number }> }`
+   - `ParliamentTurnout { resultat: Array<{ valar: number; procent: number }>; kallor: PartiProfilKalla[] }` — källorna reduceras till `namn`/`url`/`hamtad`, som är det `SourceLine` och källraden visar
+   - `ParliamentView { kammare: ParliamentChamber; valdeltagande: ParliamentTurnout }`
+   - `PartyPageData` får `riksdag?: ParliamentView`
+   - Filer att ändra: `src/server/party-data.ts`
+3. Bryt ut en cachad läsning av `derived/riksdag.json`
+   - `let derivedParliamentPromise: Promise<DerivedParliamentFile | undefined> | undefined;` och `readDerivedParliament()` med `??=` som `readParliamentResults()`; `readOutsideParliament` byter till den så att filen läses en gång per store
+   - `readParliamentView(): Promise<ParliamentView | undefined>` returnerar `undefined` när filen saknas eller `kammare`/`valdeltagande` saknas, annars vyn; partierna mappas till `{ forkortning, mandat }` i filens ordning, och både `kammare.kalla` och `valdeltagande.kallor` reduceras till `{ namn, url, hamtad }` — typannoteringen tar inte bort `id`, `titel`, `sha256` ur objektet, det gör bara en explicit projektion
+   - Filer att ändra: `src/server/party-data.ts`
+4. `readCurrentParty` läser vyn i samma `Promise.all` som profilen, kandidatlistorna och resultaten och sätter `...(riksdag ? { riksdag } : {})`
+   - Filer att ändra: `src/server/party-data.ts`
+5. Ge `readDerivedParliament` en docblock i samma stil som `readParliamentResults` ("read once"); kommentaren på `readDataFile` om att datan bara ändras vid omstart stämmer fortfarande och lämnas
+
+### Fas 2: Komponenterna och sidan
+
+1. Ta bort importen och modulkonstanterna i `elections.tsx`
+   - Ta bort `import parliamentView from 'data/derived/riksdag.json'` och raderna `chamberComposition`, `parliamentComposition`, `nationalTurnout`, `turnoutSourceNames`, `turnoutFetched` och `chamberSeats`
+   - Gör om `chamberSeats`-IIFE:n till en funktion `chamberSeatPositions(partier: ParliamentChamber['partier'])` med samma geometri; platserna läggs ut i filens ordning (som i dag, `chamberComposition` är osorterad), bara sammansättningslistan sorteras efter mandat
+   - `{ label, seats }`-formen som `chamberComposition` har i dag ersätts av `{ forkortning, mandat }` rakt igenom (`ChamberDiagram`, `parliamentComposition`, listan)
+   - Filer att ändra: `src/components/party-profile/elections.tsx`
+2. `ElectionResultsSection` får `chamber?: ParliamentChamber`
+   - Signatur: `{ results: PartiValresultat; partyLabel?: string; chamber?: ParliamentChamber }`
+   - Lokalen `const chamber = results.kammare` på rad 98 krockar med propen: döp om den till `partySeats` (den bär bara `mandat` och `valar` för partiet)
+   - `parliamentComposition = chamber.partier.toSorted((a, b) => b.mandat - a.mandat)` och `chamberSeatPositions(chamber.partier)` räknas bara när `chamber` finns; `ChamberDiagram` tar `seats` (positionerna) som prop
+   - Kammarblocket renderas när `partySeats && chamber`; rubriken, källraden (`chamber.kalla`) och sammansättningsrubriken använder `chamber.valar`
+   - Filer att ändra: `src/components/party-profile/elections.tsx`
+3. `TurnoutSection` får `turnout: ParliamentTurnout`
+   - Serien, `sourceNames` (`[...new Set(kallor.map(k => k.namn))]`) och `fetched` (`kallor.map(k => k.hamtad).toSorted().at(-1)`) räknas i komponenten; källraderna mappar `turnout.kallor` med `key` av `url` och `hamtad` som i dag
+   - SVG:ns `aria-label` blir `Valdeltagande i riksdagsval ${första valår} till ${sista valår}` ur serien i stället för den hårdkodade "1994 till 2022"
+   - Filer att ändra: `src/components/party-profile/elections.tsx`
+4. `[filnamn].tsx` plockar `riksdag` ur props och skickar vidare
+   - `<ElectionResultsSection key={slug} results={valresultat} partyLabel={abbreviation} chamber={riksdag?.kammare} />`
+   - `{valresultat && riksdag && <TurnoutSection turnout={riksdag.valdeltagande} />}`
+   - Filer att ändra: `src/pages/parti/[filnamn].tsx`
+5. Kör `npm run typecheck` och `npm run lint`; kontrollera med `grep -rn "from 'data/" src` att ingen import från `data/` finns kvar
+
+### Fas 3: Tester
+
+1. `scripts/party-data.test.js`: två fall efter testet "party pages derive their election results from the imported result files"
+   - I testet skrivs `derived/riksdag.json` med `kammare` (valår, `kalla` med `id`/`titel`/`sha256`, två partier med `parti_uuid`) och `valdeltagande` (två år, två källor med olika `hamtad` och extra fält); `resolveParty('betapartiet').props.riksdag` `deepEqual` den reducerade vyn — partierna utan `parti_uuid`, `kammare.kalla` och `valdeltagande.kallor` som exakt `{ namn, url, hamtad }`
+   - Tre fall som ger `props.riksdag === undefined`: filen saknas; filen har bara `storsta_utanfor_riksdagen`; filen har `kammare` men inte `valdeltagande`. I det första fallet fungerar `readHomeData()` fortfarande (utan `outsideParliament`)
+   - Ett fall som visar att filen läses en gång per store: `readHomeData()` följt av `resolveParty(...)` på samma store, skriv om filen mellan anropen, partisidan visar det gamla innehållet; en ny store på samma katalog visar det nya
+   - Fixturen i `withDataFiles` (`{ schema_version: 2, kammare: { valar: 2022, partier: [] } }`) saknar `valdeltagande` och ger `undefined` — de testerna påstår inget om `riksdag`, så den lämnas
+   - Filer att ändra: `scripts/party-data.test.js`
+2. `scripts/http-smoke.js`: i partisideblocket (efter påståendet om `id="deltagande"`)
+   - `assert.match(profileBody, new RegExp(\`Riksdagens sammansättning (<!-- -->)?${chamber.valar}\`))` — React lägger `<!-- -->` mellan text och uttryck, samma mönster som `valet (<!-- -->)?${chamber.valar}` på rad 273
+   - Det senaste valdeltagandevärdet ur `derivedParliament.valdeltagande.resultat.at(-1).procent`, formaterat som komponenten gör (`toFixed(2).replace(/0$/, '').replace('.', ',')`), följt av `(<!-- -->)? %`
+   - `aria-label="Valdeltagande i riksdagsval ${första} till ${sista}"` ur samma serie
+   - Ett parti med resultat men utan `riksdag` finns inte i den committade datan, så det fallet täcks av enhetstestet i steg 1, inte av röktestet
+   - Filer att ändra: `scripts/http-smoke.js`
+3. Nytt test `scripts/source-imports.test.js`: går igenom `src/**/*.{ts,tsx,js,jsx}` (`allowJs` är på) och samlar specifikatorerna ur `import ... from '...'`, `import '...'` (sidoeffektsimport), `export ... from '...'`, `import('...')` och `require('...')`; en specifikator som börjar med `data/` (baseUrl-import) eller som, relativ, löses mot filens katalog till något under `<repo>/data/` felar testet
+   - Filer att skapa: `scripts/source-imports.test.js`
+
+### Fas 4: Dokumentation
+
+1. `CLAUDE.md`: meningen på rad 18–20 blir att `public/img/sveriges_riksdag.svg` byggs in i bundeln och därför når sidhuvudet först med en release, medan allt under `data/` läses vid förfrågan
+   - Filer att ändra: `CLAUDE.md`
+2. `deploy/README.md`: stycket på rad 59–65 skrivs om till en fil: `public/img/sveriges_riksdag.svg`, genererad av `scripts/build-derived-data.js`; meningen om att `/data/derived/riksdag.json` följer en datapublicering tas bort eftersom det nu gäller allt
+   - Filer att ändra: `deploy/README.md`
+3. `docs/riksdagsvalresultat.md` rad 42 säger att startsidan använder härledningen; lägg till att partisidornas kammarblock och valdeltagande läser samma fil
+   - Filer att ändra: `docs/riksdagsvalresultat.md`
+
+### Fas 5: Verifiering
+
+1. `npm run precommit` (lint, typecheck, `check:derived-data`, `validate:data`, tester, `build:release`, `test:http`)
+2. Bekräfta manuellt att partisidan följer datan utan ombyggnad: efter `npm run build:release`, ändra ett `procent`-värde i `.release/data/derived/riksdag.json`, starta `npm start`, hämta `/parti/miljopartiet-de-grona/` och se det ändrade värdet; återställ filen (den är en kopia, inte den committade). Ett `grep -rl "Allmänna valen" .release/.next/static` utan träff är stödjande bevis, inte beviset — strängen kan saknas av andra skäl
+3. PR-body avslutas med `Closes #105`
+
+## Filöversikt
+
+| Fil | Åtgärd | Syfte |
+|-----|--------|-------|
+| `src/server/party-data.ts` | Ändra | `readDerivedParliament`/`readParliamentView`, typerna `ParliamentChamber`/`ParliamentTurnout`/`ParliamentView`, `riksdag` på `PartyPageData` |
+| `src/components/party-profile/elections.tsx` | Ändra | Importen och modulkonstanterna bort; `chamber`- och `turnout`-props |
+| `src/pages/parti/[filnamn].tsx` | Ändra | Skickar `riksdag` vidare; villkorar `TurnoutSection` |
+| `scripts/party-data.test.js` | Ändra | Vyn ur filen och fallet utan fil |
+| `scripts/http-smoke.js` | Ändra | Sammansättningsåret och valdeltagandet i partisidan |
+| `scripts/source-imports.test.js` | Skapa | Vaktar att `src/` inte importerar från `data/` |
+| `CLAUDE.md` | Ändra | Bara SVG:n nämns som bundlad |
+| `deploy/README.md` | Ändra | Samma |
+| `docs/riksdagsvalresultat.md` | Ändra | Partisidorna nämns som läsare av härledningen |
+
+## Berörda kodområden
+
+- `src/server/`
+- `src/components/party-profile/`
+- `src/pages/parti/`
+- `scripts/` (tester och röktest)
+- `CLAUDE.md`, `deploy/`, `docs/`
+
+## Designbeslut
+
+> Icke-triviala val gjorda under planeringen. Varje beslut är antingen avgjort här, med proveniens, eller uttryckligen markerat som att det kräver användaren eftersom ett felval skulle ge skada som inte går att backa. Feedback välkommen; annars implementeras enligt dessa, och beslut som är agentens bedömning listas i PR:en för granskning.
+
+### 1. Läsningen sker i `party-data.ts` och når komponenten via props
+**Alternativ:** A) `party-data.ts` läser filen, `getServerSideProps` skickar vyn som prop; B) komponenten läser filen själv i en serverkontext; C) härleda kammaren ur `readParliamentResults()` i stället för ur `derived/riksdag.json`
+**Beslut:** A
+**Proveniens:** användarbeslut (issue #105: "Move the read into `party-data.ts`, pass what the elections view needs through the party page's `getServerSideProps` props, and drop the import")
+**Vid fel val:** begränsat
+**Motivering:** Issuet anger vägen. C skulle göra `derived/riksdag.json` överflödig för partisidan men ändra vilken fil som är sanningskälla för kammaren, vilket är utanför issuet; `storsta_utanfor_riksdagen` behöver ändå filen.
+
+### 2. En smal vy, inte hela filen, som prop
+**Alternativ:** A) `riksdag: ParliamentView` med bara kammaren (valår, källa, förkortning + mandat) och valdeltagandet (serie + källor reducerade till `namn`/`url`/`hamtad`); B) hela `DerivedParliamentFile` som prop
+**Beslut:** A
+**Proveniens:** befintlig konvention (`HomeData` bär `ParliamentYear`/`OutsideParliamentData`, egna vyer av samma fil, inte råfilen; `readOutsideParliament` reducerar redan)
+**Vid fel val:** begränsat (props-formen är intern för sidan och byts i en PR)
+**Motivering:** Sidans props serialiseras in i HTML:en; `storsta_utanfor_riksdagen`, `genererad_fran` och källornas `sha256` har inget att göra där. Källorna behåller de tre fält `SourceLine` ritar.
+
+### 3. Vyn är valfri och sektionerna renderas bara när den finns
+**Alternativ:** A) `readOptionalJson`, `riksdag?: ParliamentView`, kammarblock och valdeltagande utelämnas när filen eller dess delar saknas; B) filen är obligatorisk och `resolveParty` kastar
+**Beslut:** A
+**Proveniens:** befintlig konvention (`readOutsideParliament` returnerar `undefined` utan fil; testfixturerna i `scripts/party-data.test.js` skriver `derived/riksdag.json` utan `valdeltagande`)
+**Vid fel val:** begränsat — en saknad fil i produktion syns eftersom `scripts/http-smoke.js` kräver `id="deltagande"` på ett parti med resultat, och `publish-data.yaml` kör `check:derived-data` innan rsyncen
+**Motivering:** Samma tolerans som resten av storen; testfixturerna behöver inte byggas om. Vyn är allt eller inget — `kammare` utan `valdeltagande` ger också `undefined` — eftersom `build-derived-data.js` alltid skriver båda och `check:derived-data` körs före varje publicering; att rendera kammaren men inte valdeltagandet skulle dölja ett trasigt bygge bakom en halv sida. Om användaren hellre vill att sidan felar högt utan filen är B rätt och `withDataFiles`-fixturen får `valdeltagande`.
+
+### 4. Uträkningarna görs i renderingen, utan memoization
+**Alternativ:** A) `chamberSeatPositions(partier)` och serieuträkningarna anropas i komponenten vid varje rendering; B) `useMemo`; C) räkna positionerna på servern och skicka som prop
+**Beslut:** A
+**Proveniens:** agentens bedömning
+**Vid fel val:** begränsat (prestanda på en serverrenderad sida med 349 element; byts i en uppföljning)
+**Motivering:** Sidan renderas en gång per förfrågan på servern och hydreras en gång; uträkningen är trivial. C skulle lägga 349 koordinatpar i props. B blir rätt om komponenten börjar rendera om vid interaktion i kammarblocket.
+
+### 5. Typerna för vyn ligger i `party-data.ts`, inte `src/types.ts`
+**Alternativ:** A) `ParliamentChamber`/`ParliamentTurnout`/`ParliamentView` exporteras från `src/server/party-data.ts`; B) i `src/types.ts`
+**Beslut:** A
+**Proveniens:** befintlig konvention (`HomeData`, `ParliamentYear`, `OutsideParliamentData`, `SymbolFrame` — alla sid-props-former — ligger i `party-data.ts`; `src/types.ts` bär datafilernas former)
+**Vid fel val:** begränsat
+**Motivering:** Komponenten importerar redan typer från `src/server/party-data` via sidan; `elections.tsx` importerar `ElectionType`/`CandidateLists` som är dubblerade i båda filerna, och vyn hör till sidans props, inte till datan på disk.
+
+### 6. `public/img/sveriges_riksdag.svg` lämnas i bundeln och noteras i dokumentationen
+**Alternativ:** A) Dokumentationen behåller noten om SVG:n; B) servera SVG:n från `data/` eller generera den vid förfrågan i samma PR
+**Beslut:** A
+**Proveniens:** användarbeslut (issue #105: "it is out of scope here but the same argument applies, so note in the docs that it still needs a release, or take it in a follow-up")
+**Vid fel val:** begränsat
+**Motivering:** Issuet ger valet; B blandar in `next/image`, `public/` och `build-derived-data.js` i en ändring som annars är en flytt av en läsning. Ett uppföljningsissue kan öppnas när #35 gör att SVG:n faktiskt ändras.
+
+### 7. Ett test vaktar att `src/` inte importerar från `data/`
+**Alternativ:** A) `scripts/source-imports.test.js` som läser `src/` och felar på en import från `data/`; B) ingen vakt, regeln står bara i `CLAUDE.md`
+**Beslut:** A
+**Proveniens:** agentens bedömning
+**Vid fel val:** begränsat (ett test som tas bort)
+**Motivering:** Issuets kärna är regeln "ingenting i `src/` importerar från `data/`", och den bröts en gång utan att någon märkte det förrän #100 planerades. Ett litet test gör regeln körbar i `npm test`; det fångar de fyra importformerna och relativa sökvägar, inte `fs`-läsningar med hårdkodad sökväg (de går genom `party-data.ts` och är just det regeln vill ha). B är rätt om användaren tycker att `CLAUDE.md` räcker.
+
+## Verifieringschecklista
+
+- [ ] `grep -rn "from 'data/" src` ger ingen träff
+- [ ] Partisidan för ett riksdagsparti visar kammarblocket med rätt valår, källa och sammansättning, och valdeltagandesektionen med serien och källorna — samma som före ändringen
+- [ ] Ett parti med röstrad utan mandat får valdeltagandesektionen men inget kammarblock (röktestets befintliga påståenden)
+- [ ] Ett parti utan resultat får varken resultat- eller valdeltagandesektion
+- [ ] `resolveParty` bär `riksdag` ur `derived/riksdag.json` och utelämnar den utan fil (`scripts/party-data.test.js`)
+- [ ] `derived/riksdag.json` läses en gång per store, för både startsidan och partisidorna
+- [ ] Ett ändrat värde i `.release/data/derived/riksdag.json` syns på partisidan efter omstart utan ombyggnad
+- [ ] Valdeltagandediagrammets `aria-label` anger seriens första och sista valår
+- [ ] `CLAUDE.md`, `deploy/README.md` och `docs/riksdagsvalresultat.md` nämner bara `public/img/sveriges_riksdag.svg` som bundlad
+- [ ] `npm run precommit` grönt

--- a/agent-docs/issue/105-read-riksdag-json-at-request-time/progress.md
+++ b/agent-docs/issue/105-read-riksdag-json-at-request-time/progress.md
@@ -1,0 +1,38 @@
+# Framsteg: Issue #105 — Read data/derived/riksdag.json at request time instead of bundling it
+
+**Påbörjad:** 2026-09-07
+**Senast uppdaterad:** 2026-09-07
+**Status:** Klar
+
+## Genomförda steg
+
+- [x] Fas 1, steg 1: `DerivedParliamentFile` utökas med `kammare` och `valdeltagande`
+- [x] Fas 1, steg 2: Typerna `ParliamentChamber`/`ParliamentTurnout`/`ParliamentView`, `riksdag` på `PartyPageData`
+- [x] Fas 1, steg 3: `readDerivedParliament()` och `readParliamentView()`; `readOutsideParliament` läser genom samma cache
+- [x] Fas 1, steg 4: `readCurrentParty` sätter `riksdag`
+- [x] Fas 1, steg 5: Docblock på `readDerivedParliament` och `readParliamentView`
+- [x] Fas 2, steg 1: Importen och modulkonstanterna bort ur `elections.tsx`; `chamberSeatPositions()`
+- [x] Fas 2, steg 2: `ElectionResultsSection` får `chamber`, lokalen döpt till `partySeats`
+- [x] Fas 2, steg 3: `TurnoutSection` får `turnout`, `aria-label` ur serien
+- [x] Fas 2, steg 4: `[filnamn].tsx` skickar `riksdag` vidare
+- [x] Fas 2, steg 5: `typecheck`, `lint` och `grep -rn "from 'data/" src` utan träff
+- [x] Fas 3, steg 1: Fyra fall i `scripts/party-data.test.js`
+- [x] Fas 3, steg 2: Tre påståenden i `scripts/http-smoke.js`
+- [x] Fas 3, steg 3: `scripts/source-imports.test.js`
+- [x] Fas 4, steg 1: `CLAUDE.md`
+- [x] Fas 4, steg 2: `deploy/README.md`
+- [x] Fas 4, steg 3: `docs/riksdagsvalresultat.md`
+- [x] Fas 5: `npm run precommit` grönt; ändrat värde i `.release/data/derived/riksdag.json` syns på partisidan efter omstart utan ombyggnad
+
+**Slutfört:** 2026-09-07
+
+## Anteckningar
+
+- Kammarblocket ligger i en egen komponent `ChamberBlock` i `elections.tsx`, så att
+  `chamberSeatPositions()` och sorteringen bara körs när `chamber` finns. Planen anger
+  villkoret, inte formen; en egen komponent följer filens befintliga uppdelning
+  (`ChamberDiagram`, `ElectionChart`).
+- Verifiering: `.release/data/derived/riksdag.json` fick `valdeltagande.resultat[-1].procent`
+  77.77, servern startades om utan ombyggnad, och `/parti/miljopartiet-de-grona/` visade
+  77,77 %. `grep -rl "Allmänna valen" .release/.next/static` gav ingen träff. Filen
+  återställdes och `npm run test:http` kördes om grönt.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -57,12 +57,10 @@ tip.
 - A server that does not answer is restored with a manual release run on the
   current tag.
 
-Two files are built into the bundle rather than read from `data/` at request
-time: `data/derived/riksdag.json`, which `src/components/party-profile/elections.tsx`
-imports statically, and `public/img/sveriges_riksdag.svg`, which
-`scripts/build-derived-data.js` generates. A change to either reaches the party
-pages only with a release. `/data/derived/riksdag.json` itself is served from
-disk and does follow a data publish.
+One file is built into the bundle rather than read from `data/` at request
+time: `public/img/sveriges_riksdag.svg`, which `scripts/build-derived-data.js`
+generates and the header shows. A change to it reaches the site only with a
+release.
 
 ## One-time server setup
 

--- a/docs/riksdagsvalresultat.md
+++ b/docs/riksdagsvalresultat.md
@@ -39,7 +39,7 @@ En osäker träff blir `ej_kopplade`, inte en gissad identitet. Exempelvis block
 
 ## Största partierna utanför riksdagen
 
-Startsidan använder den deterministiska härledningen i `data/derived/riksdag.json`:
+Startsidan använder den deterministiska härledningen i `data/derived/riksdag.json`, samma fil som partisidornas kammarblock och valdeltagandesektion läser:
 
 1. Perioden är 1994 till senaste importerade riksdagsval.
 2. Partier med mandat i periodens senaste val tas bort.

--- a/scripts/http-smoke.js
+++ b/scripts/http-smoke.js
@@ -366,6 +366,23 @@ async function main () {
     assert.match(profileBody, seatPattern(currentSeats.mandat), 'partisidan visar kammarmandaten från de importerade resultaten');
     assert.match(profileBody, /<section class="profile-results"/, 'ett parti med resultat får resultatsektionen');
     assert.match(profileBody, /id="deltagande"/, 'ett parti med resultat får valdeltagandesektionen');
+    assert.match(
+      profileBody,
+      new RegExp(`Riksdagens sammansättning (<!-- -->)?${chamber.valar}`),
+      'kammarblocket anger valåret ur derived/riksdag.json'
+    );
+    const turnoutSeries = derivedParliament.valdeltagande.resultat;
+    const latestTurnout = turnoutSeries.at(-1).procent.toFixed(2).replace(/0$/, '').replace('.', ',');
+    assert.match(
+      profileBody,
+      new RegExp(`${latestTurnout}(<!-- -->)? %`),
+      'valdeltagandesektionen visar det senaste värdet ur derived/riksdag.json'
+    );
+    assert.match(
+      profileBody,
+      new RegExp(`aria-label="Valdeltagande i riksdagsval ${turnoutSeries[0].valar} till ${turnoutSeries.at(-1).valar}"`),
+      'valdeltagandediagrammet anger seriens första och sista valår'
+    );
 
     const withoutSeatsProfile = await fetch(`${baseUrl}/parti/${withoutSeats.filnamn}/`);
     assert.equal(withoutSeatsProfile.status, 200);

--- a/scripts/party-data.test.js
+++ b/scripts/party-data.test.js
@@ -531,6 +531,108 @@ test('party pages derive their election results from the imported result files',
   assert.equal(withoutResults.props.valresultat, undefined);
 });
 
+/** The chamber and the turnout series as `derived/riksdag.json` carries them. */
+function derivedParliament () {
+  return {
+    schema_version: 2,
+    kammare: {
+      valar: 2026,
+      kalla: {
+        id: 'resultat',
+        namn: 'Valmyndigheten',
+        titel: 'Val till riksdagen 2026, riket',
+        url: 'https://example.com/kammare.json',
+        hamtad: '2026-08-26',
+        sha256: 'b'.repeat(64)
+      },
+      partier: [
+        { parti_uuid: '22222222-2222-4222-8222-222222222222', forkortning: 'B', mandat: 349 },
+        { parti_uuid: '11111111-1111-4111-8111-111111111111', forkortning: 'A', mandat: 0 }
+      ]
+    },
+    valdeltagande: {
+      resultat: [{ valar: 2022, procent: 84.21 }, { valar: 2026, procent: 85.5 }],
+      kallor: [
+        {
+          id: 'publikation',
+          namn: 'SCB',
+          titel: 'Allmänna valen 2022',
+          url: 'https://example.com/scb.pdf',
+          format: 'application/pdf',
+          hamtad: '2026-08-20',
+          sha256: 'c'.repeat(64),
+          transkribering_sha256: 'd'.repeat(64)
+        },
+        {
+          id: 'resultat',
+          namn: 'Valmyndigheten',
+          titel: 'Val till riksdagen 2026, riket',
+          url: 'https://example.com/kammare.json',
+          version: 'Slutligt valresultat',
+          hamtad: '2026-08-26',
+          sha256: 'b'.repeat(64)
+        }
+      ]
+    }
+  };
+}
+
+test('party pages carry the chamber and the turnout series from the derivation', async t => {
+  const { root, dataRoot } = makeHomeData();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  writeJson(dataRoot, 'derived/riksdag.json', derivedParliament());
+
+  const party = await createPartyDataStore(dataRoot).resolveParty('betapartiet');
+  assert.deepEqual(party.props.riksdag, {
+    kammare: {
+      valar: 2026,
+      kalla: { namn: 'Valmyndigheten', url: 'https://example.com/kammare.json', hamtad: '2026-08-26' },
+      partier: [{ forkortning: 'B', mandat: 349 }, { forkortning: 'A', mandat: 0 }]
+    },
+    valdeltagande: {
+      resultat: [{ valar: 2022, procent: 84.21 }, { valar: 2026, procent: 85.5 }],
+      kallor: [
+        { namn: 'SCB', url: 'https://example.com/scb.pdf', hamtad: '2026-08-20' },
+        { namn: 'Valmyndigheten', url: 'https://example.com/kammare.json', hamtad: '2026-08-26' }
+      ]
+    }
+  });
+});
+
+test('the party page omits the chamber view when the derivation is missing or half written', async t => {
+  const { root, dataRoot } = makeHomeData();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const withoutFile = createPartyDataStore(dataRoot);
+  assert.equal((await withoutFile.resolveParty('betapartiet')).props.riksdag, undefined);
+  assert.equal((await withoutFile.readHomeData()).outsideParliament, undefined, 'startsidan klarar sig utan filen');
+
+  const { kammare } = derivedParliament();
+  writeJson(dataRoot, 'derived/riksdag.json', {
+    storsta_utanfor_riksdagen: { period: { fran: 1994, till: 2026 }, metod: 'Exakt testmetod', partier: [] }
+  });
+  assert.equal((await createPartyDataStore(dataRoot).resolveParty('betapartiet')).props.riksdag, undefined);
+
+  writeJson(dataRoot, 'derived/riksdag.json', { schema_version: 2, kammare });
+  assert.equal((await createPartyDataStore(dataRoot).resolveParty('betapartiet')).props.riksdag, undefined);
+});
+
+test('the derivation is read once per store, for the start page and the party pages alike', async t => {
+  const { root, dataRoot } = makeHomeData();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  writeJson(dataRoot, 'derived/riksdag.json', derivedParliament());
+
+  const store = createPartyDataStore(dataRoot);
+  await store.readHomeData();
+
+  const changed = derivedParliament();
+  changed.kammare.valar = 2030;
+  writeJson(dataRoot, 'derived/riksdag.json', changed);
+
+  assert.equal((await store.resolveParty('betapartiet')).props.riksdag.kammare.valar, 2026, 'lagret läser filen en gång');
+  assert.equal((await createPartyDataStore(dataRoot).resolveParty('betapartiet')).props.riksdag.kammare.valar, 2030);
+});
+
 const voteSource = { id: 'resultat', namn: 'Valmyndigheten', url: 'https://example.com/roster', hamtad: '2026-08-26' };
 const seatSource = { id: 'mandat', namn: 'Valmyndigheten', url: 'https://example.com/mandat', hamtad: '2026-08-26' };
 

--- a/scripts/source-imports.test.js
+++ b/scripts/source-imports.test.js
@@ -1,0 +1,51 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const projectRoot = path.join(__dirname, '..');
+const sourceRoot = path.join(projectRoot, 'src');
+const dataRoot = path.join(projectRoot, 'data');
+
+/** Every module under `src/` TypeScript compiles, path relative to the repository root. */
+function sourceFiles (directory = sourceRoot) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const file = path.join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(file);
+    return /\.(?:ts|tsx|js|jsx)$/.test(entry.name) ? [file] : [];
+  });
+}
+
+/**
+ * The module specifiers one file names, in the four forms the sources use:
+ * `import ... from`, a side-effect `import`, `export ... from`, a dynamic
+ * `import()` and `require()`.
+ */
+function specifiers (source) {
+  const patterns = [
+    /(?:^|[^\w$.])(?:import|export)\s+(?:[^'"]*?\sfrom\s+)?(['"])([^'"]+)\1/g,
+    /(?:^|[^\w$.])import\s*\(\s*(['"])([^'"]+)\1/g,
+    /(?:^|[^\w$.])require\s*\(\s*(['"])([^'"]+)\1/g,
+  ];
+  return patterns.flatMap(pattern => [...source.matchAll(pattern)].map(match => match[2]));
+}
+
+/** Where a specifier lands, for the two forms that can reach `data/`. */
+function resolvesIntoData (specifier, file) {
+  if (specifier === 'data' || specifier.startsWith('data/')) return true;
+  if (!specifier.startsWith('.')) return false;
+  const target = path.resolve(path.dirname(file), specifier);
+  const relative = path.relative(dataRoot, target);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+test('nothing under src/ imports from data/', () => {
+  const files = sourceFiles();
+  assert.ok(files.length > 0, 'src/ har moduler att granska');
+
+  const offenders = files.flatMap(file => specifiers(fs.readFileSync(file, 'utf8'))
+    .filter(specifier => resolvesIntoData(specifier, file))
+    .map(specifier => `${path.relative(projectRoot, file)}: ${specifier}`));
+
+  assert.deepEqual(offenders, [], 'data/ läses vid förfrågan genom src/server/party-data.ts, inte som import');
+});

--- a/src/components/party-profile/elections.tsx
+++ b/src/components/party-profile/elections.tsx
@@ -1,21 +1,24 @@
 import Image from 'next/image';
 import { useState } from 'react';
-import parliamentView from 'data/derived/riksdag.json';
+import type { ParliamentChamber, ParliamentTurnout } from 'src/server/party-data';
 import type { PartiDeltagande, PartiValresultat, PartiValresultatPost } from 'src/types';
 import { SectionHeader, SourceLine } from './shared';
 
 export type ElectionType = 'R' | 'L' | 'K';
 export type CandidateLists = Record<string, ElectionType[]>;
 
-const percentageFormatter = new Intl.NumberFormat('sv-SE', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-const chamberComposition = parliamentView.kammare.partier.map(party => ({ label: party.forkortning, seats: party.mandat }));
-const parliamentComposition = chamberComposition.toSorted((a, b) => b.seats - a.seats);
-const nationalTurnout = parliamentView.valdeltagande.resultat.map(result => ({ year: result.valar, value: result.procent }));
-const turnoutSourceNames = [...new Set(parliamentView.valdeltagande.kallor.map(source => source.namn))];
-const turnoutFetched = parliamentView.valdeltagande.kallor.map(source => source.hamtad).toSorted().at(-1);
+interface ChamberSeat {
+  id: number;
+  party: string;
+  x: number;
+  y: number;
+}
 
-const chamberSeats = (() => {
-  const parties = chamberComposition.flatMap(party => Array.from({ length: party.seats }, () => party.label));
+const percentageFormatter = new Intl.NumberFormat('sv-SE', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+/** One dot per seat, laid out over nine arcs, in the order the parties are given. */
+function chamberSeatPositions (partier: ParliamentChamber['partier']): ChamberSeat[] {
+  const parties = partier.flatMap(party => Array.from({ length: party.mandat }, () => party.forkortning));
   const rows = 9;
   const radii = Array.from({ length: rows }, (_, row) => 0.4 + ((0.97 - 0.4) * row) / (rows - 1));
   const radiusTotal = radii.reduce((total, radius) => total + radius, 0);
@@ -35,7 +38,7 @@ const chamberSeats = (() => {
     x: 50 + 50 * point.radius * Math.cos(point.angle),
     y: 100 - 100 * point.radius * Math.sin(point.angle),
   }));
-})();
+}
 
 function ElectionChart ({ results, selected, onSelect }: { results: PartiValresultatPost[]; selected: number; onSelect: (index: number) => void }) {
   const highestResult = Math.max(4, ...results.map(result => result.rostandel));
@@ -76,15 +79,34 @@ function ElectionChart ({ results, selected, onSelect }: { results: PartiValresu
   );
 }
 
-function ChamberDiagram ({ mandates, partyLabel }: { mandates: number; partyLabel?: string }) {
+function ChamberDiagram ({ mandates, seats, partyLabel }: { mandates: number; seats: ChamberSeat[]; partyLabel?: string }) {
   return (
     <div className="profile-chamber" role="img" aria-label={`${mandates} av riksdagens 349 mandat`}>
-      {chamberSeats.map(seat => <span key={seat.id} style={{ left: `${seat.x}%`, top: `${seat.y}%`, background: seat.party === partyLabel ? '#f1eee4' : '#2c4a7c' }} />)}
+      {seats.map(seat => <span key={seat.id} style={{ left: `${seat.x}%`, top: `${seat.y}%`, background: seat.party === partyLabel ? '#f1eee4' : '#2c4a7c' }} />)}
     </div>
   );
 }
 
-export function ElectionResultsSection ({ results, partyLabel }: { results: PartiValresultat; partyLabel?: string }) {
+function ChamberBlock ({ chamber, mandates, partyLabel }: { chamber: ParliamentChamber; mandates: number; partyLabel?: string }) {
+  const seats = chamberSeatPositions(chamber.partier);
+  const composition = chamber.partier.toSorted((a, b) => b.mandat - a.mandat);
+
+  return (
+    <div className="profile-results__bottom">
+      <div>
+        <h3>Partiets {mandates} platser i kammaren</h3>
+        <ChamberDiagram mandates={mandates} seats={seats} partyLabel={partyLabel} />
+        <SourceLine source={chamber.kalla}>349 mandat efter valet {chamber.valar} · </SourceLine>
+      </div>
+      <div className="profile-composition">
+        <h3>Riksdagens sammansättning {chamber.valar}</h3>
+        <ul>{composition.map(party => <li key={party.forkortning} className={party.forkortning === partyLabel ? 'is-current' : undefined}><span>{party.forkortning}</span><i><b style={{ width: `${(party.mandat / composition[0].mandat) * 100}%` }} /></i><strong>{party.mandat}</strong></li>)}</ul>
+      </div>
+    </div>
+  );
+}
+
+export function ElectionResultsSection ({ results, partyLabel, chamber }: { results: PartiValresultat; partyLabel?: string; chamber?: ParliamentChamber }) {
   const [selected, setSelected] = useState(results.resultat.length - 1);
   const result = results.resultat[selected];
   const firstYear = results.resultat[0]?.valar;
@@ -95,7 +117,7 @@ export function ElectionResultsSection ({ results, partyLabel }: { results: Part
   // Valmyndigheten's is the only source logo the site carries, so it stands
   // only where Valmyndigheten is the whole series.
   const valmyndighetenOnly = sourceNames.length === 1 && sourceNames[0] === 'Valmyndigheten';
-  const chamber = results.kammare;
+  const partySeats = results.kammare;
   if (!result) return null;
 
   return (
@@ -124,17 +146,7 @@ export function ElectionResultsSection ({ results, partyLabel }: { results: Part
             </div>
           </div>
         </div>
-        {chamber && <div className="profile-results__bottom">
-          <div>
-            <h3>Partiets {chamber.mandat} platser i kammaren</h3>
-            <ChamberDiagram mandates={chamber.mandat} partyLabel={partyLabel} />
-            <SourceLine source={parliamentView.kammare.kalla}>349 mandat efter valet {parliamentView.kammare.valar} · </SourceLine>
-          </div>
-          <div className="profile-composition">
-            <h3>Riksdagens sammansättning {parliamentView.kammare.valar}</h3>
-            <ul>{parliamentComposition.map(party => <li key={party.label} className={party.label === partyLabel ? 'is-current' : undefined}><span>{party.label}</span><i><b style={{ width: `${(party.seats / parliamentComposition[0].seats) * 100}%` }} /></i><strong>{party.seats}</strong></li>)}</ul>
-          </div>
-        </div>}
+        {partySeats && chamber && <ChamberBlock chamber={chamber} mandates={partySeats.mandat} partyLabel={partyLabel} />}
         <div className="profile-results__sources">
           {results.resultat.flatMap(post => [
             <SourceLine source={post.kalla} key={`${post.valar}-${post.kalla.url}`}>Riksdagsvalet {post.valar} · </SourceLine>,
@@ -146,10 +158,13 @@ export function ElectionResultsSection ({ results, partyLabel }: { results: Part
   );
 }
 
-export function TurnoutSection () {
-  const plotPoints = nationalTurnout.map((result, index) => ({
+export function TurnoutSection ({ turnout }: { turnout: ParliamentTurnout }) {
+  const series = turnout.resultat.map(result => ({ year: result.valar, value: result.procent }));
+  const sourceNames = [...new Set(turnout.kallor.map(source => source.namn))];
+  const fetched = turnout.kallor.map(source => source.hamtad).toSorted().at(-1);
+  const plotPoints = series.map((result, index) => ({
     ...result,
-    x: (index / (nationalTurnout.length - 1)) * 100,
+    x: (index / (series.length - 1)) * 100,
     y: ((90 - result.value) / 12) * 100,
   }));
   const points = plotPoints.map(point => `${point.x},${point.y}`).join(' ');
@@ -159,18 +174,18 @@ export function TurnoutSection () {
       <div className="profile-turnout__intro">
         <h2 id="turnout-heading">Valdeltagande som jämförelse</h2>
         <p>Valdeltagandet är en egenskap hos valet, inte hos partiet. Det visas för att kunna läsa röstetalen mot antalet röstande.</p>
-        <div className="profile-source-brand profile-source-brand--small"><div><small>{turnoutSourceNames.join(' och ')} · hämtat {turnoutFetched}</small></div></div>
+        <div className="profile-source-brand profile-source-brand--small"><div><small>{sourceNames.join(' och ')} · hämtat {fetched}</small></div></div>
       </div>
       <div className="profile-turnout__chart">
         <div>
           {[90, 85, 80].map(value => <span key={value} style={{ top: `${((90 - value) / 12) * 100}%` }}>{value} %</span>)}
-          <svg viewBox="0 0 100 100" preserveAspectRatio="none" aria-label="Valdeltagande i riksdagsval 1994 till 2022"><polyline points={points} /></svg>
+          <svg viewBox="0 0 100 100" preserveAspectRatio="none" aria-label={`Valdeltagande i riksdagsval ${series[0]?.year} till ${series.at(-1)?.year}`}><polyline points={points} /></svg>
           <ul className="profile-turnout__values">
             {plotPoints.map((point, index) => <li className={index === 0 ? 'is-first' : index === plotPoints.length - 1 ? 'is-last' : undefined} key={point.year} style={{ left: `${point.x}%`, top: `${point.y}%` }} aria-label={`${point.year}: ${point.value.toFixed(2).replace(/0$/, '').replace('.', ',')} procent`}>{point.value.toFixed(2).replace(/0$/, '').replace('.', ',')} %</li>)}
           </ul>
         </div>
-        <ol>{nationalTurnout.map(result => <li key={result.year}>{result.year}</li>)}</ol>
-        {parliamentView.valdeltagande.kallor.map(source => <SourceLine source={source} key={`${source.url}-${source.hamtad}`} />)}
+        <ol>{series.map(result => <li key={result.year}>{result.year}</li>)}</ol>
+        {turnout.kallor.map(source => <SourceLine source={source} key={`${source.url}-${source.hamtad}`} />)}
       </div>
     </section>
   );

--- a/src/pages/parti/[filnamn].tsx
+++ b/src/pages/parti/[filnamn].tsx
@@ -30,6 +30,7 @@ function PartyPage ({
   symbolSrc,
   symbolFrame,
   valresultat,
+  riksdag,
 }: PartyPageProps) {
   const displayName = profile?.namn ?? registeredName;
   const pageName = duplicateName && area ? `${displayName} (${area})` : displayName;
@@ -55,8 +56,8 @@ function PartyPage ({
         <ProfileHero code={code} abbreviation={abbreviation} profile={resolvedProfile} displayName={pageName} symbol={symbol} symbolSrc={symbolSrc} symbolFrame={symbolFrame} results={valresultat} latestParticipation={participationYears[0]} wikidata={wikidata} />
         <DocumentsSection profile={resolvedProfile} abbreviation={abbreviation} />
         <RepresentativesSection profile={resolvedProfile} abbreviation={abbreviation} mandateCount={valresultat?.kammare?.mandat} />
-        {valresultat && <ElectionResultsSection key={slug} results={valresultat} partyLabel={abbreviation} />}
-        {valresultat && <TurnoutSection />}
+        {valresultat && <ElectionResultsSection key={slug} results={valresultat} partyLabel={abbreviation} chamber={riksdag?.kammare} />}
+        {valresultat && riksdag && <TurnoutSection turnout={riksdag.valdeltagande} />}
         {participationYears.length > 0 && <BallotSection participationYears={participationYears} candidateLists={candidateLists} slug={slug} partyName={displayName} />}
         <WikipediaSection profile={resolvedProfile} />
         <NewsSection profile={resolvedProfile} />

--- a/src/server/party-data.ts
+++ b/src/server/party-data.ts
@@ -30,6 +30,7 @@ export interface PartyPageData extends Parti {
   symbolSrc?: string;
   symbolFrame?: SymbolFrame;
   valresultat?: PartiValresultat;
+  riksdag?: ParliamentView;
 }
 
 export type PartyResolution =
@@ -153,6 +154,28 @@ export interface OutsideParliamentData {
   partier: OutsideParliamentParty[];
 }
 
+/**
+ * The chamber as the party page draws it: the election that seated it, the
+ * source the seat count cites, and every party's abbreviation and seats in the
+ * file's order.
+ */
+export interface ParliamentChamber {
+  valar: number;
+  kalla: PartiProfilKalla;
+  partier: Array<{ forkortning: string; mandat: number }>;
+}
+
+/** National turnout per election year, with the sources the series is read from. */
+export interface ParliamentTurnout {
+  resultat: Array<{ valar: number; procent: number }>;
+  kallor: PartiProfilKalla[];
+}
+
+export interface ParliamentView {
+  kammare: ParliamentChamber;
+  valdeltagande: ParliamentTurnout;
+}
+
 export interface HomeData {
   parties: HomeParty[];
   valar: string[];
@@ -192,6 +215,22 @@ interface DerivedParliamentFile {
       roster: number;
       rostandel: number;
       kalla: PartiProfilKalla;
+    }>;
+  };
+  kammare?: {
+    valar: number;
+    kalla: PartiProfilKalla;
+    partier: Array<{ parti_uuid: string; forkortning: string; mandat: number }>;
+  };
+  valdeltagande?: {
+    resultat: Array<{ valar: number; procent: number }>;
+    kallor: Array<PartiProfilKalla & {
+      id: string;
+      titel?: string;
+      version?: string;
+      format?: string;
+      sha256?: string;
+      transkribering_sha256?: string;
     }>;
   };
 }
@@ -332,6 +371,7 @@ export function createPartyDataStore (
   let partyIndexPromise: Promise<PartyIndex> | undefined;
   let homeDataPromise: Promise<HomeData> | undefined;
   let parliamentResultsPromise: Promise<ParliamentResultFile[]> | undefined;
+  let derivedParliamentPromise: Promise<DerivedParliamentFile | undefined> | undefined;
   let dataCatalogPromise: Promise<DataCatalog> | undefined;
   const dataFiles = new Map<string, Promise<{ body: Buffer; etag: string } | undefined>>();
 
@@ -379,10 +419,11 @@ export function createPartyDataStore (
   async function readCurrentParty (slug: string, duplicateName: boolean): Promise<PartyPageData> {
     const partyRoot = path.join(dataRoot, 'parti', slug);
     const party = await readJson<Parti>(path.join(partyRoot, 'index.json'));
-    const [profile, candidateLists, results] = await Promise.all([
+    const [profile, candidateLists, results, riksdag] = await Promise.all([
       readOptionalJson<PartiProfil>(path.join(partyRoot, 'profil.json')),
       readCandidateLists(slug),
       readParliamentResults(),
+      readParliamentView(),
     ]);
     const symbolSrc = symbolSource(party);
     const frame = symbolFrame(party.partisymbol);
@@ -396,6 +437,7 @@ export function createPartyDataStore (
       ...(symbolSrc ? { symbolSrc } : {}),
       ...(frame ? { symbolFrame: frame } : {}),
       ...(valresultat ? { valresultat } : {}),
+      ...(riksdag ? { riksdag } : {}),
     };
   }
 
@@ -444,8 +486,37 @@ export function createPartyDataStore (
       .toSorted((a, b) => b.valar - a.valar);
   }
 
+  /** The derivation in `derived/riksdag.json`, read once, or undefined without the file. */
+  function readDerivedParliament (): Promise<DerivedParliamentFile | undefined> {
+    derivedParliamentPromise ??= readOptionalJson<DerivedParliamentFile>(path.join(dataRoot, 'derived', 'riksdag.json'));
+    return derivedParliamentPromise;
+  }
+
+  /**
+   * The chamber and the turnout series as the party page needs them, reduced to
+   * the fields it draws. Undefined without the file or without either part: the
+   * derivation always writes both, so half of it is a broken build rather than a
+   * page to render halfway.
+   */
+  async function readParliamentView (): Promise<ParliamentView | undefined> {
+    const derived = await readDerivedParliament();
+    const { kammare, valdeltagande } = derived ?? {};
+    if (!kammare || !valdeltagande) return undefined;
+    return {
+      kammare: {
+        valar: kammare.valar,
+        kalla: { namn: kammare.kalla.namn, url: kammare.kalla.url, hamtad: kammare.kalla.hamtad },
+        partier: kammare.partier.map(party => ({ forkortning: party.forkortning, mandat: party.mandat })),
+      },
+      valdeltagande: {
+        resultat: valdeltagande.resultat.map(result => ({ valar: result.valar, procent: result.procent })),
+        kallor: valdeltagande.kallor.map(source => ({ namn: source.namn, url: source.url, hamtad: source.hamtad })),
+      },
+    };
+  }
+
   async function readOutsideParliament (byUuid: Map<string, PartiIndexEntry>): Promise<OutsideParliamentData | undefined> {
-    const derived = await readOptionalJson<DerivedParliamentFile>(path.join(dataRoot, 'derived', 'riksdag.json'));
+    const derived = await readDerivedParliament();
     if (!derived?.storsta_utanfor_riksdagen?.partier.length) return undefined;
     const partier = derived.storsta_utanfor_riksdagen.partier.map(result => {
       const party = byUuid.get(result.parti_uuid);


### PR DESCRIPTION
The party page's elections view imported `data/derived/riksdag.json` statically, so the chamber composition and the national turnout series were compiled into the bundle and a data publish (#100) could not reach them. The read now lives in `src/server/party-data.ts`, cached per store alongside the existing read for the start page, and the party page receives a narrow `riksdag` view through its props: the chamber and the turnout series with their sources, nothing else from the file. `elections.tsx` has no module-level data left; the turnout chart's `aria-label` year range is derived from the series instead of being hardcoded.

A new test, `scripts/source-imports.test.js`, fails if anything under `src/` imports from `data/` in any form, so the rule holds from now on. `party-data.test.js` covers the reduced view, the absent-file and partial-file cases, and the single read per store; the HTTP smoke test checks the composition year, the latest turnout value and the chart label on a live party page.

Verified end to end on the release artifact: with `riksdag.json` patched on disk and the process restarted without a rebuild, the party page served the new value.

`public/img/sveriges_riksdag.svg`, the header's chamber graphic, is still generated at build time and is now the only file the docs name as needing a release.

## Decisions open to review

- The chamber block became its own `ChamberBlock` component so the seat layout and sort only run when a chamber exists. Inline guarded constants would do the same with more narrowing in `ElectionResultsSection`.
- The chamber diagram's `aria-label` keeps the literal 349, as does the source line "349 mandat efter valet". Deriving both from the data is a small follow-up if every literal should go.

Closes #105
