### PR TITLE
Make the header's chamber graphic a plain static image again

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,8 @@ Open data about Swedish political parties. Swedish copy.
   `deploy/README.md`). Data on `main` is published without a release by running
   `publish-data.yaml` by hand (`gh workflow run publish-data.yaml`) — data and
   code ship independently. A code change still needs a tag, and takes the data
-  with it.
-  Everything under `data/` is read from disk at request time; the one file
-  built into the bundle is `public/img/sveriges_riksdag.svg`, so a change to it
-  reaches the header only with a release.
+  with it. Everything the site shows from the data is read from `data/` at
+  request time.
 
 ## Stack
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -57,11 +57,6 @@ tip.
 - A server that does not answer is restored with a manual release run on the
   current tag.
 
-One file is built into the bundle rather than read from `data/` at request
-time: `public/img/sveriges_riksdag.svg`, which `scripts/build-derived-data.js`
-generates and the header shows. A change to it reaches the site only with a
-release.
-
 ## One-time server setup
 
 Choose the deploy account, service account and target directory. The target is

--- a/public/img/sveriges_riksdag.svg
+++ b/public/img/sveriges_riksdag.svg
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Genererad av scripts/build-derived-data.js ur mandatfördelningen i riksdagsvalet 2022. Redigera inte för hand. -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" data-valar="2022">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256">
 <g style="transform: rotate(180deg); transform-origin: center">
 <g id="V" fill="#b00000">
 <circle r="6" cx="146.00" cy="250.00"/>

--- a/scripts/build-derived-data.js
+++ b/scripts/build-derived-data.js
@@ -5,26 +5,6 @@ const path = require('node:path');
 const { ROOT } = require('./utils.js');
 
 const DERIVED_FILE = path.join('derived', 'riksdag.json');
-const DIAGRAM_FILE = path.join('public', 'img', 'sveriges_riksdag.svg');
-
-/**
- * SEAT_COLOURS
- * Presentation only: the committed data carries no colour, so the diagram maps
- * the chamber's abbreviations to the hues they are recognised by. An
- * abbreviation without an entry is drawn neutral.
- * @type {Object}
- */
-const SEAT_COLOURS = {
-  V: '#b00000',
-  S: '#ed1b34',
-  MP: '#00c554',
-  C: '#39944a',
-  L: '#0069b4',
-  KD: '#2d338e',
-  M: '#019cdb',
-  SD: '#fedf09'
-};
-const NEUTRAL_COLOUR = '#d2d2d2';
 
 /**
  * SEAT_ORDER
@@ -40,8 +20,6 @@ function seatOrderIndex (forkortning) {
   const index = SEAT_ORDER.indexOf(forkortning);
   return index === -1 ? SEAT_ORDER.length : index;
 }
-
-const DIAGRAM = { width: 512, height: 256, rows: 9, innerRadius: 110, outerRadius: 244, seatRadius: 6 };
 
 function readJson (file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
@@ -146,93 +124,6 @@ function buildParliamentView (dataDirectory = path.join(ROOT, 'data')) {
 
 const buildPartyProfileParliamentView = buildParliamentView;
 
-/**
- * seatRows
- * Splits the seats over concentric rows, each row holding a share of the total
- * proportional to its radius, so the ring of seats keeps an even density. The
- * remainder goes to the rows with the largest fractional claim, which makes the
- * split a pure function of the seat count.
- * @param  {Number} total
- * @return {Number[]} Seats per row, innermost first
- */
-function seatRows (total) {
-  const radii = Array.from({ length: DIAGRAM.rows }, (unused, row) =>
-    DIAGRAM.innerRadius + (DIAGRAM.outerRadius - DIAGRAM.innerRadius) * row / (DIAGRAM.rows - 1));
-  const sum = radii.reduce((carry, radius) => carry + radius, 0);
-  const shares = radii.map((radius, row) => ({ row, exact: total * radius / sum }));
-  const counts = shares.map(share => Math.floor(share.exact));
-  const spare = total - counts.reduce((carry, count) => carry + count, 0);
-  shares
-    .toSorted((a, b) => (b.exact - Math.floor(b.exact)) - (a.exact - Math.floor(a.exact)) || a.row - b.row)
-    .slice(0, spare)
-    .forEach(share => { counts[share.row] += 1; });
-  return counts;
-}
-
-/**
- * seatPositions
- * The seats of a hemicycle, ordered the way the chamber is read: from one end
- * of the arc to the other, innermost row first where seats share an angle.
- * @param  {Number} total
- * @return {Array<{ x: String, y: String }>}
- */
-function seatPositions (total) {
-  const centreX = DIAGRAM.width / 2;
-  const centreY = DIAGRAM.height - DIAGRAM.seatRadius;
-  const seats = seatRows(total).flatMap((count, row) => {
-    const radius = DIAGRAM.innerRadius + (DIAGRAM.outerRadius - DIAGRAM.innerRadius) * row / (DIAGRAM.rows - 1);
-    return Array.from({ length: count }, (unused, seat) => ({
-      radius,
-      angle: count === 1 ? Math.PI / 2 : Math.PI * (1 - seat / (count - 1))
-    }));
-  });
-
-  return seats
-    .toSorted((a, b) => b.angle - a.angle || a.radius - b.radius)
-    .map(seat => ({
-      x: (centreX + seat.radius * Math.cos(seat.angle)).toFixed(2),
-      y: (centreY - seat.radius * Math.sin(seat.angle)).toFixed(2)
-    }));
-}
-
-function buildParliamentDiagram (dataDirectory = path.join(ROOT, 'data')) {
-  const view = buildPartyProfileParliamentView(dataDirectory);
-  const { valar, partier } = view.kammare;
-  const total = partier.reduce((carry, party) => carry + party.mandat, 0);
-  const positions = seatPositions(total);
-
-  let placed = 0;
-  const groups = partier.map(party => {
-    const seats = positions.slice(placed, placed + party.mandat);
-    placed += party.mandat;
-    const circles = seats
-      .map(seat => `<circle r="${DIAGRAM.seatRadius}" cx="${seat.x}" cy="${seat.y}"/>`)
-      .join('\n');
-    return `<g id="${party.forkortning}" fill="${SEAT_COLOURS[party.forkortning] ?? NEUTRAL_COLOUR}">\n${circles}\n</g>`;
-  });
-
-  return [
-    '<?xml version="1.0" encoding="UTF-8"?>',
-    `<!-- Genererad av scripts/build-derived-data.js ur mandatfördelningen i riksdagsvalet ${valar}. Redigera inte för hand. -->`,
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${DIAGRAM.width} ${DIAGRAM.height}" data-valar="${valar}">`,
-    '<g style="transform: rotate(180deg); transform-origin: center">',
-    ...groups,
-    '</g>',
-    '</svg>',
-    ''
-  ].join('\n');
-}
-
-function writeParliamentDiagram (dataDirectory = path.join(ROOT, 'data'), target = path.join(ROOT, DIAGRAM_FILE)) {
-  fs.writeFileSync(target, buildParliamentDiagram(dataDirectory));
-  return target;
-}
-
-function checkParliamentDiagram (dataDirectory = path.join(ROOT, 'data'), target = path.join(ROOT, DIAGRAM_FILE)) {
-  assert.ok(fs.existsSync(target), `${DIAGRAM_FILE} saknas; kör npm run build:derived-data`);
-  assert.equal(fs.readFileSync(target, 'utf8'), buildParliamentDiagram(dataDirectory), `${DIAGRAM_FILE} är inaktuell; kör npm run build:derived-data`);
-}
-
 function serializePartyProfileParliamentView (dataDirectory) {
   return `${JSON.stringify(buildPartyProfileParliamentView(dataDirectory), null, 2)}\n`;
 }
@@ -253,21 +144,14 @@ function checkPartyProfileParliamentView (dataDirectory = path.join(ROOT, 'data'
 if (require.main === module) {
   if (process.argv.includes('--check')) {
     checkPartyProfileParliamentView();
-    checkParliamentDiagram();
-    console.log(`${DERIVED_FILE} och ${DIAGRAM_FILE} är aktuella.`);
+    console.log(`${DERIVED_FILE} är aktuell.`);
   } else {
-    const targets = [writePartyProfileParliamentView(), writeParliamentDiagram()];
-    console.log(`Skrev ${targets.map(target => path.relative(ROOT, target)).join(' och ')}.`);
+    console.log(`Skrev ${path.relative(ROOT, writePartyProfileParliamentView())}.`);
   }
 }
 
-exports.SEAT_COLOURS = SEAT_COLOURS;
 exports.SEAT_ORDER = SEAT_ORDER;
 exports.buildParliamentView = buildParliamentView;
-exports.buildParliamentDiagram = buildParliamentDiagram;
 exports.buildPartyProfileParliamentView = buildPartyProfileParliamentView;
-exports.checkParliamentDiagram = checkParliamentDiagram;
 exports.checkPartyProfileParliamentView = checkPartyProfileParliamentView;
-exports.seatRows = seatRows;
-exports.writeParliamentDiagram = writeParliamentDiagram;
 exports.writePartyProfileParliamentView = writePartyProfileParliamentView;

--- a/scripts/build-derived-data.test.js
+++ b/scripts/build-derived-data.test.js
@@ -4,14 +4,7 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 
-const { ROOT } = require('./utils.js');
-const {
-  SEAT_COLOURS,
-  buildParliamentDiagram,
-  buildPartyProfileParliamentView,
-  checkParliamentDiagram,
-  seatRows
-} = require('./build-derived-data.js');
+const { buildPartyProfileParliamentView } = require('./build-derived-data.js');
 
 const SOURCE = {
   id: 'resultat',
@@ -31,7 +24,7 @@ function writeJson (root, relativePath, value) {
 }
 
 function makeData (partier) {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'partidata-diagram-'));
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'partidata-riksdag-'));
   const registry = partier.map((party, index) => ({
     uuid: `00000000-0000-4000-8000-${String(index + 1).padStart(12, '0')}`,
     kod: String(9000 + index),
@@ -80,36 +73,6 @@ function makeData (partier) {
   return root;
 }
 
-function groups (svg) {
-  return [...svg.matchAll(/<g id="([^"]+)" fill="([^"]+)">([\s\S]*?)<\/g>/g)]
-    .map(match => ({ id: match[1], fill: match[2], seats: (match[3].match(/<circle /g) ?? []).length }));
-}
-
-test('the seat rows hold every seat and grow outwards', () => {
-  for (const total of [1, 12, 349, 350]) {
-    const rows = seatRows(total);
-    assert.equal(rows.reduce((carry, count) => carry + count, 0), total);
-    assert.deepEqual(rows, [...rows].sort((a, b) => a - b));
-  }
-});
-
-test('the diagram draws one group per party, sized by its mandate count', t => {
-  const root = makeData([
-    { forkortning: 'V', mandat: 24 },
-    { forkortning: 'S', mandat: 107 },
-    { forkortning: 'SD', mandat: 218 }
-  ]);
-  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-
-  const svg = buildParliamentDiagram(root);
-  assert.deepEqual(groups(svg), [
-    { id: 'V', fill: SEAT_COLOURS.V, seats: 24 },
-    { id: 'S', fill: SEAT_COLOURS.S, seats: 107 },
-    { id: 'SD', fill: SEAT_COLOURS.SD, seats: 218 }
-  ]);
-  assert.equal((svg.match(/<circle /g) ?? []).length, 349);
-});
-
 test('the chamber is ordered along the spectrum, not in source row order', t => {
   const root = makeData([
     { forkortning: 'SD', mandat: 73 },
@@ -121,25 +84,6 @@ test('the chamber is ordered along the spectrum, not in source row order', t => 
 
   const chamber = buildPartyProfileParliamentView(root).kammare;
   assert.deepEqual(chamber.partier.map(party => party.forkortning), ['V', 'S', 'SD', 'XYZ']);
-});
-
-test('the diagram records the election year it was generated from', t => {
-  const root = makeData([{ forkortning: 'S', mandat: 349 }]);
-  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-
-  const svg = buildParliamentDiagram(root);
-  assert.match(svg, /data-valar="2022"/);
-  assert.match(svg, /riksdagsvalet 2022/);
-  assert.equal(svg, buildParliamentDiagram(root), 'the same data gives the same bytes');
-});
-
-test('an abbreviation outside the colour map is drawn neutral', t => {
-  const root = makeData([{ forkortning: 'S', mandat: 300 }, { forkortning: 'XYZ', mandat: 49 }]);
-  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-
-  const [, unknown] = groups(buildParliamentDiagram(root));
-  assert.equal(unknown.id, 'XYZ');
-  assert.equal(unknown.fill, '#d2d2d2');
 });
 
 test('outside parties are ranked by exact vote share, excluding the current chamber and keeping six', t => {
@@ -169,23 +113,4 @@ test('outside parties are ranked by exact vote share, excluding the current cham
   );
   assert.equal(result.storsta_utanfor_riksdagen.partier[0].rostandel, result.storsta_utanfor_riksdagen.partier[1].rostandel);
   assert.ok(!result.storsta_utanfor_riksdagen.partier.some(party => party.parti_uuid.endsWith('000000000001')));
-});
-
-test('the colour map covers every party in the committed chamber', () => {
-  const chamber = buildPartyProfileParliamentView().kammare;
-  const uncoloured = chamber.partier
-    .map(party => party.forkortning)
-    .filter(forkortning => !(forkortning in SEAT_COLOURS));
-  assert.deepEqual(uncoloured, [], `Lägg till färg för ${uncoloured.join(', ')} i SEAT_COLOURS`);
-});
-
-test('the committed diagram matches the committed mandate data', () => {
-  checkParliamentDiagram();
-  const svg = fs.readFileSync(path.join(ROOT, 'public', 'img', 'sveriges_riksdag.svg'), 'utf8');
-  const chamber = buildPartyProfileParliamentView().kammare;
-  assert.deepEqual(
-    groups(svg).map(group => ({ forkortning: group.id, mandat: group.seats })),
-    chamber.partier.map(party => ({ forkortning: party.forkortning, mandat: party.mandat }))
-  );
-  assert.match(svg, new RegExp(`data-valar="${chamber.valar}"`));
 });


### PR DESCRIPTION
The header's chamber graphic, `public/img/sveriges_riksdag.svg`, is a committed static image again. `scripts/build-derived-data.js` no longer computes seat positions, carries a colour table or writes the file, and `check:derived-data` no longer compares it against the data; both now concern `data/derived/riksdag.json` only. The SVG loses its "generated, do not edit" comment and the `data-valar` stamp; the drawing is byte-identical. The diagram tests are removed, the two tests for the JSON view remain.

`CLAUDE.md` and `deploy/README.md` no longer name the graphic as a file that needs a release for data reasons. Everything the site shows from the data is now read from `data/` at request time. `docs/riksdagsvalresultat.md` needed no change: it never mentioned the header graphic.

`npm run precommit` passes end to end, and re-running `build:derived-data` leaves the SVG untouched.

## Decisions open to review

- The helpers that only placed and coloured seats in the generated SVG (`seatRows`, `seatPositions`, `NEUTRAL_COLOUR`) are removed along with the functions the issue names, since nothing else uses them.
- The test's temp-dir prefix is renamed from `partidata-diagram-` to `partidata-riksdag-`. Cosmetic.

Closes #107
